### PR TITLE
fix(atlas): data race in SSE heartbeat + README markdown lint

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -61,6 +61,7 @@ GET /events?topics=agent,task&replay=20
 | `log` | `homeric-logs` | `hi.logs.>` |
 
 **Wire format** (per event):
+
 ```
 event: {topic}
 data: {json payload}
@@ -68,6 +69,7 @@ data: {json payload}
 ```
 
 Keepalive comment frames are sent every 15 seconds:
+
 ```
 : heartbeat
 

--- a/dashboard/internal/handlers/sse.go
+++ b/dashboard/internal/handlers/sse.go
@@ -5,14 +5,29 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/HomericIntelligence/atlas/internal/events"
 )
 
-// HeartbeatInterval is the interval between SSE heartbeat frames. It defaults
-// to 15 seconds but can be overridden in tests.
-var HeartbeatInterval = 15 * time.Second
+// heartbeatNanos stores the heartbeat interval in nanoseconds.
+// Access via HeartbeatInterval / SetHeartbeatInterval for race safety.
+var heartbeatNanos atomic.Int64
+
+func init() {
+	heartbeatNanos.Store(int64(15 * time.Second))
+}
+
+// HeartbeatInterval returns the current heartbeat interval.
+func HeartbeatInterval() time.Duration {
+	return time.Duration(heartbeatNanos.Load())
+}
+
+// SetHeartbeatInterval sets the heartbeat interval. Safe for concurrent use; intended for tests.
+func SetHeartbeatInterval(d time.Duration) {
+	heartbeatNanos.Store(int64(d))
+}
 
 // SSE is the Server-Sent Events handler. It streams events from the bus to
 // connected HTTP clients using the text/event-stream protocol.
@@ -68,7 +83,7 @@ func (h *SSE) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ch := h.bus.Subscribe(1000)
 	defer h.bus.Unsubscribe(ch)
 
-	ticker := time.NewTicker(HeartbeatInterval)
+	ticker := time.NewTicker(HeartbeatInterval())
 	defer ticker.Stop()
 
 	for {

--- a/dashboard/internal/handlers/sse_test.go
+++ b/dashboard/internal/handlers/sse_test.go
@@ -491,9 +491,9 @@ func TestSSEMultipleTopics(t *testing.T) {
 func TestSSEHeartbeat(t *testing.T) {
 	t.Parallel()
 
-	old := handlers.HeartbeatInterval
-	handlers.HeartbeatInterval = 50 * time.Millisecond
-	t.Cleanup(func() { handlers.HeartbeatInterval = old })
+	old := handlers.HeartbeatInterval()
+	handlers.SetHeartbeatInterval(50 * time.Millisecond)
+	t.Cleanup(func() { handlers.SetHeartbeatInterval(old) })
 
 	_, h := newTestBus(t)
 


### PR DESCRIPTION
## Summary

- **Data race** (`-race`): `HeartbeatInterval` was a plain `var time.Duration` read by `ServeHTTP` goroutines while `TestSSEHeartbeat`'s `t.Cleanup` wrote the restore value concurrently across parallel tests. Fixed by replacing with `atomic.Int64` backing + `HeartbeatInterval()` / `SetHeartbeatInterval()` accessors — race-safe with no mutex overhead.
- **markdownlint MD031**: Two fenced code blocks in `dashboard/README.md` (the SSE endpoint section added in #164) were missing blank lines before opening fences.

## Test plan

- [ ] `go test -race ./internal/handlers/...` passes with no DATA RACE warnings
- [ ] `markdownlint` passes on `dashboard/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)