### PR TITLE
docs(CLAUDE.md): document NATS_LOG_DIR env var for Promtail mount

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,21 @@ All services run on the `argus` Docker network and are managed via `docker-compo
 
 `172.20.0.1` is the WSL2 host gateway — this reaches services running on the Windows host or in other WSL distros.
 
+## Environment Variables
+
+Copy `.env.example` to `.env` at the repository root and set values before running `just start`.
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `NATS_LOG_DIR` | No | `~/.local/share/nats` | Host path Promtail mounts read-only for NATS logs |
+| `GF_ADMIN_PASSWORD` | **Yes** | `changeme` | Grafana admin password — change before first run |
+| `AGAMEMNON_URL` | No | `http://172.20.0.1:8080` | Agamemnon API base URL |
+| `NESTOR_URL` | No | `http://172.20.0.1:8081` | Nestor API base URL |
+| `NATS_URL` | No | `http://172.24.0.1:8222` | NATS monitoring API URL |
+
+`NATS_LOG_DIR` is used by the `promtail` service as a read-only bind mount
+(`docker-compose.yml:98`). The full default is `/home/mvillmow/.local/share/nats`.
+
 ## Dashboard Descriptions
 
 - **agent-health.json** (`uid: agent-health`): Total agent count (`hi_agents_total`),


### PR DESCRIPTION
## Summary

- Adds an **Environment Variables** section to `CLAUDE.md` listing all variables from `.env.example`
- `NATS_LOG_DIR` is now explicitly documented as the host path Promtail mounts read-only for NATS logs (sourced from `docker-compose.yml:98` and `.env.example:16-17`)
- `GF_ADMIN_PASSWORD`, `AGAMEMNON_URL`, `NESTOR_URL`, and `NATS_URL` also documented for completeness

## Test plan

- [x] `grep -n "NATS_LOG_DIR" CLAUDE.md` returns the new section
- [x] `awk 'length > 120' CLAUDE.md` returns no output (all lines ≤ 120 chars)
- [x] `pre-commit run --files CLAUDE.md` passes all hooks
- [x] `git diff --name-only` shows only `CLAUDE.md` modified

Closes #147, Part of #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)