### PR TITLE
fix(ci): rename build job to config-validate

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -251,8 +251,8 @@ jobs:
           path: gitleaks.sarif
           retention-days: 90
 
-  build:
-    name: build
+  config-validate:
+    name: config-validate
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -266,11 +266,11 @@ jobs:
             elif command -v hclfmt &>/dev/null; then
               echo "$HCL_FILES" | xargs -I{} hclfmt --check {}
             else
-              echo "::notice::HCL files found but no nomad/hclfmt available; validating YAML configs as build step"
+              echo "::notice::HCL files found but no nomad/hclfmt available; falling back to YAML validation"
               yamllint -c .yamllint.yaml .
             fi
           else
-            echo "::notice::No build artifacts; config validation is the build step"
+            echo "::notice::No HCL files found; validating YAML configs"
             yamllint -c .yamllint.yaml .
           fi
 


### PR DESCRIPTION
## Summary

- Renames the `build` job in `.github/workflows/_required.yml` to `config-validate`
- Updates the job `name:` field to match
- Clarifies the two `::notice::` fallback messages to remove misleading "build step" / "build artifacts" language

The job only validates HCL/YAML configuration files and never produces a build artifact. The old name violated POLA by implying compilation or packaging.

## Test plan

- [ ] CI passes with the renamed job
- [ ] No other workflows reference the old `build` job name as a `needs:` dependency (confirmed — none found)

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)