### PR TITLE
docs(github): add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- Describe what this PR does and why. -->
+
+Closes #
+
+## Checklist
+
+- [ ] This PR is linked to a GitHub issue (see "Closes #" above)
+- [ ] The stack starts successfully with these changes applied (`just start && just status`)
+- [ ] PR title is clear and descriptive (e.g. `[feat] Add NATS JetStream dashboard`)


### PR DESCRIPTION
## Summary

Adds `.github/PULL_REQUEST_TEMPLATE.md` so GitHub surfaces the PR requirements from `CONTRIBUTING.md` directly at PR creation time. Contributors no longer need to read `CONTRIBUTING.md` separately to know what's expected.

Closes #141

## Changes

- Created `.github/PULL_REQUEST_TEMPLATE.md` with a three-item checklist mirroring the requirements already documented in `CONTRIBUTING.md`:
  - PR linked to a GitHub issue
  - Stack starts successfully with changes applied
  - PR title is clear and descriptive

## Checklist

- [x] This PR is linked to a GitHub issue (Closes #141)
- [x] Docs-only change — no stack startup required
- [x] PR title is clear and descriptive