### PR TITLE
docs: populate CHANGELOG [Unreleased] section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Atlas service (M1–M3): Go module with Chi server, hello-world page, SSE endpoint,
+  NATS/JetStream subscribers, Tailscale sources, service probe matrix, and hosts page
+- `.dockerignore` to minimise Docker build context
+
+### Changed
+
+- CI lint job consolidates typecheck steps; unified required-checks workflow added
+- Python base image bumped to `3.14.0-slim`
+
+### Fixed
+
+- Atlas SSE heartbeat data race in tests
+- Atlas M2 review-wave findings (healthz plaintext, hermes port, README line wrap)
+- CI: valid job IDs in `_required.yml` (no slashes allowed in keys)
+- Dependabot: removed invalid Docker `package-ecosystem` entry
+
 ## [0.1.0] - 2026-04-23
 
 ### Added


### PR DESCRIPTION
## Summary

- Adds `### Added`, `### Changed`, and `### Fixed` subsections under `## [Unreleased]` in `CHANGELOG.md`
- Entries derived from the 12 non-merge commits since the v0.1.0 baseline (`c7af901..HEAD`), covering Atlas M1–M3 feature work, CI consolidation, Python base image bump, and bug fixes
- No entries fabricated — every bullet maps directly to one or more commits in the log

## Test plan

- [x] `grep -n "### Added\|### Fixed\|### Changed" CHANGELOG.md` confirms all three subsection headers present under `[Unreleased]`
- [x] Visual review: `[Unreleased]` section is non-empty and appears between the header and the `## [0.1.0]` block
- [x] `[0.1.0]` block and reference links at the bottom are unchanged
- [x] No trailing whitespace or broken Markdown

Closes #105
Part of #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)