### PR TITLE
feat(security): add nginx basic auth proxy in front of Loki

### DIFF
--- a/configs/nginx/htpasswd
+++ b/configs/nginx/htpasswd
@@ -1,0 +1,1 @@
+loki:$apr1$IvtTVmT2$Vyef8metZTBYPpuH6byNP.

--- a/configs/nginx/loki.conf
+++ b/configs/nginx/loki.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    location / {
+        auth_basic "Loki";
+        auth_basic_user_file /etc/nginx/htpasswd;
+        proxy_pass http://loki:3100;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,6 @@ services:
     image: grafana/loki:3.1.2
     container_name: argus-loki
     restart: unless-stopped
-    ports:
-      - "3100:3100"
     volumes:
       - ./configs/loki.yml:/etc/loki/local-config.yaml:ro
       - loki_data:/loki
@@ -55,6 +53,25 @@ services:
         limits:
           memory: 256m
           cpus: "0.25"
+
+  loki-proxy:
+    image: nginx:1.27-alpine
+    container_name: argus-loki-proxy
+    restart: unless-stopped
+    ports:
+      - "3101:80"
+    volumes:
+      - ./configs/nginx/loki.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./configs/nginx/htpasswd:/etc/nginx/htpasswd:ro
+    networks:
+      - argus
+    depends_on:
+      - loki
+    deploy:
+      resources:
+        limits:
+          memory: 64m
+          cpus: "0.10"
 
   promtail:
     image: grafana/promtail:3.1.2


### PR DESCRIPTION
## Summary
- Adds `configs/nginx/loki.conf` with an nginx reverse proxy config requiring HTTP Basic Auth in front of Loki
- Adds `configs/nginx/htpasswd` with pre-generated `loki:argus` credentials (apr1 hash)
- Adds `loki-proxy` service in `docker-compose.yml` (nginx:1.27-alpine, port 3101:80)
- Removes the exposed `ports:` block from the `loki` service (now internal-only on port 3100)
- Promtail continues to push directly to `http://loki:3100` internally (no auth needed)

## Test plan
- [ ] `GF_ADMIN_PASSWORD=test docker compose config --quiet` exits 0
- [ ] `docker compose up -d` brings up `loki-proxy` alongside other services
- [ ] Unauthenticated request to `http://localhost:3101/` returns HTTP 401
- [ ] Authenticated request `curl -u loki:argus http://localhost:3101/ready` returns 200

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)