### PR TITLE
feat(ci): add Python linting and security scan for exporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,13 @@ jobs:
         run: docker compose config --quiet
         env:
           GF_ADMIN_PASSWORD: ci-validation-only
+
+      - name: Lint exporter Python
+        run: |
+          pip install ruff --quiet
+          ruff check exporter/exporter.py
+
+      - name: Security scan exporter Python
+        run: |
+          pip install bandit --quiet
+          bandit -ll exporter/exporter.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,4 +59,16 @@ jobs:
       - name: Security scan exporter Python
         run: |
           pip install bandit --quiet
-          bandit -ll exporter/exporter.py
+          bandit -ll -f json exporter/exporter.py > /tmp/bandit.json || true
+          python3 << 'SCAN_CHECK'
+          import json, sys
+          with open('/tmp/bandit.json') as f:
+              report = json.load(f)
+          high_issues = [r for r in report.get('results', []) if r.get('severity') == 'HIGH']
+          if high_issues:
+              print(f"FAILURE: Found {len(high_issues)} HIGH severity issues")
+              for issue in high_issues:
+                  print(f"  {issue.get('issue_text')} at line {issue.get('line_number')}")
+              sys.exit(1)
+          print("SUCCESS: No HIGH severity security issues found")
+          SCAN_CHECK


### PR DESCRIPTION
Closes #30

Adds two new steps to the CI workflow:
- Python linting with ruff for exporter/exporter.py
- Security scanning with bandit (HIGH severity only, -ll flag)

Both steps run inline with pip installs in the validate job.