### PR TITLE
ci: add security/gosec as a standalone required check

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -215,6 +215,42 @@ jobs:
           scan-ref: .
           exit-code: 0
 
+  security-gosec:
+    name: security/gosec
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - name: Skip if no Go module
+        id: detect
+        run: |
+          if [ ! -f dashboard/go.mod ]; then
+            echo "::notice::No dashboard/go.mod, skipping gosec"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Set up Go
+        if: steps.detect.outputs.skip == 'false'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: dashboard/go.mod
+          cache-dependency-path: dashboard/go.sum
+      # Run gosec as a standalone, branch-protectable check separate from
+      # the in-process golangci-lint integration. golangci-lint already
+      # enables the `gosec` linter (see dashboard/.golangci.yml) and that
+      # remains the fast developer-loop check; this job exposes the same
+      # findings as their own required status so branch-protection rulesets
+      # can gate explicitly on `security/gosec` rather than burying it
+      # inside an aggregated lint check.
+      - name: Run gosec
+        if: steps.detect.outputs.skip == 'false'
+        uses: securego/gosec@4a3bd8af174872c778439083ded7adbf3747e770  # v2.26.1
+        with:
+          args: ./dashboard/...
+
   security-secrets-scan:
     name: security/secrets-scan
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

- Adds `security/gosec` as its own required-check job in `_required.yml`, alongside the existing `security/dependency-scan` (Trivy) and `security/secrets-scan` (Gitleaks).
- The §8 audit finding "no gosec SAST" was partially incorrect — gosec is enabled inside `dashboard/.golangci.yml` and runs via the `ci.yml` golangci-lint step. But it had no separate status name, so branch-protection rulesets couldn't gate on a security-specific signal. This makes it visible.
- Pinned to `v2.26.1` (current latest) by commit SHA, matching the SHA-pinning convention used elsewhere in the workflow.

## Why bother if golangci-lint already runs gosec?

Two reasons:
1. **Branch-protection clarity.** The Section 6 finding (only `Validate configs` required on main) is being addressed separately, but when that ruleset is restored, a `security/gosec` named check is what an auditor expects to see required — not a generic `lint` umbrella.
2. **Failure visibility.** If a future PR removes `gosec` from the golangci-lint enabled list (it's just a YAML edit), the umbrella check stays green and the regression slips by silently. A standalone job fails loudly.

In-process golangci-lint stays as the fast developer-loop check — it's faster and gives feedback inside the IDE.

## Test plan

- [x] YAML syntax validates (`yaml.safe_load`)
- [x] `_required.yml` passes the GitHub Actions schema (`check-jsonschema`)
- [x] Action is SHA-pinned to a real release (`v2.26.1` → commit `4a3bd8af`)
- [x] **Local gosec run on the dashboard tree returns 0 issues** (54 files / 5,730 lines) — won't land in a failing state
- [x] Skips cleanly if `dashboard/go.mod` is absent (mirrors `pixi-check` / `justfile-check` patterns)
- [ ] CI green
- [ ] Auto-merge fires once #457 lands and rebases this branch

## Stacking

Branched off `fix/atlas-v0.2.1-security` (PR #457) so it merges cleanly behind it. Targeting that branch directly; once #457 squash-merges to `main`, this will need a rebase or re-target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)