### PR TITLE
fix(promtail): mount NATS log directory and fix log path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,5 @@ NESTOR_URL=http://172.20.0.1:8081
 # NATS monitoring API
 NATS_URL=http://172.24.0.1:8222
 
-# Path to NATS server log file on the host (Promtail tails this path)
-NATS_LOG_PATH=/home/mvillmow/.local/share/nats/nats.log
+# NATS log directory on the host (Promtail mounts this read-only)
+NATS_LOG_DIR=/home/mvillmow/.local/share/nats

--- a/configs/promtail.yml
+++ b/configs/promtail.yml
@@ -19,7 +19,7 @@ scrape_configs:
           host: hermes
           __path__: /var/log/syslog
 
-  # Tail NATS server log — path configurable via NATS_LOG_PATH env var
+  # Tail NATS server log — NATS log directory mounted at /nats-logs
   - job_name: nats
     static_configs:
       - targets:
@@ -27,4 +27,4 @@ scrape_configs:
         labels:
           job: nats
           service: nats-server
-          __path__: ${NATS_LOG_PATH}
+          __path__: /nats-logs/nats.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
     volumes:
       - ./configs/promtail.yml:/etc/promtail/config.yml:ro
       - /var/log:/var/log:ro
+      - ${NATS_LOG_DIR:-/home/mvillmow/.local/share/nats}:/nats-logs:ro
     command: -config.file=/etc/promtail/config.yml -config.expand-env=true
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:9080/ready"]


### PR DESCRIPTION
## Summary

- Adds NATS log directory mount to promtail service in docker-compose.yml
- Updates promtail config to use the mounted path instead of env-var expansion
- Adds NATS_LOG_DIR env var to .env.example
- Closes #8

## Test plan

- [x] docker compose config validates with GF_ADMIN_PASSWORD=test
- [x] Three files staged and committed correctly