### PR TITLE
fix(atlas): M4 review-wave fixes — security headers, SSE whitelist, UX, docs

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -90,6 +90,10 @@ Keepalive comment frames are sent every 15 seconds:
 | `GET` | `/events` | SSE event stream (see below) |
 | `GET` | `/api/hosts` | JSON array of hosts with per-service probe results |
 | `GET` | `/partials/host/{name}` | htmx fragment — single host card (used by 5 s poll) |
+| `GET` | `/agents` | Agents list page with filter bar and live SSE row-swap |
+| `GET` | `/partials/agents/table` | htmx fragment — filtered agents tbody |
+| `GET` | `/agents/{id}` | Agent detail page with live 50-event tail |
+| `GET` | `/tasks/{id}` | Task detail page with live event tail |
 | `GET` | `/static/*` | Static assets (CSS, JS) |
 
 ## Building

--- a/dashboard/internal/handlers/sse.go
+++ b/dashboard/internal/handlers/sse.go
@@ -63,7 +63,7 @@ func (h *SSE) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if raw := r.URL.Query().Get("topics"); raw != "" {
 		for _, t := range strings.Split(raw, ",") {
 			t = strings.TrimSpace(t)
-			if t != "" {
+			if allowedTopic(t) {
 				topicFilter[t] = struct{}{}
 			}
 		}
@@ -115,6 +115,24 @@ func (h *SSE) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			flusher.Flush()
 		}
 	}
+}
+
+// allowedTopics is the server-side whitelist for SSE topic subscriptions.
+var allowedTopics = map[string]struct{}{
+	"agent":    {},
+	"task":     {},
+	"nats":     {},
+	"host":     {},
+	"log":      {},
+	"research": {},
+	"pipeline": {},
+	"myrmidon": {},
+}
+
+// allowedTopic returns true if t is a recognised bus topic.
+func allowedTopic(t string) bool {
+	_, ok := allowedTopics[t]
+	return ok
 }
 
 // writeEvent writes a single SSE frame for the given event.

--- a/dashboard/internal/server/middleware.go
+++ b/dashboard/internal/server/middleware.go
@@ -1,4 +1,15 @@
 package server
 
-// Middleware is wired via chi/middleware in routes.go.
-// This file is reserved for custom middleware additions.
+import "net/http"
+
+// securityHeaders adds baseline HTTP security headers to every response.
+func securityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		w.Header().Set("Content-Security-Policy",
+			"default-src 'self'; script-src 'self' https://unpkg.com; connect-src 'self'; style-src 'self'; img-src 'self' data:")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/dashboard/internal/server/routes.go
+++ b/dashboard/internal/server/routes.go
@@ -12,6 +12,7 @@ func (s *Server) routes() http.Handler {
 	r.Use(middleware.RealIP)
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
+	r.Use(securityHeaders)
 
 	r.Get("/healthz", s.handleHealthz)
 	r.Get("/readyz", s.handleHealthz)

--- a/dashboard/web/static/css/atlas.css
+++ b/dashboard/web/static/css/atlas.css
@@ -156,8 +156,16 @@ main { padding: 1.5rem; }
 .data-table th { color: #8b949e; font-weight: 600; text-transform: uppercase; font-size: .7rem; letter-spacing: .05em; }
 .data-table tbody tr:hover { background: var(--surface); }
 .badge.blue { background: #1a2a3a; color: #58a6ff; }
+.badge.gray { background: #1e2530; color: #8b949e; }
 .ts { color: #8b949e; }
 .empty-state { color: #8b949e; padding: 2rem 0; text-align: center; }
+
+/* Mobile: collapse data-table columns below 640 px */
+@media (max-width: 640px) {
+    .data-table th:nth-child(1),
+    .data-table td:nth-child(1) { display: none; }
+    .detail-meta { grid-template-columns: 1fr; }
+}
 
 /* ── Detail pages ─────────────────────────────────────────────────────────── */
 .detail-card { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 1rem; margin-bottom: 1.5rem; }

--- a/dashboard/web/templates/agent_row.templ
+++ b/dashboard/web/templates/agent_row.templ
@@ -4,7 +4,7 @@ import "github.com/HomericIntelligence/atlas/internal/store"
 
 templ AgentRow(a store.AgentRecord) {
 	<tr id={ "agent-row-" + a.ID }
-		hx-get={ "/agents/" + a.ID }
+		hx-get={ agentPath(a.ID) }
 		hx-target="main"
 		hx-push-url="true"
 		style="cursor:pointer">
@@ -32,4 +32,17 @@ func agentStatusClass(s string) string {
 	default:
 		return "red"
 	}
+}
+
+// agentPath returns a safe relative URL path for an agent ID.
+// Only alphanumeric and hyphen/underscore characters are preserved.
+func agentPath(id string) string {
+	safe := make([]byte, 0, len(id))
+	for i := 0; i < len(id); i++ {
+		c := id[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_' {
+			safe = append(safe, c)
+		}
+	}
+	return "/agents/" + string(safe)
 }

--- a/dashboard/web/templates/agent_row_templ.go
+++ b/dashboard/web/templates/agent_row_templ.go
@@ -49,9 +49,9 @@ func AgentRow(a store.AgentRecord) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var3 string
-		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs("/agents/" + a.ID)
+		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(agentPath(a.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_row.templ`, Line: 7, Col: 28}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_row.templ`, Line: 7, Col: 26}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
@@ -168,6 +168,19 @@ func agentStatusClass(s string) string {
 	default:
 		return "red"
 	}
+}
+
+// agentPath returns a safe relative URL path for an agent ID.
+// Only alphanumeric and hyphen/underscore characters are preserved.
+func agentPath(id string) string {
+	safe := make([]byte, 0, len(id))
+	for i := 0; i < len(id); i++ {
+		c := id[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_' {
+			safe = append(safe, c)
+		}
+	}
+	return "/agents/" + string(safe)
 }
 
 var _ = templruntime.GeneratedTemplate

--- a/dashboard/web/templates/agents.templ
+++ b/dashboard/web/templates/agents.templ
@@ -1,6 +1,23 @@
 package templates
 
-import "github.com/HomericIntelligence/atlas/internal/store"
+import (
+	"sort"
+
+	"github.com/HomericIntelligence/atlas/internal/store"
+)
+
+func uniqueHosts(agents []store.AgentRecord) []string {
+	seen := make(map[string]struct{}, len(agents))
+	for _, a := range agents {
+		seen[a.Host] = struct{}{}
+	}
+	hosts := make([]string, 0, len(seen))
+	for h := range seen {
+		hosts = append(hosts, h)
+	}
+	sort.Strings(hosts)
+	return hosts
+}
 
 templ AgentsPage(agents []store.AgentRecord, search, statusFilter, hostFilter string) {
 	@Layout("Agents") {
@@ -14,6 +31,13 @@ templ AgentsPage(agents []store.AgentRecord, search, statusFilter, hostFilter st
 				<option value="idle" selected={ statusFilter == "idle" }>idle</option>
 				<option value="running" selected={ statusFilter == "running" }>running</option>
 				<option value="error" selected={ statusFilter == "error" }>error</option>
+			</select>
+			<select name="host" hx-get="/partials/agents/table" hx-target="#agents-table-body"
+				hx-trigger="change" hx-include="[name='search'],[name='status']">
+				<option value="">All hosts</option>
+				for _, h := range uniqueHosts(agents) {
+					<option value={ h } selected={ hostFilter == h }>{ h }</option>
+				}
 			</select>
 		</div>
 		<table class="data-table">
@@ -31,13 +55,14 @@ templ AgentsPage(agents []store.AgentRecord, search, statusFilter, hostFilter st
 				sse-connect="/events?topics=agent"
 				sse-swap="agent"
 				hx-swap="outerHTML settle:50ms">
-				for _, a := range agents {
-					@AgentRow(a)
+				if len(agents) == 0 {
+					<tr><td colspan="5" class="empty-state">No agents registered.</td></tr>
+				} else {
+					for _, a := range agents {
+						@AgentRow(a)
+					}
 				}
 			</tbody>
 		</table>
-		if len(agents) == 0 {
-			<p class="empty-state">No agents registered.</p>
-		}
 	}
 }

--- a/dashboard/web/templates/agents_templ.go
+++ b/dashboard/web/templates/agents_templ.go
@@ -8,7 +8,24 @@ package templates
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import "github.com/HomericIntelligence/atlas/internal/store"
+import (
+	"sort"
+
+	"github.com/HomericIntelligence/atlas/internal/store"
+)
+
+func uniqueHosts(agents []store.AgentRecord) []string {
+	seen := make(map[string]struct{}, len(agents))
+	for _, a := range agents {
+		seen[a.Host] = struct{}{}
+	}
+	hosts := make([]string, 0, len(seen))
+	for h := range seen {
+		hosts = append(hosts, h)
+	}
+	sort.Strings(hosts)
+	return hosts
+}
 
 func AgentsPage(agents []store.AgentRecord, search, statusFilter, hostFilter string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
@@ -50,7 +67,7 @@ func AgentsPage(agents []store.AgentRecord, search, statusFilter, hostFilter str
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(search)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 8, Col: 50}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 25, Col: 50}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -63,7 +80,7 @@ func AgentsPage(agents []store.AgentRecord, search, statusFilter, hostFilter str
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(statusFilter == "idle")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 14, Col: 58}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 31, Col: 58}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -76,7 +93,7 @@ func AgentsPage(agents []store.AgentRecord, search, statusFilter, hostFilter str
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(statusFilter == "running")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 15, Col: 64}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 32, Col: 64}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -89,31 +106,81 @@ func AgentsPage(agents []store.AgentRecord, search, statusFilter, hostFilter str
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(statusFilter == "error")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 16, Col: 60}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 33, Col: 60}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\">error</option></select></div><table class=\"data-table\"><thead><tr><th>ID</th><th>Name</th><th>Host</th><th>Status</th><th>Updated</th></tr></thead> <tbody id=\"agents-table-body\" hx-ext=\"sse\" sse-connect=\"/events?topics=agent\" sse-swap=\"agent\" hx-swap=\"outerHTML settle:50ms\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\">error</option></select> <select name=\"host\" hx-get=\"/partials/agents/table\" hx-target=\"#agents-table-body\" hx-trigger=\"change\" hx-include=\"[name='search'],[name='status']\"><option value=\"\">All hosts</option> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			for _, a := range agents {
-				templ_7745c5c3_Err = AgentRow(a).Render(ctx, templ_7745c5c3_Buffer)
+			for _, h := range uniqueHosts(agents) {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<option value=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var7 string
+				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(h)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 39, Col: 22}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\" selected=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var8 string
+				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(hostFilter == h)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 39, Col: 51}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var9 string
+				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(h)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 39, Col: 57}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</option>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</tbody></table>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</select></div><table class=\"data-table\"><thead><tr><th>ID</th><th>Name</th><th>Host</th><th>Status</th><th>Updated</th></tr></thead> <tbody id=\"agents-table-body\" hx-ext=\"sse\" sse-connect=\"/events?topics=agent\" sse-swap=\"agent\" hx-swap=\"outerHTML settle:50ms\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if len(agents) == 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<p class=\"empty-state\">No agents registered.</p>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<tr><td colspan=\"5\" class=\"empty-state\">No agents registered.</td></tr>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
+			} else {
+				for _, a := range agents {
+					templ_7745c5c3_Err = AgentRow(a).Render(ctx, templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</tbody></table>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
 			}
 			return nil
 		})

--- a/dashboard/web/templates/event_row.templ
+++ b/dashboard/web/templates/event_row.templ
@@ -25,6 +25,6 @@ func topicBadgeClass(t string) string {
 	case "task":
 		return "blue"
 	default:
-		return ""
+		return "gray"
 	}
 }

--- a/dashboard/web/templates/event_row_templ.go
+++ b/dashboard/web/templates/event_row_templ.go
@@ -140,7 +140,7 @@ func topicBadgeClass(t string) string {
 	case "task":
 		return "blue"
 	default:
-		return ""
+		return "gray"
 	}
 }
 

--- a/dashboard/web/templates/layout.templ
+++ b/dashboard/web/templates/layout.templ
@@ -9,6 +9,7 @@ templ Layout(title string) {
 			<title>{ title } — HomericIntelligence</title>
 			<link rel="stylesheet" href="/static/css/atlas.css"/>
 			<script src="https://unpkg.com/htmx.org@1.9.12" defer></script>
+			<script src="https://unpkg.com/htmx-ext-sse@2.2.2/sse.js" defer></script>
 			<script src="/static/js/atlas.js" defer></script>
 		</head>
 		<body>

--- a/dashboard/web/templates/layout_templ.go
+++ b/dashboard/web/templates/layout_templ.go
@@ -42,7 +42,7 @@ func Layout(title string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, " — HomericIntelligence</title><link rel=\"stylesheet\" href=\"/static/css/atlas.css\"><script src=\"https://unpkg.com/htmx.org@1.9.12\" defer></script><script src=\"/static/js/atlas.js\" defer></script></head><body><nav><span class=\"brand\">Atlas</span> <a href=\"/\">Overview</a> <a href=\"/hosts\">Hosts</a> <a href=\"/agents\">Agents</a> <a href=\"/tasks\">Tasks</a> <a href=\"/nats\">NATS</a> <a href=\"/grafana\">Grafana</a> <a href=\"/mnemosyne\">Mnemosyne</a> <span class=\"conn-dot\" title=\"SSE disconnected\"></span></nav><main>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, " — HomericIntelligence</title><link rel=\"stylesheet\" href=\"/static/css/atlas.css\"><script src=\"https://unpkg.com/htmx.org@1.9.12\" defer></script><script src=\"https://unpkg.com/htmx-ext-sse@2.2.2/sse.js\" defer></script><script src=\"/static/js/atlas.js\" defer></script></head><body><nav><span class=\"brand\">Atlas</span> <a href=\"/\">Overview</a> <a href=\"/hosts\">Hosts</a> <a href=\"/agents\">Agents</a> <a href=\"/tasks\">Tasks</a> <a href=\"/nats\">NATS</a> <a href=\"/grafana\">Grafana</a> <a href=\"/mnemosyne\">Mnemosyne</a> <span class=\"conn-dot\" title=\"SSE disconnected\"></span></nav><main>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

Addresses the 3 `changes_requested` dimensions from the M4 review wave (team `e2a00ae0-653a-470e-b5fe-94fa0bd4ebad`). Cherry-picked onto main after M4 base PR #435 squash-merged.

## Security fixes
- `agent_row.templ`: `agentPath()` helper sanitizes agent ID before building `hx-get` path
- `sse.go`: `allowedTopic()` server-side whitelist — unknown topics silently dropped
- `middleware.go` + `routes.go`: `securityHeaders` middleware (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Content-Security-Policy`)

## UX fixes
- `layout.templ`: load `htmx-ext-sse@2.2.2` so SSE wiring is functional
- `agents.templ`: host filter `<select>` with `uniqueHosts()` helper; empty-state inside `<tbody>`
- `atlas.css`: `.badge.gray` fallback; 640px mobile breakpoint for data-table
- `event_row.templ`: `.gray` badge for unknown topics

## Docs
- `README.md`: 4 missing M4 routes added to HTTP Endpoints table

🤖 Generated with [Claude Code](https://claude.com/claude-code)