### PR TITLE
feat(scripts): add backup and restore scripts for data volumes

### DIFF
--- a/justfile
+++ b/justfile
@@ -45,6 +45,16 @@ test-scrape:
 scrape-agamemnon:
     ./scripts/scrape-agamemnon.sh {{AGAMEMNON_URL}}
 
+# === Backup & Restore ===
+
+# Back up Prometheus and Loki data volumes to ./backups/
+backup:
+    ./scripts/backup.sh
+
+# Restore a volume from a backup file: just restore <volume> <file>
+restore VOLUME FILE:
+    ./scripts/restore.sh {{VOLUME}} {{FILE}}
+
 # === Grafana ===
 
 # Import all JSON dashboards from dashboards/ into Grafana via API

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Back up Prometheus and Loki data volumes to timestamped tar.gz files
+# Usage: backup.sh
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+BACKUP_DIR="$(cd "$(dirname "$0")/.." && pwd)/backups"
+mkdir -p "$BACKUP_DIR"
+
+echo "Backing up Prometheus and Loki data volumes..."
+echo "Backup directory: $BACKUP_DIR"
+
+for vol in prometheus_data loki_data; do
+    out="$BACKUP_DIR/${vol}_${TIMESTAMP}.tar.gz"
+    echo "Backing up $vol -> $out"
+    docker run --rm -v "${vol}:/data:ro" -v "${BACKUP_DIR}:/backups" \
+        alpine tar czf "/backups/${vol}_${TIMESTAMP}.tar.gz" -C /data .
+    echo "  ✓ $vol backup complete"
+done
+
+echo ""
+echo "Backup complete: $BACKUP_DIR"
+echo "Files:"
+ls -lh "$BACKUP_DIR/${TIMESTAMP:0:8}"* 2>/dev/null || echo "  (no backups found with today's date)"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Restore a Docker volume from a backup file
+# Usage: restore.sh <volume_name> <backup_file.tar.gz>
+# Example: restore.sh prometheus_data ./backups/prometheus_data_20260422_193000.tar.gz
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage: restore.sh <volume_name> <backup_file.tar.gz>"
+    echo ""
+    echo "Example:"
+    echo "  restore.sh prometheus_data ./backups/prometheus_data_20260422_193000.tar.gz"
+    echo "  restore.sh loki_data ./backups/loki_data_20260422_193000.tar.gz"
+    exit 1
+fi
+
+VOLUME="$1"
+FILE="$2"
+
+if [[ ! -f "$FILE" ]]; then
+    echo "Error: Backup file not found: $FILE"
+    exit 1
+fi
+
+echo "Restoring $VOLUME from $FILE ..."
+docker run --rm -v "${VOLUME}:/data" -v "$(realpath "$FILE"):/backup.tar.gz:ro" \
+    alpine sh -c "cd /data && tar xzf /backup.tar.gz"
+echo "✓ Restore complete: $VOLUME"


### PR DESCRIPTION
## Summary
- Add `scripts/backup.sh` to back up `prometheus_data` and `loki_data` Docker volumes to timestamped tar.gz files in `./backups/`
- Add `scripts/restore.sh` to restore volumes from backup files
- Both scripts are self-documenting with usage printed when called without arguments
- Add `backup` and `restore VOLUME FILE` targets to justfile

## Implementation Details
- Uses `docker run --rm -v <volume>:/data` pattern for safe, containerized backups
- Backup files are timestamped (YYYYMMDD_HHMMSS) for easy version management
- Restore script validates backup file exists before attempting restore
- Scripts use `set -euo pipefail` for safety

## Closes
Closes #45