### PR TITLE
fix(lint): consolidate yamllint to single source of truth

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,5 +11,5 @@ repos:
     rev: v1.35.1
     hooks:
       - id: yamllint
-        args: ["-d", "{extends: default, rules: {line-length: {max: 120}, truthy: {check-keys: false}}}"]
+        args: ["--config-file", ".yamllint.yaml"]
         files: \.(yml|yaml)$


### PR DESCRIPTION
## Summary

- Removes the inline `-d "{extends: default, rules: {...}}"` configuration from the yamllint pre-commit hook
- Replaces it with `--config-file .yamllint.yaml` so `.yamllint.yaml` is the single authoritative source for all YAML linting rules
- The inline config was missing `truthy: allowed-values` and `comments: min-spaces-from-content` rules that `.yamllint.yaml` already had, creating divergent pass/fail outcomes between local pre-commit runs and CI

## Test plan

- [x] `yamllint --config-file .yamllint.yaml .` — passes (only expected line-length warnings)
- [x] `pre-commit run yamllint --all-files` — passes

Closes #154
Part of #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)