### PR TITLE
fix: correct LICENSE copyright year from 2025 to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2025, HomericIntelligence Contributors
+Copyright (c) 2026, HomericIntelligence Contributors
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
## Summary

- Corrects the BSD-3-Clause copyright year in `LICENSE` from `2025` to `2026`
- The project's earliest commit is from 2026 (CHANGELOG `[0.1.0] - 2026-04-23`), so `2025` was a clerical error

Closes #158

## Test plan

- [ ] Verified `LICENSE` line 3 now reads `Copyright (c) 2026, HomericIntelligence Contributors`
- No code changes; no automated tests required for a one-line text correction

🤖 Generated with [Claude Code](https://claude.com/claude-code)