### PR TITLE
fix(security): isolate Loki to internal Docker network

### DIFF
--- a/configs/grafana/datasources.yml
+++ b/configs/grafana/datasources.yml
@@ -16,7 +16,7 @@ datasources:
     type: loki
     uid: loki
     access: proxy
-    url: http://loki:3100
+    url: http://loki-proxy
     isDefault: false
     editable: false
     jsonData:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 networks:
   argus:
     driver: bridge
+  argus-loki:
+    driver: bridge
+    internal: true
 
 services:
   prometheus:
@@ -57,7 +60,7 @@ services:
       retries: 3
       start_period: 10s
     networks:
-      - argus
+      - argus-loki
     deploy:
       resources:
         limits:
@@ -75,6 +78,7 @@ services:
       - ./configs/nginx/htpasswd:/etc/nginx/htpasswd:ro
     networks:
       - argus
+      - argus-loki
     depends_on:
       - loki
     deploy:
@@ -104,7 +108,7 @@ services:
       retries: 3
       start_period: 10s
     networks:
-      - argus
+      - argus-loki
     depends_on:
       - loki
     deploy:
@@ -142,7 +146,7 @@ services:
       - argus
     depends_on:
       - prometheus
-      - loki
+      - loki-proxy
     deploy:
       resources:
         limits:

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -5,6 +5,7 @@ Uses only stdlib: yaml, pathlib, unittest.
 import unittest
 import yaml
 from pathlib import Path
+from typing import Any
 
 REPO_ROOT = Path(__file__).parent.parent
 CONFIGS_DIR = REPO_ROOT / "configs"
@@ -150,6 +151,69 @@ class TestGrafanaDashboardsConfig(unittest.TestCase):
         for provider in self.config["providers"]:
             for field in required_fields:
                 assert field in provider, f"Provider missing field '{field}': {provider}"
+
+
+class TestDockerComposeNetworkIsolation(unittest.TestCase):
+    """Verify that the argus-loki internal network is correctly configured.
+
+    Issue #128: Loki must be isolated to the argus-loki internal network so
+    that arbitrary containers on the argus network cannot reach port 3100.
+    """
+
+    def setUp(self) -> None:
+        self.compose = load_yaml(REPO_ROOT / "docker-compose.yml")
+
+    def _service_networks(self, service_name: str) -> list[str]:
+        nets: Any = self.compose["services"][service_name].get("networks", [])
+        if isinstance(nets, dict):
+            return list(nets.keys())
+        return list(nets)
+
+    def test_argus_loki_network_declared(self) -> None:
+        assert "argus-loki" in self.compose["networks"]
+
+    def test_argus_loki_network_is_internal(self) -> None:
+        assert self.compose["networks"]["argus-loki"].get("internal") is True
+
+    def test_loki_only_on_argus_loki_network(self) -> None:
+        nets = self._service_networks("loki")
+        assert "argus-loki" in nets
+        assert "argus" not in nets, "loki must not be on the argus network (issue #128)"
+
+    def test_loki_proxy_bridges_both_networks(self) -> None:
+        nets = self._service_networks("loki-proxy")
+        assert "argus" in nets
+        assert "argus-loki" in nets
+
+    def test_promtail_only_on_argus_loki_network(self) -> None:
+        nets = self._service_networks("promtail")
+        assert "argus-loki" in nets
+        assert "argus" not in nets, "promtail must not be on the argus network"
+
+    def test_grafana_not_on_argus_loki_network(self) -> None:
+        nets = self._service_networks("grafana")
+        assert "argus" in nets
+        assert "argus-loki" not in nets, "grafana should reach Loki via loki-proxy only"
+
+    def test_debug_shell_not_on_argus_loki_network(self) -> None:
+        nets = self._service_networks("debug-shell")
+        assert "argus-loki" not in nets, "debug-shell must not access the argus-loki network"
+
+    def test_grafana_depends_on_loki_proxy_not_loki(self) -> None:
+        deps: Any = self.compose["services"]["grafana"].get("depends_on", [])
+        if isinstance(deps, dict):
+            dep_names = list(deps.keys())
+        else:
+            dep_names = list(deps)
+        assert "loki-proxy" in dep_names
+        assert "loki" not in dep_names, "grafana should depend on loki-proxy, not loki directly"
+
+    def test_loki_datasource_url_uses_proxy(self) -> None:
+        datasources = load_yaml(CONFIGS_DIR / "grafana" / "datasources.yml")["datasources"]
+        loki_ds = next(ds for ds in datasources if ds["type"] == "loki")
+        assert loki_ds["url"] == "http://loki-proxy", (
+            "Loki datasource must point to loki-proxy, not loki:3100 directly"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds a new `argus-loki` Docker bridge network with `internal: true` — no internet egress, not reachable from `argus`
- Moves `loki` onto `argus-loki` only (drops `argus`), so port 3100 is no longer DNS-reachable from any container on `argus`
- Moves `promtail` onto `argus-loki` only (it only writes to Loki and reads local files — no `argus` dependency)
- Puts `loki-proxy` on both `argus` and `argus-loki` so it can proxy authenticated requests to Loki
- Updates Grafana Loki datasource URL from `http://loki:3100` to `http://loki-proxy` so all queries route through the nginx auth proxy
- Updates `grafana` `depends_on` from `loki` to `loki-proxy`

## Security impact

Before: any container on the `argus` bridge (including `debug-shell`) could push arbitrary logs to or query `http://loki:3100` without credentials.

After: `loki` is invisible to the `argus` network. The only path to Loki is through `loki-proxy`, which requires Basic Auth (nginx htpasswd). `debug-shell` on `argus` gets a DNS failure when it tries `http://loki`.

## Test plan

- [x] `pixi run python -m pytest tests/ -v` — all 111 tests pass, including 9 new `TestDockerComposeNetworkIsolation` tests that assert network assignments and the datasource URL
- [ ] Manual: `just stop && just start` — verify `just status` shows all services healthy
- [ ] Manual: `just logs promtail` — no connection errors to Loki
- [ ] Manual: `docker compose --profile dev up -d debug-shell && docker exec argus-debug-shell wget -qO- http://loki:3100/ready` — expected: DNS failure
- [ ] Manual: `docker exec argus-debug-shell wget -qO- http://loki-proxy/ready` — expected: 401 Unauthorized

Closes #128
Part of #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)