### PR TITLE
fix(promtail): replace hardcoded host:hermes label with env var substitution

### DIFF
--- a/configs/promtail.yml
+++ b/configs/promtail.yml
@@ -16,7 +16,7 @@ scrape_configs:
           - localhost
         labels:
           job: syslog
-          host: ${HOSTNAME:-hermes}
+          host: ${PROMTAIL_HOST_LABEL:-${HOSTNAME}}
           __path__: /var/log/syslog
 
   # Tail NATS server log — NATS log directory mounted at /logs/nats

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,8 @@ services:
       - ./configs/promtail.yml:/etc/promtail/config.yml:ro
       - /var/log:/var/log:ro
       - ${NATS_LOG_DIR:-/home/mvillmow/.local/share/nats}:/logs/nats:ro
+    environment:
+      HOSTNAME: ${HOSTNAME}
     command: -config.file=/etc/promtail/config.yml -config.expand-env=true
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:9080/ready"]

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -125,6 +125,16 @@ class TestPromtailConfig(unittest.TestCase):
             f"got: {host_val!r}"
         )
 
+    def test_syslog_host_label_is_not_hardcoded(self):
+        """host label must use env var substitution, not a hardcoded hostname."""
+        raw = (CONFIGS_DIR / "promtail.yml").read_text()
+        assert "hermes" not in raw, "host label must not hardcode 'hermes'"
+
+    def test_syslog_host_label_uses_env_var(self):
+        """host label must reference HOSTNAME via env var expansion syntax."""
+        raw = (CONFIGS_DIR / "promtail.yml").read_text()
+        assert "HOSTNAME" in raw, "host label must reference ${HOSTNAME} for portability"
+
 
 class TestGrafanaDatasourcesConfig(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

- Replaces `host: hermes` in `configs/promtail.yml` syslog scrape job with `host: ${PROMTAIL_HOST_LABEL:-${HOSTNAME}}`, resolving the portability issue
- Adds `HOSTNAME: ${HOSTNAME}` to the `promtail` service `environment:` block in `docker-compose.yml` so the host shell variable is available inside the container (containers don't inherit `$HOSTNAME` automatically)
- Adds two regression tests to `tests/test_configs.py` asserting that `hermes` no longer appears and that `HOSTNAME` env var syntax is present

Resolution order: explicit `PROMTAIL_HOST_LABEL` override → `$HOSTNAME` from the Docker host → empty string (visible/diagnosable) — no static fallback that would silently bake the problem in at a different layer.

## Test plan

- [ ] `pixi run python -m pytest tests/ -v` — all 104 tests pass
- [ ] `grep hermes configs/promtail.yml` — returns nothing
- [ ] `grep HOSTNAME configs/promtail.yml docker-compose.yml` — shows substitution in both files
- [ ] Runtime: `docker compose up -d --force-recreate promtail` and verify `host:` label in rendered config shows actual hostname

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)