### PR TITLE
chore: batch low-difficulty cleanup — 13 LOW issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.pixi
+.env
+.venv
+.idea
+.vscode
+dashboards/*.bak
+*.md

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,17 @@
+# Copy to .env and fill in values before running `just start`.
+# .env is gitignored and must never be committed.
+
+# Grafana admin password — change this before first run
+GF_ADMIN_PASSWORD=changeme
+
+# Agamemnon API (WSL2 host gateway)
 AGAMEMNON_URL=http://172.20.0.1:8080
+
+# Nestor API (WSL2 host gateway)
 NESTOR_URL=http://172.20.0.1:8081
-GRAFANA_PORT=3000
-GRAFANA_ADMIN_PASSWORD=admin
+
+# NATS monitoring API
+NATS_URL=http://172.24.0.1:8222
+
+# Path to NATS server log file on the host (Promtail tails this path)
+NATS_LOG_PATH=/home/mvillmow/.local/share/nats/nats.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,5 @@ jobs:
 
       - name: Check docker-compose config
         run: docker compose config --quiet
+        env:
+          GF_ADMIN_PASSWORD: ci-validation-only

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .env
 data/
 *.log
+.pixi/
+.idea/
+.vscode/
+.DS_Store
+*.swp

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Observability stack for the HomericIntelligence mesh. ProjectArgus provides cent
 just start
 ```
 
-Then access Grafana at http://localhost:3000 (default credentials: admin / admin).
+Then access Grafana at http://localhost:3000 (credentials: admin / the password set in `.env`).
 
 ## Dashboards
 
@@ -34,6 +34,14 @@ Then access Grafana at http://localhost:3000 (default credentials: admin / admin
 - **Task Throughput**: Tasks created/completed/failed per hour, dispatch latency
 
 ## Configuration
+
+Copy `.env.example` to `.env` and set your values before starting the stack:
+
+```bash
+cp .env.example .env
+# edit .env — at minimum set GF_ADMIN_PASSWORD
+just start
+```
 
 All scrape targets and service configs live in `configs/`. Alert rules are in `rules/`. Grafana dashboards (JSON) are in `dashboards/` and auto-provisioned on startup.
 

--- a/configs/grafana/dashboards.yml
+++ b/configs/grafana/dashboards.yml
@@ -6,7 +6,7 @@ providers:
     type: file
     disableDeletion: false
     updateIntervalSeconds: 30
-    allowUiUpdates: true
+    allowUiUpdates: false
     options:
       path: /var/lib/grafana/dashboards
       foldersFromFilesStructure: false

--- a/configs/prometheus.yml
+++ b/configs/prometheus.yml
@@ -16,3 +16,11 @@ scrape_configs:
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090']
+
+  # Nomad job and allocation metrics
+  - job_name: 'nomad'
+    metrics_path: /v1/metrics
+    params:
+      format: ['prometheus']
+    static_configs:
+      - targets: ['172.20.0.1:4646']

--- a/configs/promtail.yml
+++ b/configs/promtail.yml
@@ -19,17 +19,7 @@ scrape_configs:
           host: hermes
           __path__: /var/log/syslog
 
-  # Tail Hermes application log
-  - job_name: hermes
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: hermes
-          service: project-hermes
-          __path__: /tmp/hermes.log
-
-  # Tail NATS server log
+  # Tail NATS server log — path configurable via NATS_LOG_PATH env var
   - job_name: nats
     static_configs:
       - targets:
@@ -37,4 +27,4 @@ scrape_configs:
         labels:
           job: nats
           service: nats-server
-          __path__: /home/mvillmow/.local/share/nats/nats.log
+          __path__: ${NATS_LOG_PATH}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ networks:
 
 services:
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v2.54.1
     container_name: argus-prometheus
     restart: unless-stopped
     ports:
@@ -16,14 +16,13 @@ services:
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"
-      - "--web.enable-lifecycle"
       - "--web.console.libraries=/usr/share/prometheus/console_libraries"
       - "--web.console.templates=/usr/share/prometheus/consoles"
     networks:
       - argus
 
   loki:
-    image: grafana/loki:latest
+    image: grafana/loki:3.1.2
     container_name: argus-loki
     restart: unless-stopped
     ports:
@@ -36,31 +35,30 @@ services:
       - argus
 
   promtail:
-    image: grafana/promtail:latest
+    image: grafana/promtail:3.1.2
     container_name: argus-promtail
     restart: unless-stopped
     volumes:
       - ./configs/promtail.yml:/etc/promtail/config.yml:ro
       - /var/log:/var/log:ro
-      - /tmp:/tmp:ro
-    command: -config.file=/etc/promtail/config.yml
+    command: -config.file=/etc/promtail/config.yml -config.expand-env=true
     networks:
       - argus
     depends_on:
       - loki
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:11.2.2
     container_name: argus-grafana
     restart: unless-stopped
     ports:
-      - "3001:3000"
+      - "3000:3000"
     volumes:
       - ./dashboards:/var/lib/grafana/dashboards:ro
       - ./configs/grafana:/etc/grafana/provisioning:ro
       - grafana_data:/var/lib/grafana
     environment:
-      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_ADMIN_PASSWORD:?GF_ADMIN_PASSWORD must be set in .env}
       GF_PATHS_PROVISIONING: /etc/grafana/provisioning
     networks:
       - argus
@@ -69,7 +67,7 @@ services:
       - loki
 
   argus-exporter:
-    image: python:3.11-slim
+    image: python:3.11.10-slim
     container_name: argus-exporter
     restart: unless-stopped
     ports:
@@ -78,9 +76,9 @@ services:
       - ./exporter/exporter.py:/exporter.py:ro
     command: python /exporter.py
     environment:
-      AGAMEMNON_URL: "http://172.20.0.1:8080"
-      NESTOR_URL: "http://172.20.0.1:8081"
-      NATS_URL: "http://172.24.0.1:8222"
+      AGAMEMNON_URL: ${AGAMEMNON_URL:-http://172.20.0.1:8080}
+      NESTOR_URL: ${NESTOR_URL:-http://172.20.0.1:8081}
+      NATS_URL: ${NATS_URL:-http://172.24.0.1:8222}
     networks:
       - argus
 

--- a/exporter/exporter.py
+++ b/exporter/exporter.py
@@ -42,8 +42,8 @@ def _health_check(url: str) -> int:
 def collect() -> str:
     lines: list[str] = []
 
-    def gauge(name: str, value: float | int, labels: dict = {}) -> None:
-        lstr = ",".join(f'{k}="{v}"' for k, v in labels.items())
+    def gauge(name: str, value: float | int, labels: dict | None = None) -> None:
+        lstr = ",".join(f'{k}="{v}"' for k, v in (labels or {}).items())
         lines.append(f"# TYPE {name} gauge")
         lines.append(f"{name}{{{lstr}}} {value}")
 

--- a/justfile
+++ b/justfile
@@ -32,9 +32,9 @@ logs SERVICE:
 
 # === Prometheus ===
 
-# Hot-reload Prometheus configuration (no restart needed)
+# Hot-reload Prometheus configuration via SIGHUP (--web.enable-lifecycle is disabled)
 reload-prometheus:
-    curl -s -X POST http://localhost:9090/-/reload && echo "Prometheus config reloaded."
+    {{compose_cmd}} kill -s HUP prometheus && echo "Prometheus config reloaded."
 
 # Query Prometheus to verify all scrape targets are up
 test-scrape:

--- a/pixi.lock
+++ b/pixi.lock
@@ -9,7 +9,7 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.1-h73b1eb8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/just-1.49.0-hdab8a38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/just-1.50.0-hdab8a38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-hb9d3cd8_0.conda
@@ -39,17 +39,17 @@ packages:
   license_family: MIT
   size: 313184
   timestamp: 1751447310552
-- conda: https://conda.anaconda.org/conda-forge/linux-64/just-1.49.0-hdab8a38_0.conda
-  sha256: 3448bb5b8f056d2e23f5b2e562abadeac93c5fb5dce529c1eb649a2ab89fa8dc
-  md5: 2bbe04a5bda70cfae0eb863d3b522f12
+- conda: https://conda.anaconda.org/conda-forge/linux-64/just-1.50.0-hdab8a38_0.conda
+  sha256: 8f80b7c485f45464070b9eeaf804545111ba450f2348a47f7f0af1e32581d4b8
+  md5: edc7b50dc101f8f977b9421448c3462a
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   constrains:
   - __glibc >=2.17
   license: CC0-1.0
-  size: 1599742
-  timestamp: 1775377124177
+  size: 1598758
+  timestamp: 1776655084958
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
   sha256: faf7d2017b4d718951e3a59d081eb09759152f93038479b768e3d612688f83f5
   md5: 0aa00f03f9e39fb9876085dee11a85d4


### PR DESCRIPTION
## Summary

Resolves 13 LOW-difficulty issues in a single pass. All changes are config/text/trivial-code — no architectural decisions, no new services.

| Issue | Change | File(s) |
|-------|--------|---------|
| #3  | Add Nomad scrape target | `configs/prometheus.yml` |
| #5  | Fix Grafana port 3001→3000 | `docker-compose.yml`, `README.md` |
| #10 | Pin image tags (no more `:latest`) | `docker-compose.yml` |
| #12 | Fix mutable default arg in `gauge()` | `exporter/exporter.py` |
| #13 | Remove hardcoded Grafana password | `docker-compose.yml`, `.env.example` |
| #18 | Expand `.gitignore` | `.gitignore` |
| #19 | Remove `--web.enable-lifecycle`; update reload to SIGHUP | `docker-compose.yml`, `justfile` |
| #20 | Drop `/tmp:/tmp:ro` Promtail mount + aspirational hermes log job | `docker-compose.yml`, `configs/promtail.yml` |
| #24 | Commit `pixi.lock` | `pixi.lock` |
| #34 | Parameterize NATS log path via `NATS_LOG_PATH` env var | `configs/promtail.yml` |
| #40 | Add `.dockerignore` | `.dockerignore` |
| #41 | `allowUiUpdates: false` in dashboard provisioning | `configs/grafana/dashboards.yml` |
| #53 | Source compose env from `.env`; expand `.env.example` | `docker-compose.yml`, `.env.example`, `README.md` |

## Breaking change

**#19 + #53**: `just reload-prometheus` now sends SIGHUP instead of calling `/-/reload`. The `/-/reload` HTTP endpoint is removed (`--web.enable-lifecycle` dropped). `GF_ADMIN_PASSWORD` is now required in `.env` — operators must `cp .env.example .env` and set a password before `just start`.

## Test plan

- [ ] `GF_ADMIN_PASSWORD=test docker compose config -q` exits 0
- [ ] `docker compose config -q` (no env) exits 1 with clear error message
- [ ] `docker compose up -d && just test-scrape` — all targets up (nomad may be 0 if Nomad not running locally)
- [ ] `just reload-prometheus` succeeds via SIGHUP
- [ ] Grafana accessible at http://localhost:3000 (not 3001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)