### PR TITLE
feat(rules): add Prometheus recording rules for common expressions

### DIFF
--- a/rules/recording-rules.yml
+++ b/rules/recording-rules.yml
@@ -1,0 +1,24 @@
+groups:
+  - name: homeric_recording_rules
+    interval: 15s
+    rules:
+      - record: hi:agents_online_ratio:avg
+        expr: (hi_agents_online / (hi_agents_total + 1e-9))
+
+      - record: hi:agents_offline_ratio:avg
+        expr: (hi_agents_offline / (hi_agents_total + 1e-9))
+
+      - record: hi:tasks_failure_rate:avg
+        expr: (hi_tasks_by_status{status="failed"} / (hi_tasks_total + 1e-9))
+
+      - record: hi:tasks_completion_rate:avg
+        expr: (hi_tasks_by_status{status="completed"} / (hi_tasks_total + 1e-9))
+
+      - record: hi:nats_in_msgs:rate5m
+        expr: rate(nats_in_msgs_total[5m])
+
+      - record: hi:nats_out_msgs:rate5m
+        expr: rate(nats_out_msgs_total[5m])
+
+      - record: hi:nats_msgs_total:rate5m
+        expr: (rate(nats_in_msgs_total[5m]) + rate(nats_out_msgs_total[5m]))


### PR DESCRIPTION
## Summary

Adds `rules/recording-rules.yml` with 7 pre-computed Prometheus recording rules to reduce dashboard query load and improve performance for frequently accessed metrics.

## Changes

- **Agent metrics**: `hi:agents_online_ratio:avg`, `hi:agents_offline_ratio:avg` — agent availability percentages
- **Task metrics**: `hi:tasks_failure_rate:avg`, `hi:tasks_completion_rate:avg` — task success/failure ratios
- **NATS metrics**: `hi:nats_in_msgs:rate5m`, `hi:nats_out_msgs:rate5m`, `hi:nats_msgs_total:rate5m` — message throughput rates

All rules follow the naming convention `hi:metric:aggregation` and evaluate at the global 15s scrape interval.

## Test plan

- [x] YAML syntax validation (`python3 -c "import yaml; yaml.safe_load(open('rules/recording-rules.yml'))"`)
- [x] All lines within 120 character limit
- [x] Rules follow `hi:metric:aggregation` naming convention
- [x] Pre-compute agent ratios, task rates, and NATS throughput
- [x] File created in correct location (`rules/recording-rules.yml`)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)