### PR TITLE
fix(atlas): address M2 review-wave findings (code/ux/ops/docs)

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -36,6 +36,43 @@ All configuration is via environment variables with the `ATLAS_` prefix:
 | `ATLAS_TAILSCALE_SOURCE` | `static` | Tailscale source (static/api/socket) |
 | `ATLAS_POLL_AGAMEMNON_MS` | `5000` | Poll interval for Agamemnon in ms |
 
+## SSE Event Stream
+
+Atlas exposes a real-time event stream at `/events` using Server-Sent Events.
+
+```
+GET /events?topics=agent,task&replay=20
+```
+
+| Parameter | Description |
+|---|---|
+| `topics` | Comma-separated topic filter. Omit to receive all topics. |
+| `replay` | Number of buffered events to replay on connect (ring buffer, max 256). |
+
+**Topics** (derived from NATS subject prefix):
+
+| Topic | NATS stream | Subject pattern |
+|---|---|---|
+| `agent` | `homeric-agents` | `hi.agents.>` |
+| `task` | `homeric-tasks` | `hi.tasks.>` |
+| `myrmidon` | `homeric-myrmidon` | `hi.myrmidon.>` |
+| `research` | `homeric-research` | `hi.research.>` |
+| `pipeline` | `homeric-pipeline` | `hi.pipeline.>` |
+| `log` | `homeric-logs` | `hi.logs.>` |
+
+**Wire format** (per event):
+```
+event: {topic}
+data: {json payload}
+
+```
+
+Keepalive comment frames are sent every 15 seconds:
+```
+: heartbeat
+
+```
+
 ## Building
 
 ```bash

--- a/dashboard/internal/events/bus.go
+++ b/dashboard/internal/events/bus.go
@@ -107,11 +107,6 @@ func (b *Bus) Unsubscribe(ch <-chan Event) {
 func (b *Bus) Publish(e Event) {
 	b.mu.Lock()
 	b.ring.Push(e)
-	// Snapshot the subscriber set while holding the write lock so we can
-	// send without holding the lock (avoiding potential deadlock if a
-	// subscriber's select blocks, though our send is non-blocking anyway).
-	// We collect references and send inside the lock because the send itself
-	// is non-blocking (select + default).
 	for ch := range b.subs {
 		select {
 		case ch <- e:

--- a/dashboard/internal/handlers/sse.go
+++ b/dashboard/internal/handlers/sse.go
@@ -29,25 +29,21 @@ func NewSSE(bus *events.Bus) *SSE {
 // subscriber channel on the bus and receives all matching events until the
 // client disconnects or the request context is cancelled.
 func (h *SSE) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// 1. Set required SSE headers.
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("X-Accel-Buffering", "no")
 
-	// 8. Require http.Flusher; return 500 if not available.
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "streaming not supported", http.StatusInternalServerError)
 		return
 	}
 
-	// 2. WriteHeader(200) and flush.
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
 	ctx := r.Context()
 
-	// 3. Parse ?topics= query param (comma-separated; empty = accept all).
 	topicFilter := make(map[string]struct{})
 	if raw := r.URL.Query().Get("topics"); raw != "" {
 		for _, t := range strings.Split(raw, ",") {
@@ -58,7 +54,6 @@ func (h *SSE) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// 4. Parse ?replay=N and send buffered events first.
 	if replayStr := r.URL.Query().Get("replay"); replayStr != "" {
 		if n, err := strconv.Atoi(replayStr); err == nil && n > 0 {
 			for _, e := range h.bus.Snapshot(n) {
@@ -70,11 +65,9 @@ func (h *SSE) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// 5. Subscribe to bus.
 	ch := h.bus.Subscribe(1000)
 	defer h.bus.Unsubscribe(ch)
 
-	// 6. Main event loop.
 	ticker := time.NewTicker(HeartbeatInterval)
 	defer ticker.Stop()
 
@@ -84,8 +77,8 @@ func (h *SSE) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 
 		case <-ticker.C:
-			// Heartbeat to keep the connection alive.
-			if _, err := fmt.Fprint(w, "event: heartbeat\ndata: {}\n\n"); err != nil {
+			// SSE comment frame — discarded by the parser, keeps the TCP connection alive.
+			if _, err := fmt.Fprint(w, ": heartbeat\n\n"); err != nil {
 				return
 			}
 			flusher.Flush()

--- a/dashboard/internal/handlers/sse_test.go
+++ b/dashboard/internal/handlers/sse_test.go
@@ -148,7 +148,7 @@ func TestSSEEventDelivery(t *testing.T) {
 		if strings.HasPrefix(line, "event: ") {
 			topic := strings.TrimPrefix(line, "event: ")
 			if topic == "heartbeat" {
-				// Skip heartbeat frames.
+				// Skip legacy named heartbeat frames (now emitted as SSE comments).
 				continue
 			}
 			eventLine = line
@@ -266,18 +266,10 @@ func TestSSEReplay(t *testing.T) {
 	// Read 2 complete SSE frames. Each frame: "event: ...\ndata: ...\n\n".
 	lines := sseLines(t, resp.Body, 2)
 
-	// Filter out any heartbeat frames before asserting.
+	// Filter out heartbeat comment frames (": heartbeat") before asserting.
 	var dataLines []string
-	inHeartbeat := false
 	for _, l := range lines {
-		if strings.HasPrefix(l, "event: heartbeat") {
-			inHeartbeat = true
-			continue
-		}
-		if inHeartbeat {
-			if l == "" {
-				inHeartbeat = false
-			}
+		if strings.HasPrefix(l, ": ") {
 			continue
 		}
 		if strings.HasPrefix(l, "data: ") {
@@ -494,17 +486,21 @@ func TestSSEMultipleTopics(t *testing.T) {
 	}
 }
 
-// TestSSEHeartbeat asserts that a heartbeat frame is sent even when no events are
-// published, within a 20-second window. This test does NOT call t.Parallel() because
-// it carries a long timeout.
+// TestSSEHeartbeat asserts that a heartbeat comment frame is sent when no events are
+// published. HeartbeatInterval is overridden to 50ms to keep the test fast.
 func TestSSEHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	old := handlers.HeartbeatInterval
+	handlers.HeartbeatInterval = 50 * time.Millisecond
+	t.Cleanup(func() { handlers.HeartbeatInterval = old })
+
 	_, h := newTestBus(t)
 
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
 
-	// Use a context that matches the test's acceptable window.
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/events", nil)
@@ -523,7 +519,7 @@ func TestSSEHeartbeat(t *testing.T) {
 
 	go func() {
 		for scanner.Scan() {
-			if scanner.Text() == "event: heartbeat" {
+			if scanner.Text() == ": heartbeat" {
 				select {
 				case heartbeatSeen <- struct{}{}:
 				default:
@@ -535,8 +531,8 @@ func TestSSEHeartbeat(t *testing.T) {
 
 	select {
 	case <-heartbeatSeen:
-		// A heartbeat arrived within the 20-second window.
+		// Heartbeat comment frame received.
 	case <-ctx.Done():
-		t.Error("no heartbeat received within 20 seconds")
+		t.Error("no heartbeat received within 3 seconds")
 	}
 }

--- a/dashboard/internal/nats/subscriber.go
+++ b/dashboard/internal/nats/subscriber.go
@@ -7,6 +7,7 @@ package nats
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -105,8 +106,7 @@ func (s *Subscriber) Start(ctx context.Context) error {
 			natsgo.ConsumerFilterSubjects(sc.Subjects...),
 		)
 		if err != nil {
-			// Best-effort: log and continue to other streams.
-			_ = err
+			slog.Error("atlas: JetStream subscribe failed", "stream", sc.Stream, "err", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Addresses the 4 `changes_requested` dimensions from the M2 review wave (TEAM_ID: `eae4abac-4eca-4c73-bafe-3bead28522bb`):

- **code/ops**: `nats/subscriber.go` — log `js.Subscribe` errors via `slog.Error` instead of `_ = err`; `MaxReconnects(0)` retained (locked constraint: fail-fast)
- **ux**: `handlers/sse.go` — heartbeat changed from `event: heartbeat\ndata: {}\n\n` to SSE comment frame `": heartbeat\n\n"` so htmx-ext-sse discards it without triggering a swap lookup
- **ux**: `handlers/sse_test.go` — `TestSSEHeartbeat` now overrides `HeartbeatInterval=50ms` (was 15s, slowing CI), matches new comment-frame wire format; replay test heartbeat filter simplified
- **docs**: `events/bus.go` — removed multi-paragraph "what it does" comment from `Publish`
- **docs**: `dashboard/README.md` — added SSE Endpoint section documenting `/events`, `?topics=`, `?replay=`, all 6 topic→stream mappings, event wire format, and keepalive frame

## Test plan

- [ ] `go test -race ./internal/...` passes (CI: atlas/dashboard job)
- [ ] `TestSSEHeartbeat` runs in < 1s (HeartbeatInterval overridden to 50ms)
- [ ] M2 review wave re-run: all 6 dimensions approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)