### PR TITLE
fix(deps): explicitly add pyyaml to pixi.toml dependencies

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -11,6 +11,7 @@ jq = ">=1.6"
 yamllint = ">=1.35"
 ruff = ">=0.4"
 bandit = ">=1.7"
+pyyaml = ">=6.0"
 pytest = ">=8.0"
 python = ">=3.11"
 


### PR DESCRIPTION
## Summary

- `pyyaml` was being pulled as a transitive dependency via `bandit`, which is fragile
- Added `pyyaml = ">=6.0"` explicitly to `[dependencies]` in `pixi.toml`
- This ensures `tests/test_configs.py` (which `import yaml`) has a stable, declared dependency regardless of transitive dependency changes

## Test plan

- [ ] `pixi run python -m pytest tests/ -v` — all 102 tests pass

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)