### PR TITLE
feat(dx): add pre-commit hooks and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: check-json
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        args: ["-d", "{extends: default, rules: {line-length: {max: 120}, truthy: {check-keys: false}}}"]
+        files: \.(yml|yaml)$


### PR DESCRIPTION
## Summary
- Adds `.pre-commit-config.yaml` with `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-merge-conflict`, `check-json`, and `yamllint` hooks
- Adds `.editorconfig` defining consistent indent style, line endings, charset, and trailing whitespace rules for all common file types
- `yamllint` args match CI config: line-length max 120, truthy check-keys disabled

## Test plan
- [ ] `pre-commit run --all-files` passes on the repo
- [ ] `.editorconfig` is recognised by editors (VS Code, JetBrains, etc.)
- [ ] YAML validation catches malformed files before commit

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)