### PR TITLE
feat(compose): add resource limits to all services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,11 @@ services:
       start_period: 10s
     networks:
       - argus
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "0.50"
 
   loki:
     image: grafana/loki:3.1.2
@@ -45,6 +50,11 @@ services:
       start_period: 10s
     networks:
       - argus
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.25"
 
   promtail:
     image: grafana/promtail:3.1.2
@@ -64,6 +74,11 @@ services:
       - argus
     depends_on:
       - loki
+    deploy:
+      resources:
+        limits:
+          memory: 128m
+          cpus: "0.10"
 
   grafana:
     image: grafana/grafana:11.2.2
@@ -89,6 +104,11 @@ services:
     depends_on:
       - prometheus
       - loki
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.25"
 
   argus-exporter:
     build: ./exporter
@@ -108,6 +128,11 @@ services:
       start_period: 10s
     networks:
       - argus
+    deploy:
+      resources:
+        limits:
+          memory: 128m
+          cpus: "0.10"
 
 volumes:
   prometheus_data:


### PR DESCRIPTION
Fixes #29

## Summary
- Added resource limits (memory + CPU) to all 5 services
- Prevents misbehaving containers from starving the host
- Limits are suitable for an observability stack on a dev machine

## Service Limits
- prometheus: 512m RAM, 0.5 CPU
- loki: 256m RAM, 0.25 CPU  
- promtail: 128m RAM, 0.1 CPU
- grafana: 256m RAM, 0.25 CPU
- argus-exporter: 128m RAM, 0.1 CPU

## Validation
- docker compose config --quiet validated successfully