### PR TITLE
fix(exporter): emit # TYPE once per metric family

### DIFF
--- a/exporter/exporter.py
+++ b/exporter/exporter.py
@@ -41,10 +41,13 @@ def _health_check(url: str) -> int:
 
 def collect() -> str:
     lines: list[str] = []
+    emitted_types: set[str] = set()
 
     def gauge(name: str, value: float | int, labels: dict | None = None) -> None:
         lstr = ",".join(f'{k}="{v}"' for k, v in (labels or {}).items())
-        lines.append(f"# TYPE {name} gauge")
+        if name not in emitted_types:
+            lines.append(f"# TYPE {name} gauge")
+            emitted_types.add(name)
         lines.append(f"{name}{{{lstr}}} {value}")
 
     # ── Agamemnon health ───────────────────────────────────────────────────


### PR DESCRIPTION
Fixes duplicate \`# TYPE\` line emissions in \`gauge()\`. Tracks emitted metric names in a set; TYPE header only written on first occurrence per family.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)