### PR TITLE
chore(deps): add Dependabot config for Docker image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    target-branch: "main"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
Implement GitHub issue #44: Add Dependabot configuration to automatically propose PRs when container images become outdated.

## Changes
- Adds  with Docker image monitoring
- Configured to check weekly for new versions
- Targets the main branch for PRs
- Labels all created PRs with 'dependencies'

## Configuration
- Package ecosystem: docker
- Schedule: weekly
- Target branch: main
- Commit prefix: chore(deps)

Closes #44