### PR TITLE
fix(justfile): remove hardcoded admin:admin, surface auth failures in import-dashboards

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,7 +5,6 @@ compose_cmd := if `command -v podman-compose 2>/dev/null || true` != "" { "podma
 AGAMEMNON_URL := "http://172.20.0.1:8080"
 GRAFANA_PORT := "3000"
 GRAFANA_URL  := "http://localhost:" + GRAFANA_PORT
-GRAFANA_AUTH := "admin:admin"
 
 # === Default ===
 
@@ -77,4 +76,5 @@ restore VOLUME FILE:
 
 # Import all JSON dashboards from dashboards/ into Grafana via API
 import-dashboards:
-    GRAFANA_PORT={{GRAFANA_PORT}} GRAFANA_ADMIN_PASSWORD=$(echo "{{GRAFANA_AUTH}}" | cut -d: -f2) ./scripts/import-dashboards.sh
+    @test -n "${GF_ADMIN_PASSWORD:-}" || { echo "ERROR: GF_ADMIN_PASSWORD is not set. Source .env first."; exit 1; }
+    GRAFANA_PORT={{GRAFANA_PORT}} GRAFANA_ADMIN_PASSWORD="${GF_ADMIN_PASSWORD}" ./scripts/import-dashboards.sh

--- a/scripts/import-dashboards.sh
+++ b/scripts/import-dashboards.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 # import-dashboards.sh — Import all Grafana dashboard JSON files via the HTTP API.
-# Reads GRAFANA_ADMIN_PASSWORD from env (default: admin).
+# Reads GRAFANA_ADMIN_PASSWORD from env; exits with an error if unset.
 set -euo pipefail
 
 GRAFANA_PORT="${GRAFANA_PORT:-3000}"
 GRAFANA_URL="http://localhost:${GRAFANA_PORT}"
-GRAFANA_ADMIN_PASSWORD="${GRAFANA_ADMIN_PASSWORD:-admin}"
+
+if [[ -z "${GRAFANA_ADMIN_PASSWORD:-}" ]]; then
+    echo "ERROR: GRAFANA_ADMIN_PASSWORD is not set. Source .env or set GF_ADMIN_PASSWORD." >&2
+    exit 1
+fi
+
 GRAFANA_AUTH="admin:${GRAFANA_ADMIN_PASSWORD}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -27,11 +32,17 @@ fi
 for f in "${files[@]}"; do
     echo "Importing $(basename "$f") ..."
     payload=$(jq -n --slurpfile dash "$f" '{"dashboard": $dash[0], "overwrite": true, "folderId": 0}')
-    result=$(curl -sf -u "$GRAFANA_AUTH" \
+    http_code=$(curl -s -o /tmp/grafana_import_resp.json -w "%{http_code}" \
+        -u "$GRAFANA_AUTH" \
         -H "Content-Type: application/json" \
         -d "$payload" \
         "${GRAFANA_URL}/api/dashboards/db")
-    status=$(echo "$result" | jq -r '.status // "unknown"')
+    if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+        echo "  -> ERROR: HTTP $http_code from Grafana API" >&2
+        cat /tmp/grafana_import_resp.json >&2
+        exit 1
+    fi
+    status=$(jq -r '.status // "unknown"' /tmp/grafana_import_resp.json)
     echo "  -> status: $status"
 done
 

--- a/tests/test_import_dashboards.py
+++ b/tests/test_import_dashboards.py
@@ -1,0 +1,78 @@
+"""
+Tests for the import-dashboards.sh script and justfile credential handling.
+"""
+import os
+import stat
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "import-dashboards.sh"
+JUSTFILE = REPO_ROOT / "justfile"
+
+
+class TestImportDashboardsScript(unittest.TestCase):
+    def test_script_is_executable(self) -> None:
+        assert SCRIPT.exists(), f"{SCRIPT} does not exist"
+        mode = SCRIPT.stat().st_mode
+        assert mode & stat.S_IXUSR, f"{SCRIPT} is not executable"
+
+    def test_script_fails_without_password(self) -> None:
+        """Script must exit non-zero and print ERROR when GRAFANA_ADMIN_PASSWORD is unset."""
+        env = {k: v for k, v in os.environ.items() if k != "GRAFANA_ADMIN_PASSWORD"}
+        # Use an invalid port so no real network call can succeed even if the guard is missing.
+        env["GRAFANA_PORT"] = "0"
+        result = subprocess.run(
+            [str(SCRIPT)],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0, "Script should exit non-zero when password is unset"
+        assert "ERROR" in result.stderr, (
+            f"Expected 'ERROR' in stderr, got: {result.stderr!r}"
+        )
+
+    def test_script_exits_with_useful_message_on_401(self) -> None:
+        """Script must exit non-zero and surface HTTP error code on auth failure.
+
+        Verified by inspecting the script source: the curl invocation captures the HTTP
+        status code with -w "%{http_code}" and explicitly exits non-zero for any non-2xx
+        response.  We confirm this by grepping the script text rather than making a real
+        network call (which would require a running Grafana instance).
+        """
+        source = SCRIPT.read_text()
+        assert "%{http_code}" in source, (
+            "import-dashboards.sh should capture HTTP status code with -w \"%{http_code}\""
+        )
+        assert "exit 1" in source, (
+            "import-dashboards.sh should call 'exit 1' on HTTP error"
+        )
+
+
+class TestJustfileCredentials(unittest.TestCase):
+    def _justfile_text(self) -> str:
+        return JUSTFILE.read_text()
+
+    def test_no_hardcoded_admin_password(self) -> None:
+        """justfile must not contain the hardcoded 'admin:admin' credential."""
+        assert "admin:admin" not in self._justfile_text(), (
+            "justfile contains hardcoded 'admin:admin' — this was the bug fixed in #152"
+        )
+
+    def test_import_dashboards_reads_gf_admin_password(self) -> None:
+        """import-dashboards recipe must reference GF_ADMIN_PASSWORD from the environment."""
+        assert "GF_ADMIN_PASSWORD" in self._justfile_text(), (
+            "import-dashboards recipe should use GF_ADMIN_PASSWORD from the environment"
+        )
+
+    def test_grafana_auth_variable_removed(self) -> None:
+        """GRAFANA_AUTH justfile variable must no longer be defined."""
+        assert "GRAFANA_AUTH" not in self._justfile_text(), (
+            "GRAFANA_AUTH justfile variable should have been removed in #152"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Removes `GRAFANA_AUTH := "admin:admin"` from the justfile — this constant was always sent as the Grafana password regardless of what `GF_ADMIN_PASSWORD` was set to in `.env`
- Adds a preflight guard in `import-dashboards` that fails immediately with a clear message if `GF_ADMIN_PASSWORD` is not set, rather than silently sending the wrong password
- Fixes `scripts/import-dashboards.sh` to require `GRAFANA_ADMIN_PASSWORD` (no insecure default) and replace the swallowed `curl -sf` pattern with explicit HTTP status code checking — non-2xx responses now print the error body and exit 1

## Test plan

- [x] `tests/test_import_dashboards.py` — 6 new tests covering: script is executable, script exits with `ERROR` when password is unset (subprocess), script source contains explicit HTTP status checking, justfile has no `admin:admin`, justfile references `GF_ADMIN_PASSWORD`, `GRAFANA_AUTH` variable is removed
- [x] All 108 tests pass: `pixi run python -m pytest tests/ -v`
- [x] Manual verification: `just import-dashboards` without sourcing `.env` now immediately prints `ERROR: GF_ADMIN_PASSWORD is not set. Source .env first.` and exits 1

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)