### PR TITLE
fix(exporter): emit HTTP access logs at DEBUG instead of silencing them

### DIFF
--- a/exporter/exporter.py
+++ b/exporter/exporter.py
@@ -171,8 +171,8 @@ class Handler(BaseHTTPRequestHandler):
             self.send_response(404)
             self.end_headers()
 
-    def log_message(self, fmt, *args):
-        pass
+    def log_message(self, fmt: str, *args: object) -> None:
+        log.debug(fmt, *args)
 
 
 if __name__ == "__main__":

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -311,6 +311,28 @@ class TestHandler(unittest.TestCase):
         response = self._get_response("/metrics", mock_collect_output=collect_output)
         self.assertIn("hi_agents_total", response)
 
+    def test_log_message_emits_debug_record(self):
+        """log_message must forward to log.debug, not swallow the record."""
+        handler, _ = _make_handler("/metrics")
+        fmt = '%s - - [%s] "%s" %s %s'
+        args = ("127.0.0.1", "04/May/2026 12:00:00", "GET /metrics HTTP/1.1", "200", "-")
+        with patch.object(exporter_mod.log, "debug") as mock_debug:
+            handler.log_message(fmt, *args)
+        mock_debug.assert_called_once_with(fmt, *args)
+
+    def test_log_message_silent_at_info_level(self):
+        """log_message must not raise and must produce no INFO-level output."""
+        import logging
+        handler, _ = _make_handler("/metrics")
+        with patch.object(exporter_mod.log, "debug"):
+            # At INFO level the debug call should not propagate to any handler
+            original_level = exporter_mod.log.level
+            exporter_mod.log.setLevel(logging.INFO)
+            try:
+                handler.log_message("GET /metrics HTTP/1.1 200 -")
+            finally:
+                exporter_mod.log.setLevel(original_level)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Replaces the no-op `log_message` override in `exporter/exporter.py` (lines 174–175) with `log.debug(fmt, *args)`, forwarding HTTP access log entries to the existing `homeric-exporter` module logger at DEBUG level
- HTTP access logs are now visible when `LOG_LEVEL=DEBUG` is set; they remain silent at the default INFO level, so production deployments are unaffected
- Added type hints to the `log_message` signature (`fmt: str, *args: object`) to match the project convention

## Test plan

- [x] `test_log_message_emits_debug_record` — asserts `log.debug` is called with the exact `fmt` and `*args` passed to `log_message`
- [x] `test_log_message_silent_at_info_level` — asserts no exception is raised and the method completes cleanly when the logger is at INFO level
- [x] All 24 existing tests continue to pass (`pixi run python -m pytest tests/test_exporter.py -v`)

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)