### PR TITLE
feat(dashboards): add Loki log exploration dashboard

### DIFF
--- a/dashboards/loki-explorer.json
+++ b/dashboards/loki-explorer.json
@@ -1,0 +1,46 @@
+{
+  "uid": "loki-explorer",
+  "title": "Log Explorer",
+  "version": 1,
+  "schemaVersion": 39,
+  "tags": ["loki", "logs"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Syslog Stream",
+      "type": "logs",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "expr": "{job=\"syslog\"}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true
+      }
+    },
+    {
+      "id": 2,
+      "title": "NATS Log Stream",
+      "type": "logs",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "expr": "{job=\"nats\"}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Creates a new Grafana dashboard for Loki log exploration
- Includes two log panels: one for syslog streams and one for NATS logs
- Uses LogQL queries to filter logs by job name

## Validation
- Dashboard JSON is valid and passes schema validation
- Contains required fields: uid, title, panels
- Two functional panels with proper Loki datasource and LogQL queries

Closes #51