### PR TITLE
ci: add tag-triggered GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.1.0)"
+        required: true
+
+jobs:
+  release:
+    name: Publish GitHub release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract release notes from CHANGELOG.md
+        id: notes
+        env:
+          VERSION: ${{ github.ref_name || inputs.tag }}
+        run: |
+          VER="${VERSION#v}"
+          awk "/^## \[$VER\]/{found=1; next} found && /^## /{exit} found{print}" CHANGELOG.md \
+            > /tmp/release-notes.md
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name || inputs.tag }}
+          name: ${{ github.ref_name || inputs.tag }}
+          body_path: /tmp/release-notes.md
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` triggered on `v*.*.*` tag pushes and `workflow_dispatch` for manual releases
- Extracts release notes from the corresponding `CHANGELOG.md` section via `awk`
- Publishes via `softprops/action-gh-release@v1`
- Created retroactive GitHub release for `v0.1.0` pointing at commit `c7af901` (the CHANGELOG.md addition commit representing the v0.1.0 freeze)

Closes #143

## Test plan

- [x] `gh release view v0.1.0` — confirms release exists with correct notes matching CHANGELOG.md `## [0.1.0]` block
- [x] `gh release list` — confirms `v0.1.0` appears
- [ ] On next tag push (`v0.2.0`, etc.), the `Release` workflow will auto-trigger and publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)