### PR TITLE
fix(atlas): M1 followup — healthz plaintext, hermes:8080, README line wrap

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,6 +1,8 @@
 # Atlas — HomericIntelligence Dashboard
 
-Atlas is the unified observability dashboard for the HomericIntelligence distributed agent mesh. It provides a real-time overview of agents, tasks, NATS streams, and hosts via a lightweight Go/Chi HTTP server with a dark-themed UI built on htmx and SSE.
+Atlas is the unified observability dashboard for the HomericIntelligence distributed agent mesh.
+It provides a real-time overview of agents, tasks, NATS streams, and hosts via a lightweight
+Go/Chi HTTP server with a dark-themed UI built on htmx and SSE.
 
 ## Quick Start
 
@@ -27,7 +29,7 @@ All configuration is via environment variables with the `ATLAS_` prefix:
 | `ATLAS_NATS_MON_URL` | `http://nats:8222` | NATS monitoring URL |
 | `ATLAS_AGAMEMNON_URL` | `http://agamemnon:8080` | Agamemnon API URL |
 | `ATLAS_NESTOR_URL` | `http://nestor:8081` | Nestor API URL |
-| `ATLAS_HERMES_URL` | `http://hermes:8085` | Hermes event bridge URL |
+| `ATLAS_HERMES_URL` | `http://hermes:8080` | Hermes event bridge URL |
 | `ATLAS_PROMETHEUS_URL` | `http://prometheus:9090` | Prometheus URL |
 | `ATLAS_GRAFANA_URL` | `http://grafana:3000` | Grafana URL |
 | `ATLAS_AUTH_MODE` | `none` | Auth mode (none/basic/bearer) |

--- a/dashboard/internal/config/config.go
+++ b/dashboard/internal/config/config.go
@@ -54,7 +54,7 @@ func Load() *Config {
 		NATSMonURL:         getenv("ATLAS_NATS_MON_URL", "http://nats:8222"),
 		AgamemnonURL:       getenv("ATLAS_AGAMEMNON_URL", "http://agamemnon:8080"),
 		NestorURL:          getenv("ATLAS_NESTOR_URL", "http://nestor:8081"),
-		HermesURL:          getenv("ATLAS_HERMES_URL", "http://hermes:8085"),
+		HermesURL:          getenv("ATLAS_HERMES_URL", "http://hermes:8080"),
 		PrometheusURL:      getenv("ATLAS_PROMETHEUS_URL", "http://prometheus:9090"),
 		GrafanaURL:         getenv("ATLAS_GRAFANA_URL", "http://grafana:3000"),
 		LokiURL:            getenv("ATLAS_LOKI_URL", "http://loki:3100"),

--- a/dashboard/internal/server/routes.go
+++ b/dashboard/internal/server/routes.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -23,8 +22,9 @@ func (s *Server) routes() http.Handler {
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
 }
 
 func (s *Server) handleOverview(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Three fixes that were applied on the M1 feature branch but did not land on `main`
because auto-merge squashed from a pre-fix commit (the fixes landed after the merge
trigger fired).

- **routes.go**: `handleHealthz` returns `text/plain` "ok" (was JSON `{"status":"ok"}`)
- **config.go**: `ATLAS_HERMES_URL` default `8085` → `8080` (canonical port per `ProjectHermes/src/hermes/config.py:35`)
- **README.md**: wrap intro paragraph to ≤120 chars (markdownlint MD013); fix Hermes port in table

## Part of Epic
HomericIntelligence/Odysseus#151 — Atlas M1 cleanup