### PR TITLE
refactor(scripts): centralise dashboard import logic in scripts/import-dashboards.sh

### DIFF
--- a/justfile
+++ b/justfile
@@ -77,14 +77,4 @@ restore VOLUME FILE:
 
 # Import all JSON dashboards from dashboards/ into Grafana via API
 import-dashboards:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    for f in dashboards/*.json; do
-        echo "Importing $f ..."
-        payload=$(jq -n --slurpfile dash "$f" '{"dashboard": $dash[0], "overwrite": true, "folderId": 0}')
-        curl -s -u {{GRAFANA_AUTH}} \
-            -H "Content-Type: application/json" \
-            -d "$payload" \
-            "{{GRAFANA_URL}}/api/dashboards/db" | jq '.status'
-    done
-    echo "Dashboard import complete."
+    GRAFANA_PORT={{GRAFANA_PORT}} GRAFANA_ADMIN_PASSWORD=$(echo "{{GRAFANA_AUTH}}" | cut -d: -f2) ./scripts/import-dashboards.sh


### PR DESCRIPTION
## Summary

- Removes the duplicated inline bash loop from the `import-dashboards` justfile recipe
- `justfile` `import-dashboards` recipe now delegates to `./scripts/import-dashboards.sh`
- `scripts/import-dashboards.sh` is the single canonical implementation; it uses `GRAFANA_PORT` and `GRAFANA_ADMIN_PASSWORD` env vars (with defaults matching the justfile variables)

Closes #42

## Test plan

- [ ] `just import-dashboards` invokes `scripts/import-dashboards.sh`
- [ ] Script uses `GRAFANA_PORT` and `GRAFANA_ADMIN_PASSWORD` from env (or defaults `3000` / `admin`)
- [ ] `scripts/import-dashboards.sh` is executable (`chmod +x` confirmed)
- [ ] No duplicate import logic remains in `justfile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)