### PR TITLE
Add Argus stack self-health dashboard

### DIFF
--- a/dashboards/argus-health.json
+++ b/dashboards/argus-health.json
@@ -1,0 +1,77 @@
+{
+  "uid": "argus-health",
+  "title": "Argus Stack Health",
+  "version": 1,
+  "schemaVersion": 39,
+  "tags": ["argus", "meta"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Prometheus Scrape Targets Up",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 8, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "count(up == 1)",
+          "legendFormat": "Targets Up",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "green" }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Homeric Exporter Health",
+      "type": "stat",
+      "gridPos": { "x": 8, "y": 0, "w": 8, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "up{job=\"homeric-exporter\"}",
+          "legendFormat": "Health",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value"
+      }
+    },
+    {
+      "id": 3,
+      "title": "Total Scrape Targets",
+      "type": "stat",
+      "gridPos": { "x": 16, "y": 0, "w": 8, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "count(up)",
+          "legendFormat": "Total Targets",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds a new Grafana dashboard (`argus-health`) for monitoring the health of the ProjectArgus observability stack itself - meta-monitoring for Prometheus, Loki, and scrape targets.

## Dashboard Details
- **UID**: `argus-health`
- **Title**: `Argus Stack Health`
- **Panels**:
  1. Prometheus Scrape Targets Up: Shows count of healthy targets using `count(up == 1)`
  2. Homeric Exporter Health: Shows exporter status using `up{job="homeric-exporter"}`
  3. Total Scrape Targets: Shows total target count using `count(up)`

All panels are stat type with 30s refresh interval and look back over 1 hour.

Closes #55