### PR TITLE
fix(atlas): aggregate script uses .result field (Agamemnon API, not .verdict)

### DIFF
--- a/dashboard/scripts/atlas-review-aggregate.sh
+++ b/dashboard/scripts/atlas-review-aggregate.sh
@@ -8,7 +8,7 @@ TEAM_ID=${2:?Usage: atlas-review-aggregate.sh MILESTONE TEAM_ID [AGAMEMNON_URL]}
 AGAMEMNON_URL=${3:-http://localhost:8080}
 
 RESP=$(curl -fsS "${AGAMEMNON_URL}/v1/teams/${TEAM_ID}/tasks")
-TASKS=$(echo "$RESP" | jq -r '.tasks[]? // .[]? | "\(.subject | split(" review") | .[0]):\(.status // "pending"):\(.verdict // "pending")"')
+TASKS=$(echo "$RESP" | jq -r '.tasks[]? // .[]? | "\(.subject | split(" review") | .[0]):\(.status // "pending"):\(.result // .verdict // "pending")"')
 
 if [ -z "$TASKS" ]; then
   echo "Review wave ${MILESTONE} (team ${TEAM_ID}): 0 tasks found" >&2


### PR DESCRIPTION
The Agamemnon task API stores the review verdict in the `result` field, not `verdict`. The aggregate script was always reading `"pending"` because `.verdict` is null.

Fix: `atlas-review-aggregate.sh` now uses `.result // .verdict // "pending"` for backwards compatibility with any future API changes.

Caught when running the M5 review wave — all 6 dimensions showed `approved` in Agamemnon but the script reported `0/6 approved`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)