### PR TITLE
feat(grafana): provision Alertmanager contact point for alert visibility

### DIFF
--- a/configs/grafana/alerting.yml
+++ b/configs/grafana/alerting.yml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: alertmanager
+    receivers:
+      - uid: alertmanager-receiver
+        type: prometheus-alertmanager
+        settings:
+          url: http://alertmanager:9093
+        disableResolveMessage: false
+
+policies:
+  - orgId: 1
+    receiver: alertmanager

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,7 @@ services:
     volumes:
       - ./dashboards:/var/lib/grafana/dashboards:ro
       - ./configs/grafana:/etc/grafana/provisioning:ro
+      - ./configs/grafana/alerting.yml:/etc/grafana/provisioning/alerting/alerting.yml:ro
       - grafana_data:/var/lib/grafana
     environment:
       GF_SECURITY_ADMIN_PASSWORD: ${GF_ADMIN_PASSWORD:?GF_ADMIN_PASSWORD must be set in .env}


### PR DESCRIPTION
## Summary
- Adds `configs/grafana/alerting.yml` with Grafana 11.x alerting provisioning that registers Alertmanager (`http://alertmanager:9093`) as a contact point and default notification policy
- Adds explicit volume mount in `docker-compose.yml` so Grafana auto-loads the alerting config at `/etc/grafana/provisioning/alerting/alerting.yml` on startup
- No runtime impact until Alertmanager is deployed (issue #11); the config is forward-compatible and silently no-ops if the upstream is unreachable

## Test plan
- [ ] `GF_ADMIN_PASSWORD=ci docker compose config --quiet` exits 0 (validated locally)
- [ ] After `just start`, Grafana UI → Alerting → Contact points shows `alertmanager` entry
- [ ] After `just start`, Grafana UI → Alerting → Notification policies shows `alertmanager` as default receiver

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)