### PR TITLE
fix(exporter): tighten _fetch exception clause (closes #112)

### DIFF
--- a/exporter/exporter.py
+++ b/exporter/exporter.py
@@ -11,6 +11,7 @@ import os
 import signal
 import threading
 import time
+import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -41,7 +42,7 @@ def _fetch(url: str) -> dict | None:
     try:
         r = urllib.request.urlopen(url, timeout=SCRAPE_TIMEOUT)
         return json.loads(r.read())
-    except Exception as e:
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as e:
         log.warning("fetch %s failed: %s", url, e)
         return None
 
@@ -51,7 +52,7 @@ def _health_check(url: str) -> int:
     try:
         r = urllib.request.urlopen(url, timeout=SCRAPE_TIMEOUT)
         return 1 if r.status == 200 else 0
-    except Exception:
+    except Exception:  # broad catch: probe must never propagate
         return 0
 
 

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -15,6 +15,7 @@ import unittest
 import urllib.error
 import urllib.request
 from http.server import ThreadingHTTPServer
+
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -75,6 +76,32 @@ class TestFetch(unittest.TestCase):
             result = exporter_mod._fetch("http://fake/data")
         self.assertIsInstance(result, dict)
         self.assertEqual(result["key"], "value")
+
+    def test_returns_none_on_oserror(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("connection refused")):
+            result = exporter_mod._fetch("http://fake/data")
+        self.assertIsNone(result)
+
+    def test_returns_none_on_urlerror(self):
+        with patch("urllib.request.urlopen",
+                   side_effect=urllib.error.URLError("name or service not known")):
+            result = exporter_mod._fetch("http://fake/data")
+        self.assertIsNone(result)
+
+    def test_returns_none_on_json_decode_error(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"not-json"
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = exporter_mod._fetch("http://fake/data")
+        self.assertIsNone(result)
+
+    def test_propagates_unexpected_exception(self):
+        """Exceptions outside the specific tuple must not be swallowed."""
+        with patch("urllib.request.urlopen", side_effect=MemoryError("oom")):
+            with self.assertRaises(MemoryError):
+                exporter_mod._fetch("http://fake/data")
 
     def test_returns_none_on_exception(self):
         with patch("urllib.request.urlopen", side_effect=_urlopen_raises):


### PR DESCRIPTION
## Summary

- Replace `except Exception` in `_fetch` (`exporter/exporter.py:44`) with `(OSError, urllib.error.URLError, json.JSONDecodeError)` — exactly the exceptions that `urlopen` and `json.loads` can raise.
- Add `import urllib.error` (submodule not auto-imported by `import urllib.request`).
- Add inline justification comment on `_health_check`'s broad catch, which is intentional (fire-and-forget probe).

## Test plan

- [x] `test_returns_none_on_oserror` — `OSError` is caught and `None` returned
- [x] `test_returns_none_on_urlerror` — `urllib.error.URLError` is caught and `None` returned
- [x] `test_returns_none_on_json_decode_error` — malformed response body returns `None`
- [x] `test_propagates_unexpected_exception` — `MemoryError` (outside the tuple) propagates instead of being swallowed
- [x] All 26 existing tests continue to pass

Closes #112
Part of #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)