### PR TITLE
fix(promtail): replace hardcoded host label with env var substitution

### DIFF
--- a/configs/promtail.yml
+++ b/configs/promtail.yml
@@ -16,7 +16,7 @@ scrape_configs:
           - localhost
         labels:
           job: syslog
-          host: hermes
+          host: ${HOSTNAME:-hermes}
           __path__: /var/log/syslog
 
   # Tail NATS server log — NATS log directory mounted at /logs/nats

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,7 @@ services:
   promtail:
     image: grafana/promtail:3.1.2
     container_name: argus-promtail
+    hostname: hermes
     restart: unless-stopped
     logging:
       driver: json-file

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -99,6 +99,31 @@ class TestPromtailConfig(unittest.TestCase):
     def test_scrape_configs_is_list(self):
         assert isinstance(self.config["scrape_configs"], list)
 
+    def test_syslog_job_host_label_uses_env_var(self):
+        syslog_job = next(
+            (j for j in self.config["scrape_configs"] if j.get("job_name") == "syslog"),
+            None,
+        )
+        assert syslog_job is not None, "syslog scrape job not found"
+        labels = syslog_job["static_configs"][0]["labels"]
+        assert "host" in labels, "syslog job missing 'host' label"
+        assert labels["host"].startswith("${"), (
+            "host label must use env var substitution (${HOSTNAME:-...}), "
+            f"got hardcoded value: {labels['host']!r}"
+        )
+
+    def test_syslog_job_host_label_has_fallback(self):
+        syslog_job = next(
+            (j for j in self.config["scrape_configs"] if j.get("job_name") == "syslog"),
+            None,
+        )
+        assert syslog_job is not None
+        host_val = syslog_job["static_configs"][0]["labels"]["host"]
+        assert ":-" in host_val, (
+            "host label env var should have a fallback default (e.g. ${HOSTNAME:-hermes}), "
+            f"got: {host_val!r}"
+        )
+
 
 class TestGrafanaDatasourcesConfig(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

- Replaces `host: hermes` static label in `configs/promtail.yml` syslog scrape job with `host: ${HOSTNAME:-hermes}` so Loki's `host` label reflects the actual machine name on any deployment
- Adds `hostname: hermes` to the `promtail` service in `docker-compose.yml` so the original deployment retains the `hermes` label unchanged
- `HOSTNAME` is automatically set in Linux/Docker environments; `-config.expand-env=true` (already present on the promtail command) performs the substitution at startup
- Adds two new tests to `TestPromtailConfig` verifying the syslog job's `host` label uses env var syntax with a fallback

## Test plan

- [x] All 104 existing tests pass (`pixi run python -m pytest tests/ -v`)
- [x] New tests `test_syslog_job_host_label_uses_env_var` and `test_syslog_job_host_label_has_fallback` pass
- [ ] On redeployment: verify `curl http://localhost:9080/config | grep 'host:'` returns resolved hostname, not raw template string

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)