### PR TITLE
feat(tests): add local test suite for configs, dashboards, and rules

### DIFF
--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,0 +1,156 @@
+"""
+Validate that all YAML config files parse correctly and have required top-level keys.
+Uses only stdlib: yaml, pathlib, unittest.
+"""
+import unittest
+import yaml
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+CONFIGS_DIR = REPO_ROOT / "configs"
+
+
+def load_yaml(path: Path) -> dict:
+    with path.open() as f:
+        return yaml.safe_load(f)
+
+
+class TestPrometheusConfig(unittest.TestCase):
+    def setUp(self):
+        self.config = load_yaml(CONFIGS_DIR / "prometheus.yml")
+
+    def test_parses_without_error(self):
+        assert self.config is not None
+
+    def test_has_global_section(self):
+        assert "global" in self.config
+
+    def test_global_has_scrape_interval(self):
+        assert "scrape_interval" in self.config["global"]
+
+    def test_global_has_evaluation_interval(self):
+        assert "evaluation_interval" in self.config["global"]
+
+    def test_has_scrape_configs(self):
+        assert "scrape_configs" in self.config
+
+    def test_scrape_configs_is_list(self):
+        assert isinstance(self.config["scrape_configs"], list)
+
+    def test_scrape_configs_not_empty(self):
+        assert len(self.config["scrape_configs"]) > 0
+
+    def test_each_scrape_config_has_job_name(self):
+        for job in self.config["scrape_configs"]:
+            assert "job_name" in job, f"Missing job_name in scrape config: {job}"
+
+    def test_has_rule_files(self):
+        assert "rule_files" in self.config
+
+
+class TestLokiConfig(unittest.TestCase):
+    def setUp(self):
+        self.config = load_yaml(CONFIGS_DIR / "loki.yml")
+
+    def test_parses_without_error(self):
+        assert self.config is not None
+
+    def test_has_server_section(self):
+        assert "server" in self.config
+
+    def test_server_has_http_listen_port(self):
+        assert "http_listen_port" in self.config["server"]
+
+    def test_has_schema_config(self):
+        assert "schema_config" in self.config
+
+    def test_schema_config_has_configs(self):
+        assert "configs" in self.config["schema_config"]
+
+    def test_has_limits_config(self):
+        assert "limits_config" in self.config
+
+    def test_limits_config_has_retention_period(self):
+        assert "retention_period" in self.config["limits_config"]
+
+
+class TestPromtailConfig(unittest.TestCase):
+    def setUp(self):
+        self.config = load_yaml(CONFIGS_DIR / "promtail.yml")
+
+    def test_parses_without_error(self):
+        assert self.config is not None
+
+    def test_has_server_section(self):
+        assert "server" in self.config
+
+    def test_has_clients(self):
+        assert "clients" in self.config
+
+    def test_clients_is_list(self):
+        assert isinstance(self.config["clients"], list)
+
+    def test_clients_not_empty(self):
+        assert len(self.config["clients"]) > 0
+
+    def test_has_scrape_configs(self):
+        assert "scrape_configs" in self.config
+
+    def test_scrape_configs_is_list(self):
+        assert isinstance(self.config["scrape_configs"], list)
+
+
+class TestGrafanaDatasourcesConfig(unittest.TestCase):
+    def setUp(self):
+        self.config = load_yaml(CONFIGS_DIR / "grafana" / "datasources.yml")
+
+    def test_parses_without_error(self):
+        assert self.config is not None
+
+    def test_has_api_version(self):
+        assert "apiVersion" in self.config
+
+    def test_has_datasources(self):
+        assert "datasources" in self.config
+
+    def test_datasources_is_list(self):
+        assert isinstance(self.config["datasources"], list)
+
+    def test_datasources_not_empty(self):
+        assert len(self.config["datasources"]) > 0
+
+    def test_each_datasource_has_required_fields(self):
+        required_fields = {"name", "type", "uid", "url"}
+        for ds in self.config["datasources"]:
+            for field in required_fields:
+                assert field in ds, f"Datasource missing field '{field}': {ds}"
+
+
+class TestGrafanaDashboardsConfig(unittest.TestCase):
+    def setUp(self):
+        self.config = load_yaml(CONFIGS_DIR / "grafana" / "dashboards.yml")
+
+    def test_parses_without_error(self):
+        assert self.config is not None
+
+    def test_has_api_version(self):
+        assert "apiVersion" in self.config
+
+    def test_has_providers(self):
+        assert "providers" in self.config
+
+    def test_providers_is_list(self):
+        assert isinstance(self.config["providers"], list)
+
+    def test_providers_not_empty(self):
+        assert len(self.config["providers"]) > 0
+
+    def test_each_provider_has_required_fields(self):
+        required_fields = {"name", "type", "options"}
+        for provider in self.config["providers"]:
+            for field in required_fields:
+                assert field in provider, f"Provider missing field '{field}': {provider}"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -1,0 +1,125 @@
+"""
+Validate that all Grafana dashboard JSON files have required fields.
+Uses only stdlib: json, pathlib, unittest.
+"""
+import json
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+DASHBOARDS_DIR = REPO_ROOT / "dashboards"
+
+
+def load_json(path: Path) -> dict:
+    with path.open() as f:
+        return json.load(f)
+
+
+def get_dashboard_files():
+    return sorted(DASHBOARDS_DIR.glob("*.json"))
+
+
+class TestDashboardFilesExist(unittest.TestCase):
+    def test_dashboards_directory_exists(self):
+        assert DASHBOARDS_DIR.is_dir(), f"dashboards/ directory not found at {DASHBOARDS_DIR}"
+
+    def test_at_least_one_dashboard_json(self):
+        files = get_dashboard_files()
+        assert len(files) > 0, "No .json files found in dashboards/"
+
+
+class TestAgentHealthDashboard(unittest.TestCase):
+    def setUp(self):
+        path = DASHBOARDS_DIR / "agent-health.json"
+        self.path = path
+        self.dashboard = load_json(path)
+
+    def test_parses_without_error(self):
+        assert self.dashboard is not None
+
+    def test_has_title(self):
+        assert "title" in self.dashboard, f"{self.path.name} missing 'title'"
+
+    def test_title_is_string(self):
+        assert isinstance(self.dashboard["title"], str)
+
+    def test_title_not_empty(self):
+        assert self.dashboard["title"].strip() != ""
+
+    def test_has_uid(self):
+        assert "uid" in self.dashboard, f"{self.path.name} missing 'uid'"
+
+    def test_uid_is_string(self):
+        assert isinstance(self.dashboard["uid"], str)
+
+    def test_uid_not_empty(self):
+        assert self.dashboard["uid"].strip() != ""
+
+    def test_has_panels(self):
+        assert "panels" in self.dashboard, f"{self.path.name} missing 'panels'"
+
+    def test_panels_is_list(self):
+        assert isinstance(self.dashboard["panels"], list)
+
+    def test_panels_not_empty(self):
+        assert len(self.dashboard["panels"]) > 0
+
+    def test_each_panel_has_id(self):
+        for panel in self.dashboard["panels"]:
+            assert "id" in panel, f"Panel missing 'id' in {self.path.name}: {panel}"
+
+    def test_each_panel_has_title(self):
+        for panel in self.dashboard["panels"]:
+            assert "title" in panel, f"Panel missing 'title' in {self.path.name}: {panel}"
+
+    def test_each_panel_has_type(self):
+        for panel in self.dashboard["panels"]:
+            assert "type" in panel, f"Panel missing 'type' in {self.path.name}: {panel}"
+
+
+class TestAllDashboards(unittest.TestCase):
+    """Generic tests that run against every dashboard JSON in dashboards/."""
+
+    def _check_dashboard(self, path: Path):
+        dashboard = load_json(path)
+        name = path.name
+        assert "title" in dashboard, f"{name}: missing 'title'"
+        assert isinstance(dashboard["title"], str) and dashboard["title"].strip(), \
+            f"{name}: 'title' must be a non-empty string"
+        assert "uid" in dashboard, f"{name}: missing 'uid'"
+        assert isinstance(dashboard["uid"], str) and dashboard["uid"].strip(), \
+            f"{name}: 'uid' must be a non-empty string"
+        assert "panels" in dashboard, f"{name}: missing 'panels'"
+        assert isinstance(dashboard["panels"], list), f"{name}: 'panels' must be a list"
+        assert len(dashboard["panels"]) > 0, f"{name}: 'panels' must not be empty"
+
+    def test_agent_health_dashboard(self):
+        self._check_dashboard(DASHBOARDS_DIR / "agent-health.json")
+
+    def test_nats_events_dashboard(self):
+        self._check_dashboard(DASHBOARDS_DIR / "nats-events.json")
+
+    def test_task_throughput_dashboard(self):
+        self._check_dashboard(DASHBOARDS_DIR / "task-throughput.json")
+
+    def test_all_json_files_have_required_fields(self):
+        """Catch any future dashboards that might be missing required fields."""
+        files = get_dashboard_files()
+        assert len(files) > 0, "No dashboard files found"
+        for path in files:
+            with self.subTest(dashboard=path.name):
+                self._check_dashboard(path)
+
+    def test_all_dashboard_uids_are_unique(self):
+        files = get_dashboard_files()
+        uids = []
+        for path in files:
+            d = load_json(path)
+            if "uid" in d:
+                uids.append(d["uid"])
+        assert len(uids) == len(set(uids)), \
+            f"Duplicate dashboard UIDs found: {[u for u in uids if uids.count(u) > 1]}"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,169 @@
+"""
+Validate that Prometheus alerting and recording rules YAML files parse correctly
+and have required fields.
+Uses only stdlib: yaml, pathlib, unittest.
+"""
+import unittest
+import yaml
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+RULES_DIR = REPO_ROOT / "rules"
+
+
+def load_yaml(path: Path) -> dict:
+    with path.open() as f:
+        return yaml.safe_load(f)
+
+
+class TestRulesDirectoryExists(unittest.TestCase):
+    def test_rules_directory_exists(self):
+        assert RULES_DIR.is_dir(), f"rules/ directory not found at {RULES_DIR}"
+
+    def test_agent_alerts_file_exists(self):
+        assert (RULES_DIR / "agent-alerts.yml").is_file()
+
+    def test_recording_rules_file_exists(self):
+        assert (RULES_DIR / "recording-rules.yml").is_file()
+
+
+class TestAgentAlertsRules(unittest.TestCase):
+    def setUp(self):
+        self.rules = load_yaml(RULES_DIR / "agent-alerts.yml")
+
+    def test_parses_without_error(self):
+        assert self.rules is not None
+
+    def test_has_groups_key(self):
+        assert "groups" in self.rules
+
+    def test_groups_is_list(self):
+        assert isinstance(self.rules["groups"], list)
+
+    def test_groups_not_empty(self):
+        assert len(self.rules["groups"]) > 0
+
+    def test_each_group_has_name(self):
+        for group in self.rules["groups"]:
+            assert "name" in group, f"Group missing 'name': {group}"
+
+    def test_each_group_has_rules(self):
+        for group in self.rules["groups"]:
+            assert "rules" in group, f"Group '{group.get('name')}' missing 'rules'"
+
+    def test_each_group_rules_is_list(self):
+        for group in self.rules["groups"]:
+            assert isinstance(group["rules"], list), \
+                f"Group '{group.get('name')}' 'rules' must be a list"
+
+    def test_each_alert_has_alert_name(self):
+        for group in self.rules["groups"]:
+            for rule in group["rules"]:
+                if "alert" in rule:
+                    assert isinstance(rule["alert"], str), \
+                        f"Alert name must be a string: {rule}"
+                    assert rule["alert"].strip() != "", \
+                        f"Alert name must not be empty: {rule}"
+
+    def test_each_alert_has_expr(self):
+        for group in self.rules["groups"]:
+            for rule in group["rules"]:
+                if "alert" in rule:
+                    assert "expr" in rule, \
+                        f"Alert '{rule.get('alert')}' missing 'expr'"
+
+    def test_each_alert_has_labels(self):
+        for group in self.rules["groups"]:
+            for rule in group["rules"]:
+                if "alert" in rule:
+                    assert "labels" in rule, \
+                        f"Alert '{rule.get('alert')}' missing 'labels'"
+
+    def test_each_alert_severity_is_valid(self):
+        valid_severities = {"critical", "warning", "info"}
+        for group in self.rules["groups"]:
+            for rule in group["rules"]:
+                if "alert" in rule and "labels" in rule:
+                    severity = rule["labels"].get("severity")
+                    if severity is not None:
+                        assert severity in valid_severities, \
+                            f"Alert '{rule.get('alert')}' has invalid severity '{severity}'"
+
+    def test_each_alert_has_annotations(self):
+        for group in self.rules["groups"]:
+            for rule in group["rules"]:
+                if "alert" in rule:
+                    assert "annotations" in rule, \
+                        f"Alert '{rule.get('alert')}' missing 'annotations'"
+
+    def test_each_alert_annotation_has_summary(self):
+        for group in self.rules["groups"]:
+            for rule in group["rules"]:
+                if "alert" in rule and "annotations" in rule:
+                    assert "summary" in rule["annotations"], \
+                        f"Alert '{rule.get('alert')}' annotations missing 'summary'"
+
+
+class TestRecordingRules(unittest.TestCase):
+    def setUp(self):
+        self.rules = load_yaml(RULES_DIR / "recording-rules.yml")
+
+    def test_parses_without_error(self):
+        assert self.rules is not None
+
+    def test_has_groups_key(self):
+        assert "groups" in self.rules
+
+    def test_groups_is_list(self):
+        assert isinstance(self.rules["groups"], list)
+
+    def test_groups_not_empty(self):
+        assert len(self.rules["groups"]) > 0
+
+    def test_each_group_has_name(self):
+        for group in self.rules["groups"]:
+            assert "name" in group, f"Group missing 'name': {group}"
+
+    def test_each_group_has_rules(self):
+        for group in self.rules["groups"]:
+            assert "rules" in group, f"Group '{group.get('name')}' missing 'rules'"
+
+    def test_each_recording_rule_has_record_and_expr(self):
+        for group in self.rules["groups"]:
+            for rule in group["rules"]:
+                if "record" in rule:
+                    assert "expr" in rule, \
+                        f"Recording rule '{rule.get('record')}' missing 'expr'"
+                    assert isinstance(rule["record"], str), \
+                        f"Recording rule 'record' must be a string: {rule}"
+                    assert rule["record"].strip() != "", \
+                        f"Recording rule 'record' must not be empty: {rule}"
+
+    def test_recording_rule_names_follow_convention(self):
+        """Recording rule names should follow the Prometheus naming convention: level:metric:operation."""
+        for group in self.rules["groups"]:
+            for rule in group["rules"]:
+                if "record" in rule:
+                    name = rule["record"]
+                    colon_count = name.count(":")
+                    assert colon_count >= 1, \
+                        f"Recording rule '{name}' should follow level:metric:operation convention"
+
+
+class TestAllRulesFiles(unittest.TestCase):
+    """Generic test that all YAML files in rules/ parse and have 'groups'."""
+
+    def test_all_yml_files_parse_and_have_groups(self):
+        yml_files = sorted(RULES_DIR.glob("*.yml"))
+        assert len(yml_files) > 0, "No .yml files found in rules/"
+        for path in yml_files:
+            with self.subTest(rules_file=path.name):
+                data = load_yaml(path)
+                assert data is not None, f"{path.name} parsed as None"
+                assert "groups" in data, f"{path.name} missing top-level 'groups' key"
+                assert isinstance(data["groups"], list), \
+                    f"{path.name}: 'groups' must be a list"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `tests/` directory with `__init__.py` and 3 test files covering configs, dashboards, and rules
- 80 tests verify YAML/JSON structure and required fields using only stdlib (`yaml`, `json`, `pathlib`, `unittest`)
- All tests pass with `python3 -m pytest tests/ -v`

## Test Coverage
- `tests/test_configs.py`: validates `prometheus.yml`, `loki.yml`, `promtail.yml`, `grafana/datasources.yml`, `grafana/dashboards.yml` — required top-level keys, list types, non-empty collections
- `tests/test_dashboards.py`: validates all `dashboards/*.json` have `title`, `uid`, `panels`; checks panel fields; asserts UIDs are unique
- `tests/test_rules.py`: validates `agent-alerts.yml` and `recording-rules.yml` — `groups` key, alert/record fields, severity values, annotation summaries, naming convention

## Test plan
- [x] `python3 -m pytest tests/ -v` — 80 passed in 0.16s
- [x] `python3 -m unittest discover -s tests -v` also works (stdlib fallback)
- [x] Only stdlib imports — no new dependencies required

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)