### PR TITLE
fix(security): cap upstream JSON/CLI response sizes (16 MiB)

### DIFF
--- a/dashboard/internal/poller/cap_test.go
+++ b/dashboard/internal/poller/cap_test.go
@@ -1,0 +1,75 @@
+package poller
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestGetJSON_BoundedByMaxResponseBytes asserts that an upstream which
+// streams more than maxResponseBytes does NOT cause Atlas to allocate
+// unbounded memory. This is the regression for the §8 audit finding
+// "no request-body size limit on JSON decoders" — without this cap a
+// hostile or runaway Agamemnon/Nestor/NATS-mon endpoint could OOM Atlas
+// (compose memory limit is 128 MiB) by streaming a multi-GB response.
+//
+// We swap maxResponseBytes down to a few hundred bytes so the test stays
+// fast and deterministic; the production value (16 MiB) is enforced by
+// the same code path.
+func TestGetJSON_BoundedByMaxResponseBytes(t *testing.T) {
+	prev := maxResponseBytes
+	maxResponseBytes = 256
+	t.Cleanup(func() { maxResponseBytes = prev })
+
+	// Server streams a JSON array of stringified zeros that is much
+	// larger than the cap (~10 KiB > 256 B).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[`))
+		_, _ = w.Write([]byte(`"`))
+		_, _ = w.Write([]byte(strings.Repeat("0", 10000)))
+		_, _ = w.Write([]byte(`"]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	b := newBase("test-source", &http.Client{Timeout: 2 * time.Second})
+
+	var dst []string
+	err := b.getJSON(context.Background(), srv.URL, &dst)
+	if err == nil {
+		t.Fatalf("getJSON must error when upstream exceeds cap; got nil and dst=%v", dst)
+	}
+	if !strings.Contains(err.Error(), "decode") {
+		t.Fatalf("error must come from the decode path; got: %v", err)
+	}
+	// The dst slice must NOT have been populated with the giant string.
+	// (json.Decoder may have partially populated it on truncated input —
+	// the safety property is that we did not allocate the entire 10KiB
+	// payload, which is implicit in io.LimitReader returning EOF early.
+	// We assert the surface property: the decoder errored out.)
+}
+
+// TestGetJSON_AcceptsPayloadsUnderCap is the positive case — a normal-sized
+// JSON response decodes fine. Locks in that the LimitReader does not
+// regress correct behaviour on realistic payloads.
+func TestGetJSON_AcceptsPayloadsUnderCap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`["alpha","beta","gamma"]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	b := newBase("test-source", &http.Client{Timeout: 2 * time.Second})
+
+	var dst []string
+	if err := b.getJSON(context.Background(), srv.URL, &dst); err != nil {
+		t.Fatalf("getJSON on small payload must succeed; got %v", err)
+	}
+	if len(dst) != 3 || dst[0] != "alpha" {
+		t.Fatalf("unexpected decoded value: %#v", dst)
+	}
+}

--- a/dashboard/internal/poller/poller.go
+++ b/dashboard/internal/poller/poller.go
@@ -4,11 +4,28 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
 )
+
+// maxResponseBytes caps how much we will read from any upstream JSON
+// endpoint before giving up. Defends against a compromised or hostile
+// upstream (Agamemnon, Nestor, NATS monitoring) streaming a multi-GB
+// response and OOM'ing Atlas (the compose memory limit is 128 MiB).
+//
+// 16 MiB is an order of magnitude above any realistic /v1/agents,
+// /varz, /jsz?detail=1, or /connz payload — even a 1k-stream JetStream
+// cluster's /jsz?detail=1 fits comfortably inside it — while staying
+// well below the OOM threshold.
+//
+// Declared as a var (not a const) so tests can lower it without staging
+// a 16 MiB fake response. Production paths must NEVER mutate this; if a
+// future deployment legitimately needs a higher ceiling, prefer adding a
+// config knob over runtime mutation.
+var maxResponseBytes int64 = 16 << 20 // 16 MiB
 
 // MetricsSink is the metric-recording surface a poller needs. *server.AtlasMetrics
 // satisfies this interface; tests can pass a no-op or a counting fake. Pollers
@@ -120,8 +137,12 @@ func (b *base) getJSON(ctx context.Context, url string, dst any) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("GET %s: HTTP %d", url, resp.StatusCode)
 	}
-	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
-		return fmt.Errorf("decode %s: %w", url, err)
+	// Cap how much we will pull from the upstream before failing. See
+	// maxResponseBytes above for the rationale; io.LimitReader returns EOF
+	// at the cap, which the JSON decoder surfaces as a syntax error if the
+	// payload was actually truncated mid-document.
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(dst); err != nil {
+		return fmt.Errorf("decode %s (cap %d bytes): %w", url, maxResponseBytes, err)
 	}
 	return nil
 }

--- a/dashboard/internal/tailscale/api.go
+++ b/dashboard/internal/tailscale/api.go
@@ -4,9 +4,25 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
+
+// maxResponseBytes caps how much we will read from any external Tailscale
+// source (HTTP API or `tailscale status --json` subprocess) before giving
+// up. Defends Atlas against an attacker-controlled or compromised
+// Tailscale plane streaming a multi-GB response and exhausting memory
+// (compose limit is 128 MiB).
+//
+// 16 MiB is roughly two orders of magnitude above any realistic tailnet
+// device list (a 100-device tailnet API response is ~50 KiB) while
+// staying well below the OOM threshold. Matches the equivalent cap in
+// internal/poller for upstream JSON consistency.
+//
+// Declared as a var (not a const) so tests can lower it without staging
+// a 16 MiB fake response. Production paths must NEVER mutate this.
+var maxResponseBytes int64 = 16 << 20 // 16 MiB
 
 // apiResponse mirrors the Tailscale v2 API response for device listing.
 type apiResponse struct {
@@ -56,8 +72,8 @@ func (a APISource) Devices(ctx context.Context) ([]Device, error) {
 	}
 
 	var result apiResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("tailscale api: parse JSON: %w", err)
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(&result); err != nil {
+		return nil, fmt.Errorf("tailscale api: parse JSON (cap %d bytes): %w", maxResponseBytes, err)
 	}
 
 	devices := make([]Device, 0, len(result.Devices))

--- a/dashboard/internal/tailscale/cap_test.go
+++ b/dashboard/internal/tailscale/cap_test.go
@@ -1,0 +1,108 @@
+package tailscale
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// This file lives in package tailscale (not tailscale_test) so it can
+// override the package-private maxResponseBytes for fast, deterministic
+// regression coverage of the §8 audit cap. tailscale_test.go is an
+// external test package and cannot reach unexported symbols.
+
+// TestAPISource_BoundedByMaxResponseBytes asserts that an oversized
+// upstream response from the Tailscale Central API does not allow Atlas
+// to allocate unbounded memory. Hostile/compromised plane scenario.
+func TestAPISource_BoundedByMaxResponseBytes(t *testing.T) {
+	prev := maxResponseBytes
+	maxResponseBytes = 256
+	t.Cleanup(func() { maxResponseBytes = prev })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Stream ~10 KiB of valid-looking device array — well over the cap.
+		_, _ = w.Write([]byte(`{"devices":[{"hostname":"`))
+		_, _ = w.Write([]byte(strings.Repeat("a", 10000)))
+		_, _ = w.Write([]byte(`","addresses":["100.100.0.1"],"online":true,"lastSeen":"2026-01-01T00:00:00Z"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	src := APISource{
+		APIKey:  "test-key",
+		Tailnet: "example.com",
+		HTTPClient: &http.Client{
+			Transport: rewriteHostTransport{base: http.DefaultTransport, target: srv.URL},
+		},
+	}
+
+	if _, err := src.Devices(context.Background()); err == nil {
+		t.Fatalf("APISource.Devices must error when upstream exceeds cap; got nil")
+	} else if !strings.Contains(err.Error(), "parse JSON") {
+		t.Fatalf("error must come from the JSON parse path; got: %v", err)
+	}
+}
+
+// TestCLISource_BoundedByMaxResponseBytes is the subprocess equivalent.
+// We arrange for `tailscale status --json` to emit a multi-KiB JSON
+// document, lower the cap, and assert that ReadAll returns truncated
+// content that fails to JSON-decode — proving io.LimitReader is active.
+func TestCLISource_BoundedByMaxResponseBytes(t *testing.T) {
+	prev := maxResponseBytes
+	maxResponseBytes = 256
+	t.Cleanup(func() { maxResponseBytes = prev })
+
+	dir := t.TempDir()
+	fakeTailscale := dir + "/tailscale"
+	// Build a >cap-sized JSON payload in Go so we don't have to wrestle
+	// with shell quoting. The document is structurally valid JSON; the
+	// only reason it fails to decode in the test is that LimitReader
+	// truncated it after maxResponseBytes.
+	bigName := strings.Repeat("x", 4000)
+	bigJSON := `{"Self":{"HostName":"` + bigName + `","TailscaleIPs":["100.0.0.1"],"Online":true,"LastSeen":"2026-01-01T00:00:00Z"},"Peer":{}}`
+	// `cat <<'EOF'` heredoc keeps the shell from interpreting any of the
+	// JSON content. Single-quoted EOF marker disables variable expansion.
+	script := "#!/bin/sh\ncat <<'EOF'\n" + bigJSON + "\nEOF\n"
+	if err := os.WriteFile(fakeTailscale, []byte(script), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Chmod(fakeTailscale, 0o700); err != nil { //nolint:gosec // exec bit required for test
+		t.Fatalf("Chmod: %v", err)
+	}
+
+	t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
+	if p, err := exec.LookPath("tailscale"); err != nil || p != fakeTailscale {
+		t.Skipf("fake tailscale not first in PATH (got %q, %v); skipping", p, err)
+	}
+
+	src := CLISource{}
+	if _, err := src.Devices(context.Background()); err == nil {
+		t.Fatalf("CLISource.Devices must error when subprocess output exceeds cap; got nil")
+	} else if !strings.Contains(err.Error(), "parse JSON") {
+		t.Fatalf("error must come from the JSON parse path (proves cap fired before decode); got: %v", err)
+	}
+}
+
+// rewriteHostTransport is a tiny test helper duplicated from
+// tailscale_test.go because that file lives in the external test package.
+// It rewrites the outgoing request's scheme+host to point at the test
+// server, leaving the path untouched.
+type rewriteHostTransport struct {
+	base   http.RoundTripper
+	target string
+}
+
+func (rt rewriteHostTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	parsed, err := http.NewRequest(http.MethodGet, rt.target, nil)
+	if err != nil {
+		return nil, err
+	}
+	cloned.URL.Scheme = parsed.URL.Scheme
+	cloned.URL.Host = parsed.URL.Host
+	return rt.base.RoundTrip(cloned)
+}

--- a/dashboard/internal/tailscale/cli.go
+++ b/dashboard/internal/tailscale/cli.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os/exec"
 	"time"
 )
@@ -32,14 +33,31 @@ func (c CLISource) Devices(ctx context.Context) ([]Device, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "tailscale", "status", "--json")
-	out, err := cmd.Output()
+	// We deliberately do NOT use cmd.Output() — it reads the subprocess
+	// stdout into an unbounded buffer, which would let a hostile or
+	// runaway tailscale binary stream gigabytes into Atlas (compose memory
+	// limit is 128 MiB). StdoutPipe + io.LimitReader caps the read at
+	// maxResponseBytes. See the constant in api.go for rationale.
+	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("tailscale cli: exec failed: %w", err)
+		return nil, fmt.Errorf("tailscale cli: stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("tailscale cli: start: %w", err)
+	}
+	out, readErr := io.ReadAll(io.LimitReader(stdout, maxResponseBytes))
+	// Always Wait so we reap the subprocess regardless of read outcome.
+	waitErr := cmd.Wait()
+	if readErr != nil {
+		return nil, fmt.Errorf("tailscale cli: read stdout (cap %d bytes): %w", maxResponseBytes, readErr)
+	}
+	if waitErr != nil {
+		return nil, fmt.Errorf("tailscale cli: exec failed: %w", waitErr)
 	}
 
 	var status cliStatus
 	if err := json.Unmarshal(out, &status); err != nil {
-		return nil, fmt.Errorf("tailscale cli: parse JSON: %w", err)
+		return nil, fmt.Errorf("tailscale cli: parse JSON (cap %d bytes): %w", maxResponseBytes, err)
 	}
 
 	devices := make([]Device, 0, 1+len(status.Peers))


### PR DESCRIPTION
## Summary

- Wraps every upstream JSON decoder in `io.LimitReader` with a **16 MiB cap**.
- Replaces `cmd.Output()` (unbounded subprocess buffer) in the Tailscale CLI source with `StdoutPipe` + `io.LimitReader` + `io.ReadAll`, plus an unconditional `Wait()` to reap the subprocess.
- Closes the §8 audit MAJOR finding *"no request-body size limit on JSON decoders"*. Without this cap a hostile or runaway upstream — Agamemnon, Nestor, NATS monitoring, the Tailscale Central API, or the local `tailscale status --json` subprocess — could stream a multi-GB response and exhaust Atlas's 128 MiB compose memory limit.

## Sites

| File | Change |
|---|---|
| `internal/poller/poller.go` | `getJSON` wraps `resp.Body` in `io.LimitReader(_, maxResponseBytes)` before `json.NewDecoder.Decode`. Covers both Agamemnon poller endpoints and all three NATS poller endpoints (`/varz`, `/jsz?detail=1`, `/connz`). |
| `internal/tailscale/api.go` | Same `io.LimitReader` wrap on the Tailscale Central API decode. |
| `internal/tailscale/cli.go` | `cmd.Output()` → `cmd.StdoutPipe()` + `io.ReadAll(io.LimitReader(...))`. Always `Wait()` so no zombies. |

## Why 16 MiB?

Roughly two orders of magnitude above any realistic payload (a 1k-stream JetStream cluster's `/jsz?detail=1` fits comfortably; a 100-device tailnet API response is ~50 KiB) while staying well below the OOM threshold. Single value across both packages — easy to reason about.

`maxResponseBytes` is a `var` (not a `const`) so tests can lower it without staging a 16 MiB fake response. The doc-comment explicitly says production paths must never mutate it; if a future deployment legitimately needs more, the right answer is a config knob, not runtime mutation.

## Test plan

- [x] `go test -race -count=1 ./...` — all 11 packages pass with the four new regression tests in place
- [x] `TestGetJSON_BoundedByMaxResponseBytes` — server streams 10 KiB into a 256-byte cap; `getJSON` errors at the decode step
- [x] `TestGetJSON_AcceptsPayloadsUnderCap` — positive case; small payloads still decode
- [x] `TestAPISource_BoundedByMaxResponseBytes` — same shape for Tailscale HTTP API
- [x] `TestCLISource_BoundedByMaxResponseBytes` — fake `tailscale status --json` script emits >cap output via `cat<<'EOF'` heredoc; `CLISource` errors at the decode step
- [x] `gosec ./internal/poller/... ./internal/tailscale/...` is clean
- [ ] CI green
- [ ] Auto-merge fires once #457 lands and rebases this branch

## Stacking

Branched off `fix/atlas-v0.2.1-security` (PR #457) so it merges cleanly behind it. Independent of #458 (gosec required-check); both target the same base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)