### PR TITLE
fix(exporter): rename scrape timestamp metric to _seconds suffix

### DIFF
--- a/exporter/exporter.py
+++ b/exporter/exporter.py
@@ -146,7 +146,7 @@ def collect() -> str:
         gauge("nats_jetstream_bytes",     nats_jsz.get("bytes", 0))
 
     # ── exporter self ──────────────────────────────────────────────────────
-    gauge("homeric_exporter_scrape_timestamp", time.time())
+    gauge("homeric_exporter_scrape_timestamp_seconds", time.time())
     gauge("homeric_exporter_scrape_duration_seconds", time.time() - start)
     for upstream, count in fetch_errors.items():
         gauge("homeric_exporter_fetch_errors_total", count, {"upstream": upstream})

--- a/rules/agent-alerts.yml
+++ b/rules/agent-alerts.yml
@@ -20,7 +20,7 @@ groups:
           description: "ProjectNestor /v1/health has been unreachable for 2 minutes."
 
       - alert: ExporterScrapeStale
-        expr: time() - homeric_exporter_scrape_timestamp > 300
+        expr: time() - homeric_exporter_scrape_timestamp_seconds > 300
         for: 5m
         labels:
           severity: critical

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -232,7 +232,7 @@ class TestCollectMetricNames(unittest.TestCase):
 
     def test_exporter_self_metrics_present(self):
         self.assertIn("homeric_exporter_scrape_duration_seconds", self.output)
-        self.assertIn("homeric_exporter_scrape_timestamp", self.output)
+        self.assertIn("homeric_exporter_scrape_timestamp_seconds", self.output)
         self.assertIn("homeric_exporter_fetch_errors_total", self.output)
 
 


### PR DESCRIPTION
## Summary

- Renames `homeric_exporter_scrape_timestamp` → `homeric_exporter_scrape_timestamp_seconds` in `exporter/exporter.py` to comply with Prometheus naming conventions for Unix timestamp gauges
- Updates the `ExporterScrapeStale` alert expression in `rules/agent-alerts.yml` to use the new metric name
- Updates the test assertion in `tests/test_exporter.py` to match the new name

## Test plan

- [x] `pixi run python -m pytest tests/ -v` — all 102 tests pass
- [x] No other references to the old metric name remain in the codebase

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)