### PR TITLE
fix(security): restrict Grafana port binding to loopback only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,7 +123,7 @@ services:
         max-size: "50m"
         max-file: "3"
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     volumes:
       - ./dashboards:/var/lib/grafana/dashboards:ro
       - ./configs/grafana:/etc/grafana/provisioning:ro


### PR DESCRIPTION
## Summary

- Change Grafana `ports:` mapping from `"3000:3000"` (all interfaces / `0.0.0.0`) to `"127.0.0.1:3000:3000"` (loopback only)
- Eliminates public exposure of the Grafana login form without affecting any internal Docker-network communication
- Host-side tooling (`just import-dashboards`, `curl localhost:3000`, etc.) continues to work unchanged

## Test plan

- [ ] `docker compose ps grafana` shows `127.0.0.1:3000->3000/tcp` (not `0.0.0.0:3000`)
- [ ] `curl http://localhost:3000/login` returns HTTP 200 from the host
- [ ] Connecting from a LAN IP to port 3000 receives connection refused / times out
- [ ] `just import-dashboards` and `just test-scrape` succeed after restart
- [ ] Prometheus and Loki datasources remain healthy inside Grafana (container-network URLs unchanged)

Closes #126
Part of #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)