### PR TITLE
Bind exporter HTTP server to 127.0.0.1 instead of 0.0.0.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
     container_name: argus-exporter
     restart: unless-stopped
     ports:
-      - "9100:9100"
+      - "127.0.0.1:9100:9100"
     environment:
       AGAMEMNON_URL: ${AGAMEMNON_URL:-http://172.20.0.1:8080}
       NESTOR_URL: ${NESTOR_URL:-http://172.20.0.1:8081}

--- a/exporter/exporter.py
+++ b/exporter/exporter.py
@@ -181,7 +181,7 @@ if __name__ == "__main__":
     log.info("Scraping Nestor at %s", NESTOR_URL)
     log.info("Scraping NATS at %s", NATS_URL)
 
-    server = HTTPServer(("0.0.0.0", PORT), Handler)
+    server = HTTPServer(("127.0.0.1", PORT), Handler)
 
     def _shutdown(signum, frame):
         sig_name = signal.Signals(signum).name


### PR DESCRIPTION
## Summary

Restricts the homeric-exporter HTTP server to listen only on localhost (127.0.0.1) instead of binding to all interfaces (0.0.0.0). Also updates docker-compose.yml to reflect localhost-only port binding.

This is a security improvement limiting external network exposure to the metrics endpoint.

Closes #21