### PR TITLE
fix(scripts): use ${CONTAINER_CMD:-docker} in backup/restore — Podman compatibility

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,7 @@
 # === Variables ===
 
 compose_cmd := if `command -v podman-compose 2>/dev/null || true` != "" { "podman-compose" } else { "docker compose" }
+container_cmd := if `command -v podman-compose 2>/dev/null || true` != "" { "podman" } else { "docker" }
 
 AGAMEMNON_URL := "http://172.20.0.1:8080"
 GRAFANA_PORT := "3000"
@@ -67,11 +68,11 @@ scrape-agamemnon:
 
 # Back up Prometheus and Loki data volumes to ./backups/
 backup:
-    ./scripts/backup.sh
+    CONTAINER_CMD={{container_cmd}} ./scripts/backup.sh
 
 # Restore a volume from a backup file: just restore <volume> <file>
 restore VOLUME FILE:
-    ./scripts/restore.sh {{VOLUME}} {{FILE}}
+    CONTAINER_CMD={{container_cmd}} ./scripts/restore.sh {{VOLUME}} {{FILE}}
 
 # === Grafana ===
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -14,7 +14,7 @@ echo "Backup directory: $BACKUP_DIR"
 for vol in prometheus_data loki_data; do
     out="$BACKUP_DIR/${vol}_${TIMESTAMP}.tar.gz"
     echo "Backing up $vol -> $out"
-    docker run --rm -v "${vol}:/data:ro" -v "${BACKUP_DIR}:/backups" \
+    ${CONTAINER_CMD:-docker} run --rm -v "${vol}:/data:ro" -v "${BACKUP_DIR}:/backups" \
         alpine tar czf "/backups/${vol}_${TIMESTAMP}.tar.gz" -C /data .
     echo "  ✓ $vol backup complete"
 done

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -23,6 +23,6 @@ if [[ ! -f "$FILE" ]]; then
 fi
 
 echo "Restoring $VOLUME from $FILE ..."
-docker run --rm -v "${VOLUME}:/data" -v "$(realpath "$FILE"):/backup.tar.gz:ro" \
+${CONTAINER_CMD:-docker} run --rm -v "${VOLUME}:/data" -v "$(realpath "$FILE"):/backup.tar.gz:ro" \
     alpine sh -c "cd /data && tar xzf /backup.tar.gz"
 echo "✓ Restore complete: $VOLUME"

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -1,0 +1,120 @@
+"""
+Tests for backup.sh and restore.sh — verifies that scripts use ${CONTAINER_CMD:-docker}
+instead of hardcoded `docker run`, and that the justfile exports CONTAINER_CMD correctly.
+"""
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+JUSTFILE = REPO_ROOT / "justfile"
+
+
+def script_content(name: str) -> str:
+    return (SCRIPTS_DIR / name).read_text()
+
+
+# ---------------------------------------------------------------------------
+# backup.sh
+# ---------------------------------------------------------------------------
+
+
+def test_backup_sh_no_bare_docker_run() -> None:
+    """backup.sh must not contain a hardcoded `docker run` invocation."""
+    content = script_content("backup.sh")
+    # Allow 'docker' inside ${CONTAINER_CMD:-docker} but not as a standalone command
+    bare = re.search(r'(?<!\{CONTAINER_CMD:-)\bdocker\s+run\b', content)
+    assert bare is None, "backup.sh still contains a hardcoded 'docker run'"
+
+
+def test_backup_sh_uses_container_cmd() -> None:
+    """backup.sh must use ${CONTAINER_CMD:-docker} run."""
+    content = script_content("backup.sh")
+    assert "${CONTAINER_CMD:-docker} run" in content
+
+
+def test_backup_sh_syntax() -> None:
+    """backup.sh must pass bash -n syntax check."""
+    result = subprocess.run(
+        ["bash", "-n", str(SCRIPTS_DIR / "backup.sh")],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# restore.sh
+# ---------------------------------------------------------------------------
+
+
+def test_restore_sh_no_bare_docker_run() -> None:
+    """restore.sh must not contain a hardcoded `docker run` invocation."""
+    content = script_content("restore.sh")
+    bare = re.search(r'(?<!\{CONTAINER_CMD:-)\bdocker\s+run\b', content)
+    assert bare is None, "restore.sh still contains a hardcoded 'docker run'"
+
+
+def test_restore_sh_uses_container_cmd() -> None:
+    """restore.sh must use ${CONTAINER_CMD:-docker} run."""
+    content = script_content("restore.sh")
+    assert "${CONTAINER_CMD:-docker} run" in content
+
+
+def test_restore_sh_syntax() -> None:
+    """restore.sh must pass bash -n syntax check."""
+    result = subprocess.run(
+        ["bash", "-n", str(SCRIPTS_DIR / "restore.sh")],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# justfile
+# ---------------------------------------------------------------------------
+
+
+def test_justfile_defines_container_cmd() -> None:
+    """justfile must define a container_cmd variable."""
+    content = JUSTFILE.read_text()
+    assert "container_cmd" in content
+
+
+def test_justfile_backup_exports_container_cmd() -> None:
+    """The backup recipe must pass CONTAINER_CMD={{container_cmd}} to the script."""
+    content = JUSTFILE.read_text()
+    assert "CONTAINER_CMD={{container_cmd}} ./scripts/backup.sh" in content
+
+
+def test_justfile_restore_exports_container_cmd() -> None:
+    """The restore recipe must pass CONTAINER_CMD={{container_cmd}} to the script."""
+    content = JUSTFILE.read_text()
+    assert "CONTAINER_CMD={{container_cmd}} ./scripts/restore.sh" in content
+
+
+def test_justfile_container_cmd_matches_compose_cmd_runtime() -> None:
+    """container_cmd and compose_cmd must resolve to the same runtime (podman or docker)."""
+    content = JUSTFILE.read_text()
+    # Both must key off the same condition (podman-compose presence)
+    assert content.count('command -v podman-compose') >= 2, (
+        "container_cmd and compose_cmd should both detect podman-compose"
+    )
+
+
+@pytest.mark.parametrize("recipe,flag", [
+    ("backup", "CONTAINER_CMD"),
+    ("restore", "CONTAINER_CMD"),
+])
+def test_justfile_recipes_pass_container_cmd(recipe: str, flag: str) -> None:
+    """Parametrised check that backup and restore recipes both forward CONTAINER_CMD."""
+    content = JUSTFILE.read_text()
+    # Find the recipe block and assert flag appears in it
+    pattern = rf'{recipe}[^\n]*\n\s+{flag}='
+    assert re.search(pattern, content), (
+        f"Recipe '{recipe}' does not export {flag}"
+    )


### PR DESCRIPTION
## Summary

- Adds `container_cmd` variable to `justfile` that resolves to `podman` or `docker` using the same `podman-compose` detection already present for `compose_cmd`
- Exports `CONTAINER_CMD={{container_cmd}}` when invoking `scripts/backup.sh` and `scripts/restore.sh` from the `backup` and `restore` recipes
- Replaces hardcoded `docker run` in both scripts with `${CONTAINER_CMD:-docker} run` (fallback to `docker` when scripts are invoked directly without `just`)

Fixes #133 (part of #100).

## Test plan

- [x] `bash -n scripts/backup.sh` and `bash -n scripts/restore.sh` — syntax clean
- [x] `just --list` — justfile parses without error
- [x] `pixi run python -m pytest tests/ -v` — 114 tests pass, 12 new tests cover the changes
- [x] New `tests/test_backup_restore.py` asserts: no bare `docker run` in either script, `${CONTAINER_CMD:-docker}` present, justfile defines `container_cmd` and exports it in both recipes

🤖 Generated with [Claude Code](https://claude.com/claude-code)