### PR TITLE
feat(ci): use pixi for environment management and tool execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install yamllint
-        run: pip install yamllint
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "$HOME/.pixi/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: pixi install
 
       - name: Lint all YAML files
         run: |
-          yamllint -d "{extends: default, rules: {line-length: {max: 120}, truthy: disable}}" \
+          pixi run yamllint -d "{extends: default, rules: {line-length: {max: 120}, truthy: disable}}" \
             configs/prometheus.yml \
             configs/loki.yml \
             configs/promtail.yml \
@@ -52,14 +55,11 @@ jobs:
           GF_ADMIN_PASSWORD: ci-validation-only
 
       - name: Lint exporter Python
-        run: |
-          pip install ruff --quiet
-          ruff check exporter/exporter.py
+        run: pixi run ruff check exporter/exporter.py
 
       - name: Security scan exporter Python
         run: |
-          pip install bandit --quiet
-          bandit -ll -f json exporter/exporter.py > /tmp/bandit.json || true
+          pixi run bandit -ll -f json exporter/exporter.py > /tmp/bandit.json || true
           python3 << 'SCAN_CHECK'
           import json, sys
           with open('/tmp/bandit.json') as f:

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,6 +8,9 @@ platforms = ["linux-64"]
 [dependencies]
 just = ">=1.13"
 jq = ">=1.6"
+yamllint = ">=1.35"
+ruff = ">=0.4"
+bandit = ">=1.7"
 
 [tasks]
 start  = "just start"


### PR DESCRIPTION
## Summary

Replace direct pip install calls with pixi for environment management and tool invocation in CI.

- Added `yamllint`, `ruff`, and `bandit` to pixi.toml dependencies
- CI now installs pixi via official installer
- All tool invocations use `pixi run <tool>` pattern
- Removed pip install steps entirely

Closes #33

## Acceptance Criteria

- [x] `pixi.toml` has `yamllint`, `ruff`, `bandit` in `[dependencies]`
- [x] CI installs pixi via the official installer step
- [x] CI runs `pixi install` once
- [x] All tool invocations use `pixi run <tool>` instead of bare tool calls
- [x] The workflow YAML is valid