### PR TITLE
fix(atlas): M5 review-wave fixes — CSP Loki frame-src, consumer_count JSON tag, nil guards, docs

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -39,6 +39,9 @@ All configuration is via environment variables with the `ATLAS_` prefix:
 | `ATLAS_TAILSCALE_API_KEY` | `` | API source: Tailscale API key |
 | `ATLAS_TAILNET_NAME` | `` | API source: Tailnet name (e.g. `example.com`) |
 | `ATLAS_POLL_AGAMEMNON_MS` | `5000` | Poll interval for Agamemnon in ms |
+| `ATLAS_NATS_DASHBOARD_URL` | `` | Optional: URL of external nats-dashboard (linked on /nats page) |
+| `ATLAS_NATS_TOP_URL` | `` | Optional: ttyd URL serving nats-top (embedded as iframe on /nats page) |
+| `ATLAS_MNEMOSYNE_SKILLS_DIR` | `/mnt/mnemosyne/skills` | Path to Mnemosyne skills directory (read by /mnemosyne page) |
 
 ## SSE Event Stream
 
@@ -94,6 +97,13 @@ Keepalive comment frames are sent every 15 seconds:
 | `GET` | `/partials/agents/table` | htmx fragment — filtered agents tbody |
 | `GET` | `/agents/{id}` | Agent detail page with live 50-event tail |
 | `GET` | `/tasks/{id}` | Task detail page with live event tail |
+| `GET` | `/grafana` | Grafana iframe panel matrix (8 panels, time-range selector) |
+| `GET` | `/nats` | NATS monitoring page — JetStream streams, connections, external links |
+| `GET` | `/partials/nats/streams` | htmx fragment — JetStream streams table (5 s poll) |
+| `GET` | `/partials/nats/connections` | htmx fragment — NATS connections table (5 s poll) |
+| `GET` | `/mnemosyne` | Mnemosyne skill registry browser with live search |
+| `GET` | `/partials/mnemosyne/search` | htmx fragment — filtered skill list |
+| `GET` | `/partials/mnemosyne/skill/{name}` | htmx fragment — rendered markdown body of a skill |
 | `GET` | `/static/*` | Static assets (CSS, JS) |
 
 ## Building

--- a/dashboard/internal/handlers/pages.go
+++ b/dashboard/internal/handlers/pages.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -11,6 +12,10 @@ import (
 	"github.com/HomericIntelligence/atlas/internal/store"
 	"github.com/HomericIntelligence/atlas/web/templates"
 )
+
+// validTimeRange matches Grafana relative time expressions (now, now-1h, now-7d, etc.)
+// and absolute epoch-millisecond timestamps (13-digit numbers).
+var validTimeRange = regexp.MustCompile(`^(now(-[0-9]+(s|m|h|d|w|y))?|[0-9]{13})$`)
 
 // HostsHandler serves the /hosts page and the /partials/host/{name} fragment.
 type HostsHandler struct {
@@ -122,11 +127,11 @@ func filterAgents(agents []store.AgentRecord, search, status, host string) []sto
 // GrafanaPage renders the /grafana panel matrix page.
 func (h *HostsHandler) GrafanaPage(w http.ResponseWriter, r *http.Request) {
 	from := r.URL.Query().Get("from")
-	if from == "" {
+	if !validTimeRange.MatchString(from) {
 		from = "now-1h"
 	}
 	to := r.URL.Query().Get("to")
-	if to == "" {
+	if !validTimeRange.MatchString(to) {
 		to = "now"
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -156,7 +161,10 @@ func (h *HostsHandler) NATSConnsPartial(w http.ResponseWriter, r *http.Request) 
 // MnemosynePage renders the /mnemosyne skill registry browser page.
 func (h *HostsHandler) MnemosynePage(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query().Get("q")
-	skills, _ := h.mnemoReader.Skills() //nolint:errcheck
+	var skills []mnemosyne.Skill
+	if h.mnemoReader != nil {
+		skills, _ = h.mnemoReader.Skills() //nolint:errcheck
+	}
 	filtered := mnemosyne.Filter(skills, q)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	templates.MnemosynePage(filtered, q).Render(r.Context(), w) //nolint:errcheck

--- a/dashboard/internal/handlers/partials.go
+++ b/dashboard/internal/handlers/partials.go
@@ -14,7 +14,10 @@ import (
 // GET /partials/mnemosyne/search?q=
 func (h *HostsHandler) MnemosyneSearch(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query().Get("q")
-	skills, _ := h.mnemoReader.Skills() //nolint:errcheck
+	var skills []mnemosyne.Skill
+	if h.mnemoReader != nil {
+		skills, _ = h.mnemoReader.Skills() //nolint:errcheck
+	}
 	filtered := mnemosyne.Filter(skills, q)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	templates.SkillList(filtered).Render(r.Context(), w) //nolint:errcheck
@@ -24,6 +27,10 @@ func (h *HostsHandler) MnemosyneSearch(w http.ResponseWriter, r *http.Request) {
 // GET /partials/mnemosyne/skill/{name}
 func (h *HostsHandler) MnemosyneSkillBody(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
+	if h.mnemoReader == nil {
+		http.NotFound(w, r)
+		return
+	}
 	skills, _ := h.mnemoReader.Skills() //nolint:errcheck
 	for _, s := range skills {
 		if s.Name == name {

--- a/dashboard/internal/poller/nats.go
+++ b/dashboard/internal/poller/nats.go
@@ -44,7 +44,7 @@ type jszStreamConfig struct {
 type jszStreamState struct {
 	Messages  uint64 `json:"messages"`
 	Bytes     uint64 `json:"bytes"`
-	Consumers int    `json:"num_consumers"`
+	Consumers int    `json:"consumer_count"`
 }
 
 // connzResponse is the NATS /connz response.

--- a/dashboard/internal/server/middleware.go
+++ b/dashboard/internal/server/middleware.go
@@ -15,8 +15,8 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		w.Header().Set("Content-Security-Policy",
 			fmt.Sprintf(
-				"default-src 'self'; script-src 'self' https://unpkg.com; connect-src 'self'; style-src 'self'; img-src 'self' data:; frame-src 'self' %s",
-				s.cfg.GrafanaURL,
+				"default-src 'self'; script-src 'self' https://unpkg.com; connect-src 'self'; style-src 'self'; img-src 'self' data:; frame-src 'self' %s %s",
+				s.cfg.GrafanaURL, s.cfg.LokiURL,
 			),
 		)
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
## M5 Review-Wave Fixes

Addresses 4 issues raised by the M5 review wave on PR #438.

### Security — time-range param validation
`handlers/pages.go`: validate `from`/`to` query params against a strict Grafana time-range pattern (`now`, `now-Nd`, 13-digit epoch) before passing to `PanelURL()`. Arbitrary strings are rejected and replaced with defaults.

### Security — CSP frame-src missing Loki
`server/middleware.go`: `frame-src` CSP directive now includes both `GrafanaURL` and `LokiURL`. The `loki-explorer` panel (listed in `grafana/panels.go`) uses Loki as its data source and would have been blocked without this.

### Bug fix — NATS stream consumer count always zero
`poller/nats.go`: `jszStreamState.Consumers` had JSON tag `"num_consumers"` but the live NATS `/jsz?detail=1` response uses `"consumer_count"`. Fixed to match the actual API field.

### Robustness — nil guard on Mnemosyne reader
`handlers/pages.go`, `handlers/partials.go`: guard `h.mnemoReader != nil` before calling `.Skills()` so the Mnemosyne page/partials degrade gracefully to an empty list when `ATLAS_MNEMOSYNE_SKILLS_DIR` is not configured.

### Docs
`README.md`: add `ATLAS_NATS_DASHBOARD_URL`, `ATLAS_NATS_TOP_URL`, `ATLAS_MNEMOSYNE_SKILLS_DIR` to config table; add all 7 M5 HTTP routes to endpoints table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)