### PR TITLE
feat(exporter): add graceful SIGTERM/SIGINT shutdown handling

### DIFF
--- a/exporter/exporter.py
+++ b/exporter/exporter.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import signal
+import threading
 import time
 import urllib.request
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -140,4 +142,17 @@ if __name__ == "__main__":
     log.info("Scraping Agamemnon at %s", AGAMEMNON_URL)
     log.info("Scraping Nestor at %s", NESTOR_URL)
     log.info("Scraping NATS at %s", NATS_URL)
-    HTTPServer(("0.0.0.0", PORT), Handler).serve_forever()
+
+    server = HTTPServer(("0.0.0.0", PORT), Handler)
+
+    def _shutdown(signum, frame):
+        sig_name = signal.Signals(signum).name
+        log.info("received %s — shutting down gracefully", sig_name)
+        t = threading.Thread(target=server.shutdown, daemon=True)
+        t.start()
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+
+    server.serve_forever()
+    log.info("homeric-exporter stopped cleanly")


### PR DESCRIPTION
## Summary
- Imports `signal` and `threading` modules
- Creates the `HTTPServer` instance before registering handlers so it can be referenced in the signal handler
- Registers `_shutdown` for both `SIGTERM` and `SIGINT`; the handler calls `server.shutdown()` in a daemon thread, which unblocks `serve_forever()` only after any in-flight request completes
- Process exits with code 0 after `serve_forever()` returns

## Test plan
- [ ] Verify syntax: `python3 -m py_compile exporter/exporter.py`
- [ ] Start exporter, send `kill -TERM <pid>` while a `/metrics` request is in flight — confirm request completes and process exits 0
- [ ] Confirm `/metrics` output format is unchanged
- [ ] Confirm `SIGINT` (Ctrl-C) also triggers clean shutdown

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)