### PR TITLE
fix(security): remove committed htpasswd, generate at runtime (#130)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ NATS_URL=http://172.24.0.1:8222
 
 # NATS log directory on the host (Promtail mounts this read-only)
 NATS_LOG_DIR=/home/mvillmow/.local/share/nats
+
+# Loki basic-auth credentials — used by scripts/gen-htpasswd.sh to generate secrets/htpasswd
+LOKI_AUTH_USER=loki
+LOKI_AUTH_PASSWORD=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ data/
 .vscode/
 .DS_Store
 *.swp
+secrets/
+configs/nginx/htpasswd
+configs/nginx/htpasswd.generated

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,18 @@
+# Gitleaks configuration for ProjectArgus.
+# Extends the default ruleset with project-specific rules.
+
+title = "ProjectArgus Gitleaks Config"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "argus-htpasswd-file"
+description = "htpasswd credential file committed to repository"
+regex = '''^loki:'''
+path = '''(^|/)htpasswd$'''
+tags = ["credentials", "nginx", "basic-auth"]
+
+  [rules.allowlist]
+  paths = ['''htpasswd\.example$''']
+  description = "htpasswd.example is a documentation placeholder with no real credentials"

--- a/configs/nginx/htpasswd
+++ b/configs/nginx/htpasswd
@@ -1,1 +1,0 @@
-loki:$apr1$IvtTVmT2$Vyef8metZTBYPpuH6byNP.

--- a/configs/nginx/htpasswd.example
+++ b/configs/nginx/htpasswd.example
@@ -1,0 +1,10 @@
+# This file is NOT used at runtime. It exists only as a format reference.
+# The real htpasswd file is generated at startup by scripts/gen-htpasswd.sh
+# and written to secrets/htpasswd (gitignored).
+#
+# To regenerate: set LOKI_AUTH_USER and LOKI_AUTH_PASSWORD in .env, then run:
+#   just gen-htpasswd
+#
+# Format: <user>:<apr1-hash>
+# Example (do not commit real credentials):
+loki:$apr1$EXAMPLE0$placeholder000000000000000000000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - "3101:80"
     volumes:
       - ./configs/nginx/loki.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./configs/nginx/htpasswd:/etc/nginx/htpasswd:ro
+      - ./secrets/htpasswd:/etc/nginx/htpasswd:ro
     networks:
       - argus
     depends_on:

--- a/justfile
+++ b/justfile
@@ -14,8 +14,12 @@ default:
 
 # === Services ===
 
+# Generate secrets/htpasswd from LOKI_AUTH_USER and LOKI_AUTH_PASSWORD in .env
+gen-htpasswd:
+    @scripts/gen-htpasswd.sh
+
 # Start all observability services
-start:
+start: gen-htpasswd
     {{compose_cmd}} up -d
 
 # Stop all services
@@ -27,7 +31,7 @@ status:
     {{compose_cmd}} ps
 
 # Restart all services (stop then start)
-restart:
+restart: gen-htpasswd
     {{compose_cmd}} down
     {{compose_cmd}} up -d
 

--- a/scripts/gen-htpasswd.sh
+++ b/scripts/gen-htpasswd.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Generates secrets/htpasswd from LOKI_AUTH_USER and LOKI_AUTH_PASSWORD.
+# Reads from .env if present; both vars must be set.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Source .env if it exists and vars are not already set
+if [[ -f "${REPO_ROOT}/.env" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "${REPO_ROOT}/.env"
+    set +a
+fi
+
+: "${LOKI_AUTH_USER:?LOKI_AUTH_USER must be set in .env or environment}"
+: "${LOKI_AUTH_PASSWORD:?LOKI_AUTH_PASSWORD must be set in .env or environment}"
+
+SECRETS_DIR="${REPO_ROOT}/secrets"
+mkdir -p "${SECRETS_DIR}"
+
+HASH="$(openssl passwd -apr1 "${LOKI_AUTH_PASSWORD}")"
+printf '%s:%s\n' "${LOKI_AUTH_USER}" "${HASH}" > "${SECRETS_DIR}/htpasswd"
+chmod 600 "${SECRETS_DIR}/htpasswd"
+
+echo "Generated ${SECRETS_DIR}/htpasswd for user '${LOKI_AUTH_USER}'"

--- a/tests/test_htpasswd_security.py
+++ b/tests/test_htpasswd_security.py
@@ -1,0 +1,211 @@
+"""
+Tests for issue #130: htpasswd file must not be tracked in git;
+secrets/htpasswd must be generated at runtime from environment variables.
+"""
+import os
+import re
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+GEN_SCRIPT = REPO_ROOT / "scripts" / "gen-htpasswd.sh"
+SECRETS_DIR = REPO_ROOT / "secrets"
+GITIGNORE = REPO_ROOT / ".gitignore"
+ENV_EXAMPLE = REPO_ROOT / ".env.example"
+DOCKER_COMPOSE = REPO_ROOT / "docker-compose.yml"
+JUSTFILE = REPO_ROOT / "justfile"
+COMMITTED_HTPASSWD = REPO_ROOT / "configs" / "nginx" / "htpasswd"
+HTPASSWD_EXAMPLE = REPO_ROOT / "configs" / "nginx" / "htpasswd.example"
+GITLEAKS_TOML = REPO_ROOT / ".gitleaks.toml"
+
+
+class TestHtpasswdNotCommitted(unittest.TestCase):
+    def test_htpasswd_not_tracked_by_git(self) -> None:
+        result = subprocess.run(
+            ["git", "ls-files", "configs/nginx/htpasswd"],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+        )
+        self.assertEqual(result.stdout.strip(), "",
+                         "configs/nginx/htpasswd must not be tracked in git")
+
+    def test_htpasswd_file_not_present_on_disk(self) -> None:
+        self.assertFalse(
+            COMMITTED_HTPASSWD.exists(),
+            "configs/nginx/htpasswd must not exist on disk (only secrets/htpasswd at runtime)",
+        )
+
+    def test_htpasswd_example_exists(self) -> None:
+        self.assertTrue(
+            HTPASSWD_EXAMPLE.exists(),
+            "configs/nginx/htpasswd.example must exist as a documentation placeholder",
+        )
+
+    def test_htpasswd_example_contains_no_real_hash(self) -> None:
+        content = HTPASSWD_EXAMPLE.read_text()
+        self.assertNotIn("$apr1$IvtTVmT2$", content,
+                         "htpasswd.example must not contain the old leaked hash")
+
+
+class TestGitignore(unittest.TestCase):
+    def setUp(self) -> None:
+        self.content = GITIGNORE.read_text()
+
+    def test_secrets_dir_is_ignored(self) -> None:
+        self.assertIn("secrets/", self.content)
+
+    def test_nginx_htpasswd_is_ignored(self) -> None:
+        self.assertIn("configs/nginx/htpasswd", self.content)
+
+
+class TestEnvExample(unittest.TestCase):
+    def setUp(self) -> None:
+        self.content = ENV_EXAMPLE.read_text()
+
+    def test_loki_auth_user_present(self) -> None:
+        self.assertIn("LOKI_AUTH_USER=", self.content)
+
+    def test_loki_auth_password_present(self) -> None:
+        self.assertIn("LOKI_AUTH_PASSWORD=", self.content)
+
+
+class TestDockerCompose(unittest.TestCase):
+    def setUp(self) -> None:
+        self.content = DOCKER_COMPOSE.read_text()
+
+    def test_volume_mount_uses_secrets_dir(self) -> None:
+        self.assertIn("./secrets/htpasswd:/etc/nginx/htpasswd:ro", self.content)
+
+    def test_old_committed_path_not_referenced(self) -> None:
+        self.assertNotIn("configs/nginx/htpasswd", self.content)
+
+
+class TestJustfile(unittest.TestCase):
+    def setUp(self) -> None:
+        self.content = JUSTFILE.read_text()
+
+    def test_gen_htpasswd_recipe_exists(self) -> None:
+        self.assertIn("gen-htpasswd:", self.content)
+
+    def test_start_depends_on_gen_htpasswd(self) -> None:
+        self.assertRegex(self.content, r"start:\s+gen-htpasswd")
+
+    def test_restart_depends_on_gen_htpasswd(self) -> None:
+        self.assertRegex(self.content, r"restart:\s+gen-htpasswd")
+
+
+class TestGenScript(unittest.TestCase):
+    def test_script_exists(self) -> None:
+        self.assertTrue(GEN_SCRIPT.exists(), "scripts/gen-htpasswd.sh must exist")
+
+    def test_script_is_executable(self) -> None:
+        mode = GEN_SCRIPT.stat().st_mode
+        self.assertTrue(mode & stat.S_IXUSR, "scripts/gen-htpasswd.sh must be executable")
+
+    def test_script_generates_htpasswd(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env = {
+                **os.environ,
+                "LOKI_AUTH_USER": "testuser",
+                "LOKI_AUTH_PASSWORD": "testpass123",
+            }
+            result = subprocess.run(
+                [str(GEN_SCRIPT)],
+                capture_output=True,
+                text=True,
+                env=env,
+                cwd=tmpdir,
+            )
+            # Script uses REPO_ROOT derived from its own path, so output goes to
+            # the real secrets/ dir. Run it and check the output file.
+            secrets_htpasswd = REPO_ROOT / "secrets" / "htpasswd"
+            self.assertEqual(result.returncode, 0,
+                             f"gen-htpasswd.sh failed: {result.stderr}")
+            self.assertTrue(secrets_htpasswd.exists(),
+                            "secrets/htpasswd must be created by gen-htpasswd.sh")
+
+    def test_generated_htpasswd_format(self) -> None:
+        env = {
+            **os.environ,
+            "LOKI_AUTH_USER": "myuser",
+            "LOKI_AUTH_PASSWORD": "mypassword",
+        }
+        result = subprocess.run(
+            [str(GEN_SCRIPT)],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        self.assertEqual(result.returncode, 0,
+                         f"gen-htpasswd.sh failed: {result.stderr}")
+
+        secrets_htpasswd = REPO_ROOT / "secrets" / "htpasswd"
+        content = secrets_htpasswd.read_text().strip()
+        # Format: user:$apr1$<salt>$<hash>
+        self.assertTrue(content.startswith("myuser:$apr1$"),
+                        f"Generated htpasswd has unexpected format: {content}")
+
+    def test_script_fails_without_user_var(self) -> None:
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("LOKI_AUTH_USER", "LOKI_AUTH_PASSWORD")}
+        env["LOKI_AUTH_PASSWORD"] = "somepass"
+        result = subprocess.run(
+            [str(GEN_SCRIPT)],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        self.assertNotEqual(result.returncode, 0,
+                            "Script must exit non-zero when LOKI_AUTH_USER is unset")
+
+    def test_script_fails_without_password_var(self) -> None:
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("LOKI_AUTH_USER", "LOKI_AUTH_PASSWORD")}
+        env["LOKI_AUTH_USER"] = "loki"
+        result = subprocess.run(
+            [str(GEN_SCRIPT)],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        self.assertNotEqual(result.returncode, 0,
+                            "Script must exit non-zero when LOKI_AUTH_PASSWORD is unset")
+
+    def test_generated_file_permissions(self) -> None:
+        env = {
+            **os.environ,
+            "LOKI_AUTH_USER": "loki",
+            "LOKI_AUTH_PASSWORD": "securepassword",
+        }
+        subprocess.run([str(GEN_SCRIPT)], env=env, check=True,
+                       capture_output=True)
+        secrets_htpasswd = REPO_ROOT / "secrets" / "htpasswd"
+        mode = secrets_htpasswd.stat().st_mode & 0o777
+        self.assertEqual(mode, 0o600,
+                         f"secrets/htpasswd must be chmod 600, got {oct(mode)}")
+
+
+class TestGitleaksConfig(unittest.TestCase):
+    def test_gitleaks_toml_exists(self) -> None:
+        self.assertTrue(GITLEAKS_TOML.exists(), ".gitleaks.toml must exist")
+
+    def test_gitleaks_extends_default_ruleset(self) -> None:
+        content = GITLEAKS_TOML.read_text()
+        self.assertIn("useDefault = true", content)
+
+    def test_gitleaks_has_htpasswd_rule(self) -> None:
+        content = GITLEAKS_TOML.read_text()
+        self.assertIn("htpasswd", content)
+
+    def test_gitleaks_allowlist_excludes_example(self) -> None:
+        content = GITLEAKS_TOML.read_text()
+        self.assertIn("htpasswd.example", content,
+                      ".gitleaks.toml must allowlist htpasswd.example")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Deletes `configs/nginx/htpasswd` from git tracking — the file contained an MD5-crypt (`$apr1$`) hash committed to the repo, requiring a commit to rotate credentials and leaving a crackable hash in history
- Adds `scripts/gen-htpasswd.sh` which reads `LOKI_AUTH_USER` / `LOKI_AUTH_PASSWORD` from `.env` and writes `secrets/htpasswd` via `openssl passwd -apr1` at startup
- Wires `gen-htpasswd` as a `just start` / `just restart` dependency so credentials are always fresh from the environment
- Updates `docker-compose.yml` loki-proxy volume mount from `./configs/nginx/htpasswd` → `./secrets/htpasswd`
- Adds `secrets/` and `configs/nginx/htpasswd` to `.gitignore`; adds `.env.example` entries for the two new vars
- Adds `configs/nginx/htpasswd.example` as a format-only documentation placeholder (no real credentials)
- Adds `.gitleaks.toml` with a custom rule that flags any future htpasswd re-commit while allowlisting the `.example` file
- Adds 24 tests in `tests/test_htpasswd_security.py` covering all the above

## Test plan

- [x] `python3 -m pytest tests/ -v` → 126 passed, 0 failed
- [x] `git ls-files configs/nginx/htpasswd` → empty (file not tracked)
- [x] `secrets/` is `.gitignore`d; running `scripts/gen-htpasswd.sh` with env vars set produces `secrets/htpasswd` at chmod 600
- [x] Script exits non-zero when `LOKI_AUTH_USER` or `LOKI_AUTH_PASSWORD` is unset
- [x] Generated file format: `<user>:$apr1$<salt>$<hash>`
- [ ] Manual: `just start` on clean checkout generates `secrets/htpasswd` before compose up
- [ ] Manual: `curl -u loki:<new-password> http://localhost:3101/ready` returns 200 after stack is up

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)