### PR TITLE
chore(github): configure milestones and triage issues for v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to ProjectArgus will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [Unreleased] — targeting v0.2.0
+
+### Added
+<!-- items from v0.2.0 milestone -->
 
 ## [0.1.0] - 2026-04-23
 


### PR DESCRIPTION
## Summary

- Created two GitHub milestones: **v0.2.0** (near-term committed deliverables) and **Backlog** (no committed release target)
- Triaged all 212 open issues: 43 → `v0.2.0` (severity:major audit findings, actionable bugs/enhancements), 169 → `Backlog`
- Updated `CHANGELOG.md` `[Unreleased]` block to reference the `v0.2.0` target, keeping `pixi.toml` version → CHANGELOG → milestone names coherent

## Test plan

- [x] `gh api repos/HomericIntelligence/ProjectArgus/milestones` — both `v0.2.0` (43 open) and `Backlog` (169 open) present
- [x] No open issue left without a milestone (`select(.milestone == null)` returns empty)
- [x] `Backlog` milestone has no `due_on` date
- [x] `CHANGELOG.md` `[Unreleased]` references `v0.2.0`

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)