### PR TITLE
feat(justfile): add restart, clean, validate, and test targets

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,6 +26,24 @@ stop:
 status:
     {{compose_cmd}} ps
 
+# Restart all services (stop then start)
+restart:
+    {{compose_cmd}} down
+    {{compose_cmd}} up -d
+
+# Remove all containers and volumes (destructive — data loss!)
+clean:
+    {{compose_cmd}} down -v
+
+# Validate docker-compose config and YAML files
+validate:
+    {{compose_cmd}} config --quiet
+    @echo "Config is valid."
+
+# Run local test suite
+test:
+    python3 -m pytest tests/ -v 2>/dev/null || python3 -m unittest discover -s tests -v
+
 # Tail logs for a specific service (e.g. just logs prometheus)
 logs SERVICE:
     {{compose_cmd}} logs -f {{SERVICE}}


### PR DESCRIPTION
## Summary
Adds common operational `just` targets to improve developer workflow and operational consistency.

- **restart**: Stops all services then starts them again for a clean restart
- **clean**: Removes all containers and volumes (destructive operation with data loss)
- **validate**: Validates docker-compose config files using `docker compose config --quiet`
- **test**: Runs the local test suite with pytest or unittest fallback

## Test plan
- [x] Run `just restart` to verify services restart properly
- [x] Run `just validate` to verify config validation works
- [x] Run `just clean` to verify volume cleanup
- [x] Run `just test` to verify test suite execution

Closes #56

Generated with Claude Code