### PR TITLE
feat(exporter): add env var validation and configurable scrape timeout

### DIFF
--- a/exporter/exporter.py
+++ b/exporter/exporter.py
@@ -22,10 +22,23 @@ NESTOR_URL    = os.environ.get("NESTOR_URL",    "http://172.20.0.1:8081")
 NATS_URL      = os.environ.get("NATS_URL",      "http://172.24.0.1:8222")
 PORT          = int(os.environ.get("EXPORTER_PORT", "9100"))
 
+_raw_timeout = os.environ.get("SCRAPE_TIMEOUT", "5")
+try:
+    SCRAPE_TIMEOUT: float = float(_raw_timeout)
+except ValueError:
+    log.warning("SCRAPE_TIMEOUT=%r is not numeric; falling back to 5", _raw_timeout)
+    SCRAPE_TIMEOUT = 5.0
+
+for _var, _val in (("AGAMEMNON_URL", AGAMEMNON_URL),
+                   ("NESTOR_URL",    NESTOR_URL),
+                   ("NATS_URL",      NATS_URL)):
+    if not _val:
+        log.warning("environment variable %s is empty; scrapes against this target will fail", _var)
+
 
 def _fetch(url: str) -> dict | None:
     try:
-        r = urllib.request.urlopen(url, timeout=5)
+        r = urllib.request.urlopen(url, timeout=SCRAPE_TIMEOUT)
         return json.loads(r.read())
     except Exception as e:
         log.warning("fetch %s failed: %s", url, e)
@@ -35,7 +48,7 @@ def _fetch(url: str) -> dict | None:
 def _health_check(url: str) -> int:
     """Return 1 if the URL returns HTTP 200, 0 otherwise."""
     try:
-        r = urllib.request.urlopen(url, timeout=5)
+        r = urllib.request.urlopen(url, timeout=SCRAPE_TIMEOUT)
         return 1 if r.status == 200 else 0
     except Exception:
         return 0


### PR DESCRIPTION
## Summary
- Validates `AGAMEMNON_URL`, `NESTOR_URL`, `NATS_URL` on startup; logs a warning (non-fatal) if any are empty
- Adds `SCRAPE_TIMEOUT` env var (default: 5) parsed as float; invalid values fall back to 5 with a logged warning
- Updates `_fetch()` and `_health_check()` to use module-level `SCRAPE_TIMEOUT` instead of hardcoded `timeout=5`

## Test plan
- [ ] `python3 -m py_compile exporter/exporter.py` passes
- [ ] Start exporter with `SCRAPE_TIMEOUT=2` and confirm timeout behavior changes
- [ ] Start exporter with `SCRAPE_TIMEOUT=notanumber` and confirm fallback warning is logged
- [ ] Start exporter with `AGAMEMNON_URL=` (empty) and confirm warning is logged without crash

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)