### PR TITLE
feat(compose): add dev profile with debug-shell service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,6 +135,16 @@ services:
           memory: 128m
           cpus: "0.10"
 
+  # dev-only: interactive debug shell for exec-based troubleshooting
+  # Start with: docker compose --profile dev up -d debug-shell
+  debug-shell:
+    image: python:3.11.10-slim
+    container_name: argus-debug-shell
+    profiles: [dev]
+    command: sleep infinity
+    networks:
+      - argus
+
 volumes:
   prometheus_data:
   loki_data:


### PR DESCRIPTION
## Summary

- Adds `debug-shell` service (`python:3.11.10-slim`, `command: sleep infinity`) gated behind `profiles: [dev]`
- All 5 core services (prometheus, loki, promtail, grafana, argus-exporter) remain always-on with no `profiles:` key
- Demonstrates the Docker Compose profiles mechanism for separating dev vs prod configurations

## Test plan

- [x] `GF_ADMIN_PASSWORD=test docker compose config --quiet` exits 0
- [x] `GF_ADMIN_PASSWORD=test docker compose --profile dev config --quiet` exits 0
- [ ] `docker compose --profile dev up -d debug-shell` starts the debug-shell container
- [ ] `docker compose up -d` does NOT start the debug-shell container

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)