### PR TITLE
docs: document argus-health and loki-explorer dashboards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,11 @@ All services run on the `argus` Docker network and are managed via `docker-compo
   storage used, distinct subject counts.
 - **task-throughput.json** (`uid: task-throughput`): Tasks by status
   (`hi_tasks_by_status`), completed/failed counts per hour.
+- **argus-health.json** (`uid: argus-health`): Prometheus scrape-target counts (`up`),
+  Homeric Exporter health (`up{job="homeric-exporter"}`), total targets. Stat panels
+  backed by Prometheus.
+- **loki-explorer.json** (`uid: loki-explorer`): Syslog stream (`{job="syslog"}`),
+  NATS log stream (`{job="nats"}`). Log panels backed by Loki.
 
 ## Repository Structure
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Then access Grafana at <http://localhost:3000> (credentials: admin / the passwor
 - **HomericIntelligence - Agent Health**: Agent count, active/hibernated agents, uptime
 - **NATS Event Bus**: Message rate, JetStream storage, subject counts
 - **Task Throughput**: Tasks created/completed/failed per hour, dispatch latency
+- **Argus Stack Health**: Prometheus scrape-target count (`up`), Homeric Exporter health, total targets. Stat panels
+  backed by Prometheus.
+- **Log Explorer**: Syslog and NATS log streams. Log panels backed by Loki.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- Adds `argus-health` and `loki-explorer` entries to the `## Dashboards` list in `README.md`
- Adds matching entries to the Dashboard Descriptions block in `CLAUDE.md`
- All five dashboards in `dashboards/` are now discoverable without browsing the directory

## Test plan

- [x] `grep` confirms all five dashboard identifiers present in both files
- [x] No lines exceed 120 characters
- [x] Descriptions derived from JSON source (`uid`, panel types, datasource queries) — no invented language

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)