### PR TITLE
feat(jetstream): add durable JetStream consumer for real-time event metrics

### DIFF
--- a/configs/prometheus.yml
+++ b/configs/prometheus.yml
@@ -12,6 +12,12 @@ scrape_configs:
     static_configs:
       - targets: ['argus-exporter:9100']
 
+  # JetStream consumer: durable pull subscriber for hi.agents.> and hi.tasks.>
+  # Exposes real-time event-rate and task-latency metrics on port 9101
+  - job_name: 'jetstream-consumer'
+    static_configs:
+      - targets: ['jetstream-consumer:9101']
+
   # Prometheus self-monitoring
   - job_name: 'prometheus'
     static_configs:

--- a/dashboards/jetstream-events.json
+++ b/dashboards/jetstream-events.json
@@ -1,0 +1,175 @@
+{
+  "title": "JetStream Events",
+  "uid": "jetstream-events",
+  "version": 1,
+  "schemaVersion": 38,
+  "tags": ["nats", "jetstream", "events"],
+  "timezone": "browser",
+  "refresh": "15s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Agent Event Rate (5m)",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(hi_jetstream_events_total{subject_prefix=\"hi.agents\"}[5m]))",
+          "legendFormat": "agent events/s",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background"
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "ops" }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Task Event Rate (5m)",
+      "type": "stat",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(hi_jetstream_events_total{subject_prefix=\"hi.tasks\"}[5m]))",
+          "legendFormat": "task events/s",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background"
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "ops" }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Mean Task Completion Latency",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "hi_jetstream_task_latency_seconds{status=\"completed\"}",
+          "legendFormat": "completion latency",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "s" }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Consumer Connected",
+      "type": "stat",
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "hi_jetstream_consumer_connected",
+          "legendFormat": "connected",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "thresholds": {
+          "mode": "absolute",
+          "steps": [
+            { "color": "red", "value": null },
+            { "color": "green", "value": 1 }
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "options": { "0": { "text": "Disconnected" }, "1": { "text": "Connected" } }, "type": "value" }
+          ]
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Event Rate by Subject Prefix",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 4, "w": 24, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (subject_prefix) (rate(hi_jetstream_events_total[5m]))",
+          "legendFormat": "{{subject_prefix}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "ops" }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Task Event Rate by Type",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (event_type) (rate(hi_jetstream_events_total{subject_prefix=\"hi.tasks\"}[5m]))",
+          "legendFormat": "{{event_type}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "ops" }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Task Latency by Status",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "hi_jetstream_task_latency_seconds",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s" }
+      }
+    },
+    {
+      "id": 8,
+      "title": "Consumer Last Sequence (Lag Proxy)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 20, "w": 24, "h": 6 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "hi_jetstream_consumer_last_seq",
+          "legendFormat": "{{stream}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short" }
+      }
+    }
+  ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,6 +228,21 @@ services:
     networks:
       - argus
 
+  jetstream-consumer:
+    image: python:3.11-slim
+    container_name: argus-jetstream-consumer
+    restart: unless-stopped
+    ports:
+      - "9101:9101"
+    volumes:
+      - ./jetstream-consumer/consumer.py:/consumer.py:ro
+    command: sh -c "pip install nats-py -q && python /consumer.py"
+    environment:
+      NATS_URL: "nats://172.24.0.1:4222"
+      EXPORTER_PORT: "9101"
+    networks:
+      - argus
+
 volumes:
   prometheus_data:
   loki_data:

--- a/jetstream-consumer/consumer.py
+++ b/jetstream-consumer/consumer.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+jetstream-consumer — Durable JetStream pull subscriber for hi.agents.> and hi.tasks.>.
+Exposes real-time event-rate and task-completion-latency metrics in Prometheus format
+on port 9101.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+import nats
+from nats.errors import TimeoutError as NatsTimeoutError
+from nats.js.errors import NotFoundError
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("jetstream-consumer")
+logging.getLogger("nats").setLevel(logging.CRITICAL)
+
+NATS_URL       = os.environ.get("NATS_URL",       "nats://172.24.0.1:4222")
+EXPORTER_PORT  = int(os.environ.get("EXPORTER_PORT", "9101"))
+FETCH_BATCH    = int(os.environ.get("FETCH_BATCH",   "100"))
+FETCH_TIMEOUT  = float(os.environ.get("FETCH_TIMEOUT", "1.0"))
+RETRY_INTERVAL = int(os.environ.get("RETRY_INTERVAL", "30"))
+DURABLE_NAME   = "argus-jetstream-consumer"
+
+# ── Shared metrics state (guarded by _lock) ────────────────────────────────
+_lock = threading.Lock()
+
+# {(subject_prefix, event_type): count}
+_event_counts: dict[tuple[str, str], int] = {}
+
+# {stream_name: last_sequence}
+_last_seq: dict[str, int] = {}
+
+# {status: (sum_latency_seconds, count)} for running mean
+_latency_accum: dict[str, tuple[float, int]] = {}
+
+_scrape_ts: float = 0.0
+_connected: int = 0  # 1 = connected, 0 = disconnected
+
+
+def _subject_prefix(subject: str) -> str:
+    """Extract the two-part prefix from a dotted subject, e.g. 'hi.agents' from 'hi.agents.created'."""
+    parts = subject.split(".")
+    return ".".join(parts[:2]) if len(parts) >= 2 else subject
+
+
+def _event_type(subject: str) -> str:
+    """Extract the event type token (3rd segment) from a subject."""
+    parts = subject.split(".")
+    return parts[2] if len(parts) >= 3 else "unknown"
+
+
+def _update_event(subject: str, seq: int, stream: str) -> None:
+    prefix = _subject_prefix(subject)
+    etype = _event_type(subject)
+    with _lock:
+        key = (prefix, etype)
+        _event_counts[key] = _event_counts.get(key, 0) + 1
+        if seq > _last_seq.get(stream, 0):
+            _last_seq[stream] = seq
+
+
+def _update_task_latency(payload: bytes, subject: str) -> None:
+    """Parse task payload for created_at/completed_at and accumulate latency by status."""
+    try:
+        data: dict[str, Any] = json.loads(payload)
+    except (json.JSONDecodeError, ValueError):
+        return
+
+    status = data.get("status", _event_type(subject))
+    completed_at = data.get("completed_at")
+    created_at = data.get("created_at")
+    if completed_at is not None and created_at is not None:
+        try:
+            latency = float(completed_at) - float(created_at)
+        except (TypeError, ValueError):
+            return
+        with _lock:
+            prev_sum, prev_count = _latency_accum.get(status, (0.0, 0))
+            _latency_accum[status] = (prev_sum + latency, prev_count + 1)
+
+
+def _render_metrics() -> str:
+    lines: list[str] = []
+
+    def gauge(name: str, value: float | int, labels: dict[str, str] | None = None) -> None:
+        if labels:
+            lstr = ",".join(f'{k}="{v}"' for k, v in labels.items())
+            lines.append(f"# TYPE {name} gauge")
+            lines.append(f"{name}{{{lstr}}} {value}")
+        else:
+            lines.append(f"# TYPE {name} gauge")
+            lines.append(f"{name} {value}")
+
+    with _lock:
+        for (prefix, etype), count in _event_counts.items():
+            gauge(
+                "hi_jetstream_events_total",
+                count,
+                {"subject_prefix": prefix, "event_type": etype},
+            )
+        for stream, seq in _last_seq.items():
+            gauge("hi_jetstream_consumer_last_seq", seq, {"stream": stream})
+        for status, (total_lat, count) in _latency_accum.items():
+            mean = total_lat / count if count > 0 else 0.0
+            gauge("hi_jetstream_task_latency_seconds", mean, {"status": status})
+        gauge("hi_jetstream_consumer_scrape_timestamp", _scrape_ts)
+        gauge("hi_jetstream_consumer_connected", _connected)
+
+    return "\n".join(lines) + "\n"
+
+
+# ── HTTP server ────────────────────────────────────────────────────────────
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        if self.path == "/metrics":
+            body = _render_metrics().encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/health":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        pass
+
+
+def _run_http_server(port: int) -> None:
+    HTTPServer(("0.0.0.0", port), Handler).serve_forever()
+
+
+# ── JetStream subscription loop ────────────────────────────────────────────
+
+async def _fetch_loop(
+    sub: Any,
+    stream: str,
+    stop_event: asyncio.Event,
+) -> None:
+    """Pull messages in batches until stop_event is set."""
+    while not stop_event.is_set():
+        try:
+            msgs = await asyncio.wait_for(
+                sub.fetch(FETCH_BATCH),
+                timeout=FETCH_TIMEOUT,
+            )
+        except NatsTimeoutError:
+            msgs = []
+        except asyncio.TimeoutError:
+            msgs = []
+
+        for msg in msgs:
+            meta = msg.metadata
+            _update_event(msg.subject, meta.sequence.stream if meta else 0, stream)
+            if msg.subject.startswith("hi.tasks."):
+                _update_task_latency(msg.data, msg.subject)
+            await msg.ack()
+
+        with _lock:
+            global _scrape_ts
+            _scrape_ts = time.time()
+
+
+async def subscribe_loop(stop_event: asyncio.Event) -> None:
+    """Outer retry loop: connect → subscribe → pull until stop or disconnect."""
+    global _connected, _scrape_ts
+    while not stop_event.is_set():
+        nc = None
+        try:
+            log.info("Connecting to NATS at %s", NATS_URL)
+            nc = await asyncio.wait_for(
+                nats.connect(
+                    NATS_URL,
+                    allow_reconnect=False,
+                    connect_timeout=3,
+                ),
+                timeout=5,
+            )
+            js = nc.jetstream()
+
+            sub_agents = await js.pull_subscribe(
+                "hi.agents.>",
+                durable=DURABLE_NAME,
+                stream="hi_agents",
+            )
+            sub_tasks = await js.pull_subscribe(
+                "hi.tasks.>",
+                durable=DURABLE_NAME,
+                stream="hi_tasks",
+            )
+
+            with _lock:
+                _connected = 1
+            log.info("Connected. Consuming hi.agents.> and hi.tasks.>")
+
+            fetch_agents = asyncio.ensure_future(
+                _fetch_loop(sub_agents, "hi_agents", stop_event)
+            )
+            fetch_tasks = asyncio.ensure_future(
+                _fetch_loop(sub_tasks, "hi_tasks", stop_event)
+            )
+
+            await asyncio.gather(fetch_agents, fetch_tasks)
+
+        except asyncio.CancelledError:
+            break
+        except Exception as exc:
+            log.warning("NATS connection/subscription error: %s", exc)
+        finally:
+            with _lock:
+                _connected = 0
+            if nc is not None:
+                try:
+                    await nc.close()
+                except Exception:
+                    pass
+
+        if stop_event.is_set():
+            break
+
+        log.info("Retrying in %ds...", RETRY_INTERVAL)
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=RETRY_INTERVAL)
+        except asyncio.TimeoutError:
+            pass
+
+
+# ── Entry point ────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    log.info("jetstream-consumer starting on port %d", EXPORTER_PORT)
+
+    http_thread = threading.Thread(
+        target=_run_http_server, args=(EXPORTER_PORT,), daemon=True
+    )
+    http_thread.start()
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    stop_event: asyncio.Event = asyncio.Event()
+
+    try:
+        loop.run_until_complete(subscribe_loop(stop_event))
+    except KeyboardInterrupt:
+        stop_event.set()
+    finally:
+        loop.close()
+        log.info("jetstream-consumer stopped")

--- a/justfile
+++ b/justfile
@@ -90,6 +90,11 @@ restore VOLUME FILE:
 
 # === Grafana ===
 
+# Check jetstream-consumer metrics endpoint
+test-jetstream:
+    @echo "Checking jetstream-consumer metrics endpoint..."
+    curl -s http://localhost:9101/metrics | grep hi_jetstream
+
 # Import all JSON dashboards from dashboards/ into Grafana via API
 import-dashboards:
     @test -n "${GF_ADMIN_PASSWORD:-}" || { echo "ERROR: GF_ADMIN_PASSWORD is not set. Source .env first."; exit 1; }

--- a/rules/agent-alerts.yml
+++ b/rules/agent-alerts.yml
@@ -86,3 +86,21 @@ groups:
         annotations:
           summary: "NATS slow consumers detected"
           description: "NATS broker detected {{ $value }} slow consumers for 5 minutes. Consumer lag may be increasing."
+
+      - alert: JetstreamConsumerStale
+        expr: time() - hi_jetstream_consumer_scrape_timestamp > 300
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "JetStream consumer scrape is stale"
+          description: "No scrape from jetstream-consumer in more than 5 minutes."
+
+      - alert: JetstreamConsumerNotConnected
+        expr: absent(hi_jetstream_consumer_scrape_timestamp)
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "JetStream consumer is not running"
+          description: "hi_jetstream_consumer_scrape_timestamp metric is absent."

--- a/tests/test_jetstream_consumer.py
+++ b/tests/test_jetstream_consumer.py
@@ -1,0 +1,302 @@
+"""
+Unit tests for jetstream-consumer/consumer.py.
+Tests pure helper functions and metric rendering without a live NATS connection.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import threading
+import time
+import types
+import urllib.request
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Stub out the `nats` package so consumer.py can be imported without
+# installing nats-py in the test environment.
+# ---------------------------------------------------------------------------
+
+def _make_nats_stub() -> types.ModuleType:
+    nats_mod = types.ModuleType("nats")
+    nats_mod.connect = MagicMock()
+
+    errors_mod = types.ModuleType("nats.errors")
+
+    class TimeoutError(Exception):
+        pass
+
+    errors_mod.TimeoutError = TimeoutError
+    nats_mod.errors = errors_mod
+    sys.modules["nats.errors"] = errors_mod
+
+    js_errors_mod = types.ModuleType("nats.js.errors")
+
+    class NotFoundError(Exception):
+        pass
+
+    js_errors_mod.NotFoundError = NotFoundError
+    nats_mod.js = types.ModuleType("nats.js")
+    nats_mod.js.errors = js_errors_mod
+    sys.modules["nats.js"] = nats_mod.js
+    sys.modules["nats.js.errors"] = js_errors_mod
+
+    return nats_mod
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _stub_nats():
+    """Install the nats stub before importing the consumer module."""
+    nats_stub = _make_nats_stub()
+    sys.modules["nats"] = nats_stub
+    yield
+    # Leave stub in place — other tests in the same session may need it.
+
+
+@pytest.fixture(autouse=True, scope="module")
+def consumer():
+    """Import the consumer module once after the nats stub is in place."""
+    spec = importlib.util.spec_from_file_location(
+        "consumer",
+        "/home/mvillmow/Projects/ProjectArgus/.worktrees/issue-4/jetstream-consumer/consumer.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    sys.modules["consumer"] = mod
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Helper: reset shared state between tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def reset_state(consumer):
+    with consumer._lock:
+        consumer._event_counts.clear()
+        consumer._last_seq.clear()
+        consumer._latency_accum.clear()
+        consumer._scrape_ts = 0.0
+        consumer._connected = 0
+    yield
+
+
+# ---------------------------------------------------------------------------
+# _subject_prefix
+# ---------------------------------------------------------------------------
+
+class TestSubjectPrefix:
+    def test_two_part(self, consumer):
+        assert consumer._subject_prefix("hi.agents") == "hi.agents"
+
+    def test_three_part(self, consumer):
+        assert consumer._subject_prefix("hi.agents.created") == "hi.agents"
+
+    def test_deep_subject(self, consumer):
+        assert consumer._subject_prefix("hi.tasks.foo.bar") == "hi.tasks"
+
+    def test_single_segment(self, consumer):
+        assert consumer._subject_prefix("hi") == "hi"
+
+    def test_empty(self, consumer):
+        assert consumer._subject_prefix("") == ""
+
+
+# ---------------------------------------------------------------------------
+# _event_type
+# ---------------------------------------------------------------------------
+
+class TestEventType:
+    @pytest.mark.parametrize("subject,expected", [
+        ("hi.agents.created", "created"),
+        ("hi.tasks.completed", "completed"),
+        ("hi.tasks.failed", "failed"),
+    ])
+    def test_known_types(self, consumer, subject, expected):
+        assert consumer._event_type(subject) == expected
+
+    def test_short_subject_returns_unknown(self, consumer):
+        assert consumer._event_type("hi.agents") == "unknown"
+
+    def test_deep_subject_uses_third_token(self, consumer):
+        assert consumer._event_type("hi.tasks.updated.extra") == "updated"
+
+
+# ---------------------------------------------------------------------------
+# _update_event
+# ---------------------------------------------------------------------------
+
+class TestUpdateEvent:
+    def test_increments_count(self, consumer):
+        consumer._update_event("hi.agents.created", seq=1, stream="hi_agents")
+        with consumer._lock:
+            assert consumer._event_counts[("hi.agents", "created")] == 1
+
+    def test_accumulates_multiple(self, consumer):
+        for _ in range(5):
+            consumer._update_event("hi.tasks.completed", seq=1, stream="hi_tasks")
+        with consumer._lock:
+            assert consumer._event_counts[("hi.tasks", "completed")] == 5
+
+    def test_tracks_last_seq(self, consumer):
+        consumer._update_event("hi.agents.online", seq=42, stream="hi_agents")
+        with consumer._lock:
+            assert consumer._last_seq["hi_agents"] == 42
+
+    def test_last_seq_only_advances(self, consumer):
+        consumer._update_event("hi.agents.online", seq=10, stream="hi_agents")
+        consumer._update_event("hi.agents.online", seq=5, stream="hi_agents")
+        with consumer._lock:
+            assert consumer._last_seq["hi_agents"] == 10
+
+    def test_different_streams_independent(self, consumer):
+        consumer._update_event("hi.agents.created", seq=3, stream="hi_agents")
+        consumer._update_event("hi.tasks.created", seq=7, stream="hi_tasks")
+        with consumer._lock:
+            assert consumer._last_seq["hi_agents"] == 3
+            assert consumer._last_seq["hi_tasks"] == 7
+
+
+# ---------------------------------------------------------------------------
+# _update_task_latency
+# ---------------------------------------------------------------------------
+
+class TestUpdateTaskLatency:
+    def _payload(self, **kwargs) -> bytes:
+        return json.dumps(kwargs).encode()
+
+    def test_computes_latency(self, consumer):
+        payload = self._payload(status="completed", created_at=1000.0, completed_at=1010.0)
+        consumer._update_task_latency(payload, "hi.tasks.completed")
+        with consumer._lock:
+            total, count = consumer._latency_accum["completed"]
+        assert count == 1
+        assert total == pytest.approx(10.0)
+
+    def test_running_mean_accumulates(self, consumer):
+        consumer._update_task_latency(
+            self._payload(status="completed", created_at=0.0, completed_at=10.0),
+            "hi.tasks.completed",
+        )
+        consumer._update_task_latency(
+            self._payload(status="completed", created_at=0.0, completed_at=30.0),
+            "hi.tasks.completed",
+        )
+        with consumer._lock:
+            total, count = consumer._latency_accum["completed"]
+        assert count == 2
+        assert total == pytest.approx(40.0)
+
+    def test_ignores_invalid_json(self, consumer):
+        consumer._update_task_latency(b"not json", "hi.tasks.completed")
+        with consumer._lock:
+            assert "completed" not in consumer._latency_accum
+
+    def test_ignores_missing_timestamps(self, consumer):
+        consumer._update_task_latency(
+            self._payload(status="completed"),
+            "hi.tasks.completed",
+        )
+        with consumer._lock:
+            assert "completed" not in consumer._latency_accum
+
+    def test_status_from_subject_when_missing_in_payload(self, consumer):
+        payload = self._payload(created_at=0.0, completed_at=5.0)
+        consumer._update_task_latency(payload, "hi.tasks.done")
+        with consumer._lock:
+            assert "done" in consumer._latency_accum
+
+
+# ---------------------------------------------------------------------------
+# _render_metrics
+# ---------------------------------------------------------------------------
+
+class TestRenderMetrics:
+    def test_includes_scrape_timestamp(self, consumer):
+        with consumer._lock:
+            consumer._scrape_ts = 9999.0
+        output = consumer._render_metrics()
+        assert "hi_jetstream_consumer_scrape_timestamp 9999.0" in output
+
+    def test_includes_connected_gauge(self, consumer):
+        with consumer._lock:
+            consumer._connected = 1
+        output = consumer._render_metrics()
+        assert "hi_jetstream_consumer_connected 1" in output
+
+    def test_includes_event_count(self, consumer):
+        with consumer._lock:
+            consumer._event_counts[("hi.agents", "created")] = 3
+        output = consumer._render_metrics()
+        assert 'hi_jetstream_events_total{subject_prefix="hi.agents",event_type="created"} 3' in output
+
+    def test_includes_last_seq(self, consumer):
+        with consumer._lock:
+            consumer._last_seq["hi_agents"] = 100
+        output = consumer._render_metrics()
+        assert 'hi_jetstream_consumer_last_seq{stream="hi_agents"} 100' in output
+
+    def test_includes_latency(self, consumer):
+        with consumer._lock:
+            consumer._latency_accum["completed"] = (20.0, 2)
+        output = consumer._render_metrics()
+        assert 'hi_jetstream_task_latency_seconds{status="completed"} 10.0' in output
+
+    def test_empty_state_still_has_type_lines(self, consumer):
+        output = consumer._render_metrics()
+        assert "hi_jetstream_consumer_scrape_timestamp" in output
+        assert "hi_jetstream_consumer_connected" in output
+
+    def test_zero_count_latency_renders_zero(self, consumer):
+        with consumer._lock:
+            consumer._latency_accum["failed"] = (0.0, 0)
+        output = consumer._render_metrics()
+        assert 'hi_jetstream_task_latency_seconds{status="failed"} 0.0' in output
+
+
+# ---------------------------------------------------------------------------
+# HTTP handler
+# ---------------------------------------------------------------------------
+
+class TestHandler:
+    """Smoke-test the HTTP metrics and health endpoints via a live server."""
+
+    @pytest.fixture(scope="class")
+    def server_port(self, consumer):
+        import socketserver
+
+        class ThreadedServer(socketserver.ThreadingMixIn, urllib.request.AbstractHTTPHandler.__class__):
+            pass
+
+        from http.server import HTTPServer
+        server = HTTPServer(("127.0.0.1", 0), consumer.Handler)
+        port = server.server_address[1]
+        t = threading.Thread(target=server.serve_forever, daemon=True)
+        t.start()
+        yield port
+        server.shutdown()
+
+    def test_metrics_returns_200(self, consumer, server_port):
+        resp = urllib.request.urlopen(f"http://127.0.0.1:{server_port}/metrics", timeout=3)
+        assert resp.status == 200
+
+    def test_metrics_content_type(self, consumer, server_port):
+        resp = urllib.request.urlopen(f"http://127.0.0.1:{server_port}/metrics", timeout=3)
+        ct = resp.headers.get("Content-Type", "")
+        assert "text/plain" in ct
+
+    def test_health_returns_ok(self, consumer, server_port):
+        resp = urllib.request.urlopen(f"http://127.0.0.1:{server_port}/health", timeout=3)
+        assert resp.status == 200
+        assert resp.read() == b"ok"
+
+    def test_unknown_path_returns_404(self, consumer, server_port):
+        import urllib.error
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(f"http://127.0.0.1:{server_port}/unknown", timeout=3)
+        assert exc_info.value.code == 404


### PR DESCRIPTION
## Summary

- Introduces `jetstream-consumer/consumer.py` — a new asyncio sidecar that opens durable pull subscriptions on `hi.agents.>` and `hi.tasks.>` via `nats-py`, accumulates event counts, task latency (running mean per status), and last-consumed sequence number, then exposes all of it as Prometheus gauges on port 9101
- Adds `dashboards/jetstream-events.json` (uid: `jetstream-events`) with 8 panels: agent/task event rates, task event breakdown by type, mean completion latency, consumer connected status, and sequence lag
- Wires the sidecar into `docker-compose.yml`, `configs/prometheus.yml` (new `jetstream-consumer` scrape job), and `rules/agent-alerts.yml` (`JetstreamConsumerStale` + `JetstreamConsumerNotConnected` alerts)
- Adds `just test-jetstream` recipe to spot-check the `/metrics` endpoint
- 31 unit tests in `tests/test_jetstream_consumer.py`, all passing — includes coverage of subject parsing, event counting, latency accumulation, metric rendering, and HTTP handler correctness

## Test plan

- [ ] `python3 -m pytest tests/ -v` — 31/31 passing locally
- [ ] `just start` then `just test-jetstream` — confirm `hi_jetstream_*` metrics appear on port 9101
- [ ] `just test-scrape` — confirm `jetstream-consumer` job shows `up=1`
- [ ] `just reload-prometheus` — confirm no config errors
- [ ] `just import-dashboards` — confirm `jetstream-events` dashboard imports into Grafana

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)