### PR TITLE
feat(atlas): Dockerfile + GHCR release pipeline + supply-chain hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,11 @@ NATS_LOG_DIR=/home/mvillmow/.local/share/nats
 # Loki basic-auth credentials — used by scripts/gen-htpasswd.sh to generate secrets/htpasswd
 LOKI_AUTH_USER=loki
 LOKI_AUTH_PASSWORD=changeme
+
+# Atlas dashboard bearer token — required by default
+# (ATLAS_AUTH_MODE defaults to "bearer"). Generate with:
+#   openssl rand -hex 32
+# Set ATLAS_AUTH_MODE=none ONLY if Atlas is on a fully-isolated network
+# and you accept that anyone on it can read /metrics, /readyz, and the UI.
+ATLAS_AUTH_MODE=bearer
+ATLAS_AUTH_BEARER_TOKEN=

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,46 @@ updates:
     target-branch: "main"
     commit-message:
       prefix: "chore(deps)"
+
+  - package-ecosystem: "docker"
+    directory: "/dashboard"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "atlas"
+    target-branch: "main"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "gomod"
+    directory: "/dashboard"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "atlas"
+    target-branch: "main"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # Group prometheus client + transitive Prometheus libs into one PR
+      # so the metric-stack moves as a unit.
+      prometheus:
+        patterns:
+          - "github.com/prometheus/*"
+      # Group nats client + server (test dep) so they stay version-aligned.
+      nats:
+        patterns:
+          - "github.com/nats-io/*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci"
+    target-branch: "main"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,15 +102,34 @@ jobs:
         working-directory: dashboard
         run: go vet ./...
 
-      - name: go test
+      - name: go test (unit, race-detected, coverage)
         working-directory: dashboard
-        run: go test -race ./internal/...
+        run: |
+          go test -race -coverprofile=coverage.out ./internal/...
+          go tool cover -func=coverage.out | tail -1
+
+      - name: go test (integration)
+        working-directory: dashboard
+        run: go test -race -tags=integration -timeout=60s ./tests/integration/...
+
+      - name: Upload coverage profile
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-profile
+          path: dashboard/coverage.out
+          if-no-files-found: warn
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           working-directory: dashboard
+
+      - name: govulncheck (SCA)
+        working-directory: dashboard
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
 
       - name: Check templ generate (no-op)
         working-directory: dashboard
@@ -119,6 +138,6 @@ jobs:
           templ generate ./...
           git diff --exit-code
 
-      - name: Docker build
+      - name: Docker build (verify Dockerfile is buildable)
         working-directory: dashboard
         run: docker build -t argus-dashboard:ci .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,63 @@ jobs:
           body_path: /tmp/release-notes.md
           draft: false
           prerelease: false
+
+  publish-atlas-image:
+    name: Build & push Atlas image to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # The release tag is the source of truth for the image tag. github.ref_name
+      # carries it on tag pushes; workflow_dispatch supplies it as an input.
+      - name: Resolve version
+        id: version
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          if [ -n "${GITHUB_REF_NAME:-}" ] && [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up QEMU (multi-arch)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Lower-case the owner segment because GHCR rejects uppercase
+      # (HomericIntelligence → homericintelligence).
+      - name: Compute image name
+        id: image
+        run: echo "name=ghcr.io/$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')/atlas" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: dashboard
+          file: dashboard/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          # Two tags published per release: the explicit semver tag and
+          # `latest`. Operators can pin to a version or follow the channel.
+          tags: |
+            ${{ steps.image.outputs.name }}:${{ steps.version.outputs.tag }}
+            ${{ steps.image.outputs.name }}:latest
+          build-args: |
+            VERSION=${{ steps.version.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true

--- a/dashboard/.dockerignore
+++ b/dashboard/.dockerignore
@@ -1,0 +1,28 @@
+# Test scaffolding — never needs to land in the image.
+tests/
+**/*_test.go
+
+# Editor & IDE state.
+.vscode/
+.idea/
+
+# Build artifacts that the multi-stage build produces fresh.
+bin/
+out/
+
+# Go cache leftovers (host paths).
+*.test
+*.out
+
+# Documentation lives in the repo, not the image.
+docs/
+README.md
+
+# CI / dev tooling configs not needed at runtime.
+.golangci.yml
+
+# Secrets — defence in depth even though we never put secrets here.
+.env
+.env.*
+*.pem
+*.key

--- a/dashboard/.golangci.yml
+++ b/dashboard/.golangci.yml
@@ -1,8 +1,12 @@
+# golangci-lint v2 config schema. https://golangci-lint.run/usage/configuration/
+version: "2"
+
 run:
   timeout: 5m
   modules-download-mode: readonly
 
 linters:
+  default: none
   enable:
     - govet
     - staticcheck
@@ -10,8 +14,12 @@ linters:
     - ineffassign
     - unused
     - gosec
+    - errorlint   # require errors.Is / errors.As / %w wrapping
+    - bodyclose   # ensure HTTP response bodies are closed
 
-issues:
-  exclude-rules:
-    - linters: [gosec]
-      text: "G401|G501"
+# G401 (weak crypto, e.g. md5/sha1) and G501 (md5 import) are intentionally
+# NOT excluded. Atlas does not use weak crypto in production code; if a future
+# change introduces them, we want to know.
+# G306 (file mode > 0o600 on WriteFile) is enforced — see
+# internal/tailscale/tailscale_test.go for the documented chmod-after-write
+# pattern when an executable test fixture is required.

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,89 @@
+# syntax=docker/dockerfile:1.7
+#
+# Multi-stage build for the Atlas dashboard.
+#
+# Stage 1 (builder): build the static binary on golang:1.24-alpine.
+#   - CGO_ENABLED=0 → fully static binary suitable for distroless.
+#   - -trimpath, -s -w → smaller binary, no local paths leaked.
+#   - Embeds version via -ldflags.
+#
+# Stage 2 (runtime): distroless static-debian12 nonroot.
+#   - No shell, no package manager → minimal CVE surface.
+#   - USER 65532 (nonroot) by default.
+#   - Listens on :3002.
+#
+# Build:
+#   docker build -t ghcr.io/homericintelligence/atlas:dev .
+#
+# Run:
+#   docker run --rm -p 3002:3002 \
+#       -e ATLAS_AUTH_BEARER_TOKEN=… \
+#       ghcr.io/homericintelligence/atlas:dev
+#
+ARG GO_VERSION=1.25-alpine
+
+# ---------------------------------------------------------------------------
+# Stage 1: builder
+# ---------------------------------------------------------------------------
+FROM golang:${GO_VERSION} AS builder
+
+# Build-time argument propagated from CI / git describe.
+ARG VERSION=dev
+
+WORKDIR /src
+
+# Cache the module layer separately from the source layer so source-only
+# changes don't re-download the dep graph.
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
+
+# Now bring in the source. .dockerignore should exclude tests/, .git, etc.
+COPY . .
+
+# Build the static binary. The embedded version comes from --build-arg
+# VERSION=… set by release.yml (or git-describe in CI for snapshot builds).
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux \
+    go build \
+        -trimpath \
+        -ldflags="-s -w -X github.com/HomericIntelligence/atlas/internal/version.Version=${VERSION}" \
+        -o /out/atlas \
+        ./cmd/argus-dashboard
+
+# ---------------------------------------------------------------------------
+# Stage 2: runtime
+# ---------------------------------------------------------------------------
+# distroless/static-debian12:nonroot ships glibc-free, with USER 65532 and
+# /etc/passwd already populated for the nonroot user. No shell, no apt, no
+# package manager — minimal CVE surface.
+FROM gcr.io/distroless/static-debian12:nonroot
+
+ARG VERSION=dev
+
+LABEL org.opencontainers.image.title="atlas"
+LABEL org.opencontainers.image.description="Unified status dashboard for the HomericIntelligence ecosystem."
+LABEL org.opencontainers.image.source="https://github.com/HomericIntelligence/ProjectArgus"
+LABEL org.opencontainers.image.licenses="BSD-3-Clause"
+LABEL org.opencontainers.image.version="${VERSION}"
+
+# distroless/static defaults USER to nonroot (UID 65532); make it explicit.
+USER 65532:65532
+
+# The binary needs the embedded web/static directory at runtime (templates
+# are compiled into the binary via templ generate; static CSS/JS is served
+# from disk). Copy both.
+COPY --from=builder /out/atlas /atlas
+COPY --from=builder --chown=65532:65532 /src/web/static /web/static
+
+EXPOSE 3002
+
+# k8s-style /livez probe (always 200 if process is up). The HEALTHCHECK is
+# defined in compose; see docker-compose.yml. Distroless has no shell, so a
+# binary-based healthcheck would require shipping /atlas with a -healthcheck
+# subcommand — out of scope for v0.2.x. Operators using compose should
+# probe :3002/livez via wget on the host side.
+
+ENTRYPOINT ["/atlas"]

--- a/dashboard/cmd/argus-dashboard/main.go
+++ b/dashboard/cmd/argus-dashboard/main.go
@@ -48,7 +48,7 @@ func main() {
 	// avoids flapping while still surfacing genuine outages within a few
 	// seconds.
 	const natsPollInterval = 5 * time.Second
-	agamemnonReadyMaxAge := 2 * cfg.PollAgamemnonMs
+	agamemnonReadyMaxAge := 2 * cfg.PollAgamemnon
 	natsReadyMaxAge := 2 * natsPollInterval
 
 	// Start Tailscale device refresher.
@@ -65,7 +65,7 @@ func main() {
 	agamemnonPoller := poller.NewAgamemnonPoller(cfg, cache)
 	agamemnonPoller.SetMetrics(metrics)
 	ready.Register(server.PollerCheck(agamemnonPoller, agamemnonReadyMaxAge))
-	go agamemnonPoller.Start(ctx, cfg.PollAgamemnonMs)
+	go agamemnonPoller.Start(ctx, cfg.PollAgamemnon)
 
 	// Start NATS monitoring poller (varz + jsz every 5s).
 	natsPoller := poller.NewNATSPoller(cfg, cache)

--- a/dashboard/go.mod
+++ b/dashboard/go.mod
@@ -2,7 +2,7 @@ module github.com/HomericIntelligence/atlas
 
 go 1.23.0
 
-toolchain go1.24.2
+toolchain go1.25.8
 
 require (
 	github.com/a-h/templ v0.3.1001

--- a/dashboard/internal/catalog/probe.go
+++ b/dashboard/internal/catalog/probe.go
@@ -101,7 +101,7 @@ func doProbe(ctx context.Context, client *http.Client, host HostAddr, svc Servic
 		resp, doErr := client.Do(req)
 		if doErr == nil {
 			ok = resp.StatusCode < 400
-			resp.Body.Close()
+			_ = resp.Body.Close()
 		}
 	}
 

--- a/dashboard/internal/config/config.go
+++ b/dashboard/internal/config/config.go
@@ -34,7 +34,11 @@ type Config struct {
 	AuthUser           string
 	AuthPass           string
 	AuthBearerToken    string
-	PollAgamemnonMs    time.Duration
+	// PollAgamemnon is the interval between Agamemnon poller cycles. Sourced
+	// from ATLAS_POLL_AGAMEMNON_MS (named with the "Ms" suffix in the env
+	// var to communicate the unit; the field is a time.Duration so the
+	// suffix is dropped on the Go side per staticcheck ST1011).
+	PollAgamemnon      time.Duration
 }
 
 func getenv(key, def string) string {
@@ -50,7 +54,7 @@ func getenv(key, def string) string {
 // Defaults of note:
 //   - AuthMode defaults to "bearer" (fail-secure). An explicit ATLAS_AUTH_MODE=none
 //     is required to disable auth, and Validate logs a warning when that happens.
-//   - PollAgamemnonMs defaults to 2000ms.
+//   - PollAgamemnon defaults to 2000ms (env: ATLAS_POLL_AGAMEMNON_MS).
 func Load() *Config {
 	logLevelStr := getenv("ATLAS_LOG_LEVEL", "info")
 	var logLevel slog.Level
@@ -86,7 +90,7 @@ func Load() *Config {
 		AuthUser:           getenv("ATLAS_AUTH_USER", ""),
 		AuthPass:           getenv("ATLAS_AUTH_PASS", ""),
 		AuthBearerToken:    getenv("ATLAS_AUTH_BEARER_TOKEN", ""),
-		PollAgamemnonMs:    time.Duration(pollMs) * time.Millisecond,
+		PollAgamemnon:      time.Duration(pollMs) * time.Millisecond,
 	}
 }
 

--- a/dashboard/internal/handlers/detail.go
+++ b/dashboard/internal/handlers/detail.go
@@ -39,7 +39,7 @@ func (h *HostsHandler) AgentDetail(w http.ResponseWriter, r *http.Request) {
 
 	history := h.cache.GetAgentEvents(id)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	templates.AgentDetailPage(*found, task, history).Render(r.Context(), w) //nolint:errcheck
+	renderTempl(w, r, templates.AgentDetailPage(*found, task, history), "/agents/{id}")
 }
 
 // TaskDetail handles GET /tasks/{id}.
@@ -62,5 +62,5 @@ func (h *HostsHandler) TaskDetail(w http.ResponseWriter, r *http.Request) {
 
 	history := h.cache.GetAgentEvents(found.AssigneeID)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	templates.TaskDetailPage(*found, history).Render(r.Context(), w) //nolint:errcheck
+	renderTempl(w, r, templates.TaskDetailPage(*found, history), "/tasks/{id}")
 }

--- a/dashboard/internal/handlers/pages.go
+++ b/dashboard/internal/handlers/pages.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"log/slog"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,7 @@ func (h *HostsHandler) WithNATSURLs(dashURL, topURL, monURL string) *HostsHandle
 func (h *HostsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	views := store.BuildHostViews(h.cache)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	templates.HostsPage(views).Render(r.Context(), w) //nolint:errcheck
+	renderTempl(w, r, templates.HostsPage(views), "/hosts")
 }
 
 // Partial renders a single host card fragment for HTMX polling.
@@ -66,7 +67,7 @@ func (h *HostsHandler) Partial(w http.ResponseWriter, r *http.Request) {
 	for _, v := range views {
 		if v.Hostname == name {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			templates.HostCard(v).Render(r.Context(), w) //nolint:errcheck
+			renderTempl(w, r, templates.HostCard(v), "/partials/host/{name}")
 			return
 		}
 	}
@@ -81,7 +82,7 @@ func (h *HostsHandler) AgentsPage(w http.ResponseWriter, r *http.Request) {
 	hostF := r.URL.Query().Get("host")
 	filtered := filterAgents(agents, search, statusF, hostF)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	templates.AgentsPage(filtered, search, statusF, hostF).Render(r.Context(), w) //nolint:errcheck
+	renderTempl(w, r, templates.AgentsPage(filtered, search, statusF, hostF), "/agents")
 }
 
 // AgentsTablePartial renders only the table rows for HTMX partial updates.
@@ -93,7 +94,7 @@ func (h *HostsHandler) AgentsTablePartial(w http.ResponseWriter, r *http.Request
 	filtered := filterAgents(agents, search, statusF, hostF)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	for _, a := range filtered {
-		templates.AgentRow(a).Render(r.Context(), w) //nolint:errcheck
+		renderTempl(w, r, templates.AgentRow(a), "/partials/agents/table")
 	}
 }
 
@@ -135,7 +136,7 @@ func (h *HostsHandler) GrafanaPage(w http.ResponseWriter, r *http.Request) {
 		to = "now"
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	templates.GrafanaPage(grafana.KnownPanels, h.grafanaURL, from, to).Render(r.Context(), w) //nolint:errcheck
+	renderTempl(w, r, templates.GrafanaPage(grafana.KnownPanels, h.grafanaURL, from, to), "/grafana")
 }
 
 // NATSPage renders the /nats page with JetStream streams and connections.
@@ -143,19 +144,19 @@ func (h *HostsHandler) NATSPage(w http.ResponseWriter, r *http.Request) {
 	streams := h.cache.GetNATSStreams()
 	conns := h.cache.GetNATSConns()
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	templates.NATSPage(streams, conns, h.natsDashURL, h.natsTopURL, h.natsMon).Render(r.Context(), w) //nolint:errcheck
+	renderTempl(w, r, templates.NATSPage(streams, conns, h.natsDashURL, h.natsTopURL, h.natsMon), "/nats")
 }
 
 // NATSStreamsPartial renders only the streams table rows for HTMX partial updates.
 func (h *HostsHandler) NATSStreamsPartial(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	templates.NATSStreamRows(h.cache.GetNATSStreams()).Render(r.Context(), w) //nolint:errcheck
+	renderTempl(w, r, templates.NATSStreamRows(h.cache.GetNATSStreams()), "/partials/nats/streams")
 }
 
 // NATSConnsPartial renders only the connections table rows for HTMX partial updates.
 func (h *HostsHandler) NATSConnsPartial(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	templates.NATSConnRows(h.cache.GetNATSConns()).Render(r.Context(), w) //nolint:errcheck
+	renderTempl(w, r, templates.NATSConnRows(h.cache.GetNATSConns()), "/partials/nats/connections")
 }
 
 // MnemosynePage renders the /mnemosyne skill registry browser page.
@@ -163,9 +164,13 @@ func (h *HostsHandler) MnemosynePage(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query().Get("q")
 	var skills []mnemosyne.Skill
 	if h.mnemoReader != nil {
-		skills, _ = h.mnemoReader.Skills() //nolint:errcheck
+		var err error
+		skills, err = h.mnemoReader.Skills()
+		if err != nil {
+			slog.Warn("mnemosyne: failed to load skills", "err", err)
+		}
 	}
 	filtered := mnemosyne.Filter(skills, q)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	templates.MnemosynePage(filtered, q).Render(r.Context(), w) //nolint:errcheck
+	renderTempl(w, r, templates.MnemosynePage(filtered, q), "/mnemosyne")
 }

--- a/dashboard/internal/handlers/partials.go
+++ b/dashboard/internal/handlers/partials.go
@@ -1,7 +1,8 @@
 package handlers
 
 import (
-	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -16,11 +17,15 @@ func (h *HostsHandler) MnemosyneSearch(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query().Get("q")
 	var skills []mnemosyne.Skill
 	if h.mnemoReader != nil {
-		skills, _ = h.mnemoReader.Skills() //nolint:errcheck
+		var err error
+		skills, err = h.mnemoReader.Skills()
+		if err != nil {
+			slog.Warn("mnemosyne: failed to load skills", "err", err, "route", "/partials/mnemosyne/search")
+		}
 	}
 	filtered := mnemosyne.Filter(skills, q)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	templates.SkillList(filtered).Render(r.Context(), w) //nolint:errcheck
+	renderTempl(w, r, templates.SkillList(filtered), "/partials/mnemosyne/search")
 }
 
 // MnemosyneSkillBody renders the markdown body of a skill as HTML.
@@ -31,17 +36,28 @@ func (h *HostsHandler) MnemosyneSkillBody(w http.ResponseWriter, r *http.Request
 		http.NotFound(w, r)
 		return
 	}
-	skills, _ := h.mnemoReader.Skills() //nolint:errcheck
+	skills, err := h.mnemoReader.Skills()
+	if err != nil {
+		slog.Warn("mnemosyne: failed to load skills", "err", err, "route", "/partials/mnemosyne/skill/{name}")
+		http.Error(w, "skills unavailable", http.StatusServiceUnavailable)
+		return
+	}
 	for _, s := range skills {
 		if s.Name == name {
 			html, err := mnemosyne.RenderMarkdown(s.Body)
 			if err != nil {
+				slog.Warn("mnemosyne: render failed", "err", err, "skill", name)
 				http.Error(w, "render error", http.StatusInternalServerError)
 				return
 			}
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			// Safe: goldmark renders with Unsafe=false (raw HTML stripped)
-			fmt.Fprint(w, html) //nolint:errcheck
+			// Safe: goldmark renders with Unsafe=false (raw HTML stripped).
+			// We use io.WriteString rather than fmt.Fprint so the bytes-written
+			// error is explicit; client-disconnect during a partial is normal
+			// and demoted to debug.
+			if _, werr := io.WriteString(w, html); werr != nil && !isClientDisconnect(werr) {
+				slog.Warn("mnemosyne: write skill body failed", "err", werr, "skill", name)
+			}
 			return
 		}
 	}

--- a/dashboard/internal/handlers/render.go
+++ b/dashboard/internal/handlers/render.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"syscall"
+)
+
+// templComponent matches the subset of templ.Component we need without
+// importing the templ runtime package directly here. Every templ-generated
+// _templ.go produces values that implement this method.
+type templComponent interface {
+	Render(ctx context.Context, w io.Writer) error
+}
+
+// renderTempl renders c into w and logs render failures. By the time we call
+// Render the headers are already written and committed, so we cannot recover
+// with a clean http.Error — the client may see a truncated page. This helper
+// captures the structured log we want plus distinguishes ordinary client
+// disconnects (broken pipe / reset) from genuine template errors so operators
+// don't see a flood of WARN-level noise on healthy traffic.
+func renderTempl(w http.ResponseWriter, r *http.Request, c templComponent, route string) {
+	if err := c.Render(r.Context(), w); err != nil {
+		// Client-disconnect family — extremely common on SSE-adjacent
+		// pages and HTMX swaps when the user navigates away mid-flush.
+		// Demote to debug so /var/log doesn't drown in noise.
+		if isClientDisconnect(err) {
+			slog.Debug("template render: client disconnect", "route", route, "err", err)
+			return
+		}
+		slog.Warn("template render failed", "route", route, "err", err)
+	}
+}
+
+func isClientDisconnect(err error) bool {
+	switch {
+	case errors.Is(err, syscall.EPIPE),
+		errors.Is(err, syscall.ECONNRESET),
+		errors.Is(err, context.Canceled),
+		errors.Is(err, context.DeadlineExceeded):
+		return true
+	}
+	return false
+}

--- a/dashboard/internal/handlers/sse_test.go
+++ b/dashboard/internal/handlers/sse_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -48,7 +49,7 @@ func sseLines(t *testing.T, r io.ReadCloser, frames int) []string {
 			}
 		}
 	}
-	if err := scanner.Err(); err != nil && err != io.EOF {
+	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
 		t.Fatalf("sseLines: scanner error: %v", err)
 	}
 	return lines
@@ -91,7 +92,7 @@ func TestSSEHeaders(t *testing.T) {
 		}
 	}
 	if resp != nil {
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -133,7 +134,7 @@ func TestSSEEventDelivery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Do: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Give the handler a moment to register the subscription before publishing.
 	time.Sleep(20 * time.Millisecond)
@@ -163,7 +164,7 @@ func TestSSEEventDelivery(t *testing.T) {
 			break
 		}
 	}
-	if err := scanner.Err(); err != nil && err != io.EOF {
+	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
 		t.Fatalf("scanner: %v", err)
 	}
 
@@ -203,7 +204,7 @@ func TestSSETopicFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Do: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	time.Sleep(20 * time.Millisecond)
 
@@ -261,7 +262,7 @@ func TestSSEReplay(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Do: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Read 2 complete SSE frames. Each frame: "event: ...\ndata: ...\n\n".
 	lines := sseLines(t, resp.Body, 2)
@@ -314,7 +315,7 @@ type blockingResponseWriter struct {
 }
 
 func (b *blockingResponseWriter) Write(p []byte) (int, error) {
-	<-b.ctx.Done() //nolint:gosimple // S1000: select with single case is intentional for readability
+	<-b.ctx.Done()
 	return 0, b.ctx.Err()
 }
 
@@ -379,19 +380,18 @@ func TestSSEConnectionClose(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Do: %v", err)
 	}
+	defer func() { _ = resp.Body.Close() }()
 
 	// Let the handler start streaming.
 	time.Sleep(30 * time.Millisecond)
 
-	// Track handler completion via a WaitGroup by sending a probe publish and
-	// watching the connection body drain. We close the connection by cancelling
-	// the request context.
+	// Track handler completion via a WaitGroup by draining the connection body
+	// in a goroutine. We close the connection by cancelling the request context.
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		io.Copy(io.Discard, resp.Body) //nolint:errcheck
-		resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
 	}()
 
 	// Cancel the request context — this simulates the client closing the connection.
@@ -436,7 +436,7 @@ func TestSSEMultipleTopics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Do: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	time.Sleep(20 * time.Millisecond)
 
@@ -510,7 +510,7 @@ func TestSSEHeartbeat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Do: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	scanner := bufio.NewScanner(resp.Body)
 	heartbeatSeen := make(chan struct{}, 1)

--- a/dashboard/internal/mnemosyne/reader.go
+++ b/dashboard/internal/mnemosyne/reader.go
@@ -59,13 +59,37 @@ func loadFromDir(dir string) ([]Skill, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Resolve the configured skills directory once so we can verify every
+	// candidate file resolves underneath it. This defends against an
+	// operator pointing ATLAS_MNEMOSYNE_SKILLS_DIR at a path that contains
+	// symlinks escaping the intended root.
+	rootAbs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+	rootAbs = filepath.Clean(rootAbs) + string(filepath.Separator)
+
 	var skills []Skill
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
 			continue
 		}
 		path := filepath.Join(dir, e.Name())
-		data, err := os.ReadFile(path)
+		// Containment check: the resolved absolute path must live under
+		// rootAbs. EvalSymlinks follows symlinks; if any link points outside
+		// the configured skills dir we skip the file rather than reading it.
+		resolved, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			continue
+		}
+		resolvedAbs, err := filepath.Abs(resolved)
+		if err != nil {
+			continue
+		}
+		if !strings.HasPrefix(resolvedAbs+string(filepath.Separator), rootAbs) {
+			continue
+		}
+		data, err := os.ReadFile(resolved) //nolint:gosec // resolved path verified to live under rootAbs above
 		if err != nil {
 			continue
 		}

--- a/dashboard/internal/poller/agamemnon.go
+++ b/dashboard/internal/poller/agamemnon.go
@@ -37,7 +37,7 @@ type tasksAPIResponse struct {
 
 // AgamemnonPoller polls the Agamemnon service for agent and task data.
 type AgamemnonPoller struct {
-	base
+	*base
 	cache *store.Cache
 	url   string
 }

--- a/dashboard/internal/poller/nats.go
+++ b/dashboard/internal/poller/nats.go
@@ -64,7 +64,7 @@ type connzEntry struct {
 
 // NATSPoller polls the NATS monitoring endpoints for server statistics.
 type NATSPoller struct {
-	base
+	*base
 	cache *store.Cache
 	url   string
 }

--- a/dashboard/internal/poller/poller.go
+++ b/dashboard/internal/poller/poller.go
@@ -45,8 +45,12 @@ type base struct {
 // newBase initialises a base with a no-op metrics sink. Callers should call
 // SetMetrics from the composition root (cmd/argus-dashboard/main.go) once the
 // real metrics object exists.
-func newBase(name string, client *http.Client) base {
-	b := base{name: name, client: client}
+//
+// Returns *base (pointer) because base contains a sync.RWMutex, which must
+// never be copied (govet copylocks). Concrete pollers (AgamemnonPoller,
+// NATSPoller) therefore embed *base, not base.
+func newBase(name string, client *http.Client) *base {
+	b := &base{name: name, client: client}
 	var sink MetricsSink = noopMetrics{}
 	b.metrics.Store(&sink)
 	return b
@@ -112,7 +116,7 @@ func (b *base) getJSON(ctx context.Context, url string, dst any) error {
 	if err != nil {
 		return fmt.Errorf("GET %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("GET %s: HTTP %d", url, resp.StatusCode)
 	}

--- a/dashboard/internal/server/routes.go
+++ b/dashboard/internal/server/routes.go
@@ -61,5 +61,5 @@ func (s *Server) handleLivez(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleOverview(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write(overviewHTML) //nolint:errcheck
+	_, _ = w.Write(overviewHTML)
 }

--- a/dashboard/internal/tailscale/api.go
+++ b/dashboard/internal/tailscale/api.go
@@ -49,7 +49,7 @@ func (a APISource) Devices(ctx context.Context) ([]Device, error) {
 	if err != nil {
 		return nil, fmt.Errorf("tailscale api: HTTP GET: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("tailscale api: unexpected status %d", resp.StatusCode)

--- a/dashboard/internal/tailscale/tailscale_test.go
+++ b/dashboard/internal/tailscale/tailscale_test.go
@@ -107,8 +107,22 @@ func TestCLISource_ParseError(t *testing.T) {
 	dir := t.TempDir()
 	fakeTailscale := dir + "/tailscale"
 	script := "#!/bin/sh\necho 'not valid json'\n"
-	if err := os.WriteFile(fakeTailscale, []byte(script), 0o755); err != nil {
+	// Write at 0o600 (owner read/write only — gosec G306 requires ≤0o600 on
+	// WriteFile), then add the execute bit via chmod so the shell can run
+	// it. Final mode 0o700: owner-only read/write/execute, no group/world
+	// access. This is strictly more secure than the prior 0o755.
+	if err := os.WriteFile(fakeTailscale, []byte(script), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
+	}
+	// 0o700 is the minimum mode that makes the test script executable. The
+	// file lives in t.TempDir() (per-test private directory, mode 0o700,
+	// owned by the test runner UID), and only the test runner needs to run
+	// it. No group/world bits at any point — strictly more secure than the
+	// prior 0o755. gosec G302 still flags any chmod above 0o600; that rule
+	// is incorrect here because it cannot model "this file MUST be
+	// executable for the test to work."
+	if err := os.Chmod(fakeTailscale, 0o700); err != nil { //nolint:gosec // see comment above
+		t.Fatalf("Chmod: %v", err)
 	}
 
 	// Put our fake script at the front of PATH.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,14 +197,19 @@ services:
       ATLAS_GRAFANA_URL: "http://argus-grafana:3000"
       ATLAS_LOKI_URL: "http://argus-loki-proxy:80"
       ATLAS_PROMETHEUS_URL: "http://argus-prometheus:9090"
-      ATLAS_AUTH_MODE: ${ATLAS_AUTH_MODE:-none}
+      # Atlas defaults to bearer auth and refuses to start without
+      # ATLAS_AUTH_BEARER_TOKEN. Operators who genuinely need an
+      # unauthenticated dashboard (single-host dev, fully isolated
+      # network) must set ATLAS_AUTH_MODE=none explicitly in their .env.
+      ATLAS_AUTH_MODE: ${ATLAS_AUTH_MODE:-bearer}
       ATLAS_AUTH_BEARER_TOKEN: ${ATLAS_AUTH_BEARER_TOKEN:-}
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3002/healthz"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
-      start_period: 5s
+    # No container-level healthcheck: the Atlas image is built on
+    # gcr.io/distroless/static-debian12:nonroot which has no shell,
+    # no wget, no curl, and no busybox to invoke. Operators should rely
+    # on Docker's process-up signal plus external HTTP probes against
+    # http://<host>:3002/livez (always 200 if the process is up) for
+    # liveness and /readyz (200 only when every component is loaded,
+    # enabled, and reporting valid results without error) for readiness.
     networks:
       - argus
     deploy:


### PR DESCRIPTION
## Summary

Closes the v0.2.0 packaging blockers (audit S6 / S7 / S8 / S12) and
absorbs every CRITICAL/MAJOR finding the new linter set (golangci-lint v2
with `errorlint` + `bodyclose`) surfaces along the way. After this merges,
v0.2.0 is genuinely shippable: tag → release.yml → GHCR
`ghcr.io/homericintelligence/atlas:v0.2.0` + `:latest` (multi-arch).

### Image
* `dashboard/Dockerfile` — multi-stage `golang:1.25-alpine` builder →
  `gcr.io/distroless/static-debian12:nonroot`. CGO_ENABLED=0,
  -trimpath, -ldflags injects version, USER 65532, OCI labels. Final
  image **~14.9 MB**.
* `dashboard/.dockerignore` — keeps the build context lean.

Verified locally:
* `podman build` succeeds; image starts; `/livez`=200,
  `/metrics` (no auth) =401, `/metrics` (bearer) =200,
  `/readyz` (bearer) =503 with named components when upstreams down.

### Release pipeline
* `release.yml` — adds `publish-atlas-image` job: buildx multi-arch
  (`linux/amd64,linux/arm64`), GHCR auth via `GITHUB_TOKEN`, publishes
  `:<tag>` and `:latest`, SBOM + provenance attestations.

### Supply chain
* `ci.yml` — adds `govulncheck`, coverage profile artefact, separate
  integration-tests step, kept Docker build verify (now actually finds
  a Dockerfile).
* `dependabot.yml` — adds `gomod` ecosystem on `/dashboard/` (with
  prometheus/* and nats-io/* grouped); adds docker on `/dashboard/`;
  adds `github-actions` on `/`.

### Toolchain bump (Go 1.24 → 1.25)
Resolves **6 stdlib CVEs** govulncheck reports against 1.24
(net/url IPv6 parse, archive/tar, encoding/asn1, …). Local govulncheck
on 1.25: **`No vulnerabilities found`**.

* `go.mod` `toolchain go1.25.8`
* `Dockerfile` `GO_VERSION=1.25-alpine`
* `.golangci.yml` migrated to v2 schema, removed G401/G501 exclusions

### Lint-driven correctness fixes
The new lint config surfaced **four real bugs** the prior config missed.
All fixed:

* `internal/poller/poller.go` — `newBase` now returns `*base`. `base`
  contains `sync.RWMutex`; returning by value would copy the lock
  (govet copylocks — silent races in production).
* `internal/handlers/sse_test.go` — `defer resp.Body.Close()` →
  `defer func(){ _ = resp.Body.Close() }()`; `err != io.EOF` →
  `errors.Is(err, io.EOF)`; bodyclose-flagged `Do(req)` defers Close
  immediately; dead `//nolint:gosimple` removed.
* `internal/{catalog,poller,tailscale}/*` — explicit
  `_ = resp.Body.Close()` everywhere.

### Handler render-error swallowing → real logging
Audit S4 MAJOR called out **11 sites** swallowing template render errors
via `//nolint:errcheck`. New helper `internal/handlers/render.go` provides
`renderTempl(w, r, c, route)` that distinguishes client-disconnect
(broken pipe / context cancel — `slog.Debug`) from genuine template
errors (`slog.Warn`). Every handler now uses it.

### Security hardening
* `internal/mnemosyne/reader.go` — adds containment check before
  `os.ReadFile`: every candidate path's resolved absolute (after
  `EvalSymlinks`) must live under the configured skills root. Defends
  against an operator pointing `ATLAS_MNEMOSYNE_SKILLS_DIR` at a tree
  with escape symlinks (gosec G304).
* `internal/tailscale/tailscale_test.go` — gosec G306: WriteFile at
  0o600 then chmod 0o700 (was 0o755). Strictly more secure.
* `docker-compose.yml` — removes broken wget healthcheck (distroless has
  no wget); changes `ATLAS_AUTH_MODE` default to `bearer` (operators
  must explicitly opt-out of auth in their `.env`).
* `.env.example` — adds `ATLAS_AUTH_MODE` / `ATLAS_AUTH_BEARER_TOKEN`
  with `openssl rand -hex 32` recipe.

### Naming
* `config.PollAgamemnonMs` → `PollAgamemnon` (staticcheck ST1011: no
  unit suffix on `time.Duration`). Env var keeps the suffix.

## Audit-finding refs

* S6 CRITICAL #1 (CI docker build with no Dockerfile)
* S6 CRITICAL #2 (release.yml does no docker push)
* S6 MAJOR (no deploy strategy / security scans don't gate)
* S7 MAJOR (no govulncheck / Dependabot no gomod)
* S8 CRITICAL (gosec G401/G501 excluded)
* S8 MAJOR (no Dockerfile / no container hardening)
* S4 MAJOR (render errors silently dropped × 11)
* S4 MAJOR (resp.Body.Close errors unchecked × 6+)
* S12 CRITICAL (no Dockerfile, no release automation, version mismatch)

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race ./...` all unit pass
- [x] `go test -race -tags=integration ./tests/integration/...` pass
- [x] `golangci-lint v2 run ./...` — **0 issues**
- [x] `govulncheck ./...` — **No vulnerabilities found**
- [x] `podman build -t atlas:dev .` succeeds, 14.9 MB
- [x] Smoke test: /livez=200, /metrics(noauth)=401, /readyz(bearer)=503
- [ ] CI green
- [ ] After merge: tag v0.2.0 → release pipeline auto-publishes image
- [ ] Bump Odysseus submodule pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)