### PR TITLE
fix(codeowners): add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Default owner for all files
+* @HomericIntelligence/argus-maintainers
+
+# Prometheus scrape configs and alert rules — security-sensitive (metric poisoning, alert suppression)
+/configs/prometheus.yml @HomericIntelligence/argus-maintainers @HomericIntelligence/security
+/rules/ @HomericIntelligence/argus-maintainers @HomericIntelligence/security
+
+# Grafana dashboards and datasource provisioning
+/configs/grafana/ @HomericIntelligence/argus-maintainers
+/dashboards/ @HomericIntelligence/argus-maintainers
+
+# Loki and Promtail configs — log pipeline (log injection risk)
+/configs/loki.yml @HomericIntelligence/argus-maintainers @HomericIntelligence/security
+/configs/promtail.yml @HomericIntelligence/argus-maintainers @HomericIntelligence/security
+
+# CI/CD and GitHub configuration
+/.github/ @HomericIntelligence/argus-maintainers


### PR DESCRIPTION
## Summary

- Creates `.github/CODEOWNERS` with a catch-all default owner (`@HomericIntelligence/argus-maintainers`) so no PR can be un-owned
- Adds `@HomericIntelligence/security` as co-owner on security-sensitive paths: Prometheus scrape config, alert rules, Loki config, and Promtail config (log injection / metric poisoning / alert suppression attack surface)
- Covers CI/CD and GitHub configuration under `/.github/`

## Test plan

- [ ] Confirm GitHub shows "Review requested from argus-maintainers" automatically on this PR
- [ ] Confirm GitHub does not surface a CODEOWNERS syntax error under Files Changed
- [ ] Verify `@HomericIntelligence/argus-maintainers` and `@HomericIntelligence/security` team slugs resolve (no warning badge)

Closes #142
Part of #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)