### PR TITLE
fix(restore): stop service before overwriting data volume

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -17,9 +17,28 @@ fi
 VOLUME="$1"
 FILE="$2"
 
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+declare -A VOLUME_TO_SERVICE=(
+    [prometheus_data]=prometheus
+    [loki_data]=loki
+    [grafana_data]=grafana
+)
+
+SERVICE="${VOLUME_TO_SERVICE[$VOLUME]:-}"
+
 if [[ ! -f "$FILE" ]]; then
     echo "Error: Backup file not found: $FILE"
     exit 1
+fi
+
+if [[ -n "$SERVICE" ]]; then
+    echo "Stopping $SERVICE before restore..."
+    docker compose --project-directory "$PROJECT_DIR" stop "$SERVICE"
+    # shellcheck disable=SC2064
+    trap "echo 'Restarting $SERVICE...'; docker compose --project-directory '$PROJECT_DIR' start '$SERVICE'" EXIT
+else
+    echo "Warning: unknown volume '$VOLUME' — ensure the stack is stopped before restoring."
 fi
 
 echo "Restoring $VOLUME from $FILE ..."


### PR DESCRIPTION
## Summary

- Maps known volume names (`prometheus_data`, `loki_data`, `grafana_data`) to their Docker Compose service names
- Stops the target service before the restore `docker run` command runs
- Registers a `trap EXIT` that restarts the service whether the restore succeeds or fails, preventing the service from being left down permanently
- Emits a warning and skips stop/start for unknown volumes rather than silently proceeding

## Test plan

- [x] `bash -n scripts/restore.sh` — syntax clean
- [x] All 102 existing pytest tests pass (`pixi run python -m pytest tests/ -v`)
- [ ] Manual smoke test: `just start && just restore prometheus_data <backup>` — script stops prometheus, restores, restarts prometheus
- [ ] Simulate failure: `just restore prometheus_data /dev/null` — stop runs, restore fails, trap fires and restarts prometheus, script exits nonzero
- [ ] Unknown volume: `just restore unknown_vol ./some.tar.gz` — warning printed, no stop/start attempted

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)