### PR TITLE
fix(ci): pin pixi to v0.67.2 via setup-pixi action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "$HOME/.pixi/bin" >> $GITHUB_PATH
+        uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          pixi-version: v0.67.2
+          cache: true
 
       - name: Install dependencies
         run: pixi install


### PR DESCRIPTION
## Summary

- Replaces the unpinned `curl -fsSL https://pixi.sh/install.sh | bash` install with `prefix-dev/setup-pixi@v0.9.5` and `pixi-version: v0.67.2`
- Matches the pattern already used in `_required.yml` (`pixi-check` job)
- Adds `cache: true` for faster CI runs

Closes #118

## Test plan

- [ ] CI workflow runs with the pinned pixi version
- [ ] `pixi install` and subsequent steps succeed as before
- [ ] No behavioural change — only the pixi install mechanism changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)