### PR TITLE
fix(dependabot): remove docker package-ecosystem (no Dockerfiles)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/exporter"
     schedule:
       interval: "weekly"
     labels:


### PR DESCRIPTION
Dependabot fails with dependency_file_not_found because the docker package-ecosystem is configured but no Dockerfiles exist in this repository.

Removes the docker entry from dependabot.yml to stop the false-positive failures.

Fixes Dependabot error: dependency_file_not_found /Dockerfile