### PR TITLE
fix(security): log auth failures via slog.Warn

### DIFF
--- a/dashboard/internal/server/auth.go
+++ b/dashboard/internal/server/auth.go
@@ -3,6 +3,7 @@ package server
 import (
 	"crypto/subtle"
 	"encoding/base64"
+	"log/slog"
 	"net/http"
 	"strings"
 )
@@ -40,12 +41,14 @@ func Middleware(mode AuthMode, user, pass, bearerToken string) func(http.Handler
 				// ATLAS_AUTH_MODE=none and config.Validate logs a warning.
 			case AuthBasic:
 				if !checkBasic(r, user, pass) {
+					logAuthFailure(r, "basic", basicFailureReason(r))
 					w.Header().Set("WWW-Authenticate", `Basic realm="Atlas"`)
 					http.Error(w, "Unauthorized", http.StatusUnauthorized)
 					return
 				}
 			case AuthBearer:
 				if !checkBearer(r, bearerToken) {
+					logAuthFailure(r, "bearer", bearerFailureReason(r, bearerToken))
 					http.Error(w, "Unauthorized", http.StatusUnauthorized)
 					return
 				}
@@ -55,12 +58,80 @@ func Middleware(mode AuthMode, user, pass, bearerToken string) func(http.Handler
 				// something bypassed Validate (e.g. a future code path that
 				// constructs Server with a hand-built Config), and we'd
 				// rather 401 every request than open the dashboard.
+				logAuthFailure(r, string(mode), "unknown-mode")
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// logAuthFailure emits one slog.Warn per failed auth event so security
+// monitoring (Loki alert rules, SIEM ingest) can detect scanners,
+// brute-force attempts, and misconfigured clients. The line carries
+// enough context for triage but NEVER the offered credential or token —
+// see also the access_log middleware (path-only logging) which already
+// strips query strings to keep SSE bearer tokens out of stdout.
+//
+// Fields:
+//   - mode    : the configured auth scheme (basic / bearer / unknown-mode-string)
+//   - reason  : a stable discriminator (missing-header / wrong-creds /
+//               wrong-token / empty-configured-token / unknown-mode)
+//   - method  : HTTP method, useful for distinguishing browsers from CLIs
+//   - path    : URL path only (no query string — see access_log for why)
+//   - remote  : r.RemoteAddr; reflects middleware.RealIP rewrites if any
+//
+// At scanner volumes this fires often. That is the point. If a future
+// operator wants throttling, the right place to add it is here, not by
+// reverting to silent 401s.
+func logAuthFailure(r *http.Request, mode, reason string) {
+	slog.Default().Warn("auth failure",
+		"mode", mode,
+		"reason", reason,
+		"method", r.Method,
+		"path", r.URL.Path,
+		"remote", r.RemoteAddr,
+	)
+}
+
+// basicFailureReason classifies why a basic-auth check failed without
+// disclosing whether the username or password was the wrong half. The
+// distinction between a missing/malformed header and a comparison
+// mismatch is operationally useful (scanners vs typos) and not a
+// confidentiality leak.
+func basicFailureReason(r *http.Request) string {
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		return "missing-header"
+	}
+	if !strings.HasPrefix(authHeader, "Basic ") {
+		return "wrong-scheme"
+	}
+	encoded := strings.TrimPrefix(authHeader, "Basic ")
+	if _, err := base64.StdEncoding.DecodeString(encoded); err != nil {
+		return "malformed-base64"
+	}
+	return "wrong-creds"
+}
+
+// bearerFailureReason classifies why a bearer check failed. Mirrors the
+// same shape as basicFailureReason. The "empty-configured-token" reason
+// is distinct because it points at a server-side misconfiguration rather
+// than a client-side problem (config.Validate rejects this at startup,
+// but the runtime guard in checkBearer also handles it; if this reason
+// ever fires in production, something bypassed Validate — investigate).
+func bearerFailureReason(r *http.Request, configuredToken string) string {
+	if configuredToken == "" {
+		return "empty-configured-token"
+	}
+	authHeader := r.Header.Get("Authorization")
+	hasHeader := strings.HasPrefix(authHeader, "Bearer ")
+	hasQuery := r.URL.Query().Get("token") != ""
+	if !hasHeader && !hasQuery {
+		return "missing-header"
+	}
+	return "wrong-token"
 }
 
 // checkBasic validates an HTTP Basic auth header against the expected credentials.

--- a/dashboard/internal/server/auth_test.go
+++ b/dashboard/internal/server/auth_test.go
@@ -1,10 +1,13 @@
 package server
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -224,4 +227,191 @@ func TestMiddleware_UnknownModeFailsClosed(t *testing.T) {
 			t.Errorf("mode %q: expected 401, got %d (middleware must fail closed on unknown mode)", string(mode), rr.Code)
 		}
 	}
+}
+
+// captureSlog redirects slog.Default() into a buffer for the duration of
+// the test, returning the buffer and a restore function. Tests must call
+// the restore function in a t.Cleanup so failures don't leak the test
+// logger into other tests running in parallel.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	prev := slog.Default()
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// TestAuth_LogsFailures asserts that every failed auth path emits exactly
+// one slog.Warn line with the documented field set, and that the line
+// NEVER contains the offered credential or token. Closes the §8 audit
+// finding "no audit-log channel for security events; failed auth attempts
+// are silently 401'd; not even an slog.Warn in checkBasic/checkBearer."
+//
+// Each case captures slog output, makes one request, and asserts:
+//   - exactly one "auth failure" line was emitted
+//   - the expected mode + reason discriminator are present
+//   - the offered credential/token does NOT appear anywhere in the line
+func TestAuth_LogsFailures(t *testing.T) {
+	const offeredSecret = "REDACTED-MUST-NEVER-APPEAR-IN-LOGS"
+
+	cases := []struct {
+		name       string
+		setup      func() http.Handler
+		req        func() *http.Request
+		wantMode   string
+		wantReason string
+	}{
+		{
+			name:  "bearer missing header",
+			setup: func() http.Handler { return applyMiddleware(AuthBearer, "", "", "secret", okHandler) },
+			req: func() *http.Request {
+				return httptest.NewRequest(http.MethodGet, "/readyz", nil)
+			},
+			wantMode:   "bearer",
+			wantReason: "missing-header",
+		},
+		{
+			name:  "bearer wrong header token",
+			setup: func() http.Handler { return applyMiddleware(AuthBearer, "", "", "secret", okHandler) },
+			req: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+				r.Header.Set("Authorization", "Bearer "+offeredSecret)
+				return r
+			},
+			wantMode:   "bearer",
+			wantReason: "wrong-token",
+		},
+		{
+			name:  "bearer wrong query token",
+			setup: func() http.Handler { return applyMiddleware(AuthBearer, "", "", "secret", okHandler) },
+			req: func() *http.Request {
+				return httptest.NewRequest(http.MethodGet, "/events?token="+offeredSecret, nil)
+			},
+			wantMode:   "bearer",
+			wantReason: "wrong-token",
+		},
+		{
+			name:  "bearer empty configured token",
+			setup: func() http.Handler { return applyMiddleware(AuthBearer, "", "", "", okHandler) },
+			req: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+				r.Header.Set("Authorization", "Bearer "+offeredSecret)
+				return r
+			},
+			wantMode:   "bearer",
+			wantReason: "empty-configured-token",
+		},
+		{
+			name:  "basic missing header",
+			setup: func() http.Handler { return applyMiddleware(AuthBasic, "u", "p", "", okHandler) },
+			req: func() *http.Request {
+				return httptest.NewRequest(http.MethodGet, "/readyz", nil)
+			},
+			wantMode:   "basic",
+			wantReason: "missing-header",
+		},
+		{
+			name:  "basic wrong creds",
+			setup: func() http.Handler { return applyMiddleware(AuthBasic, "u", "p", "", okHandler) },
+			req: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+				bad := base64.StdEncoding.EncodeToString([]byte("wronguser:" + offeredSecret))
+				r.Header.Set("Authorization", "Basic "+bad)
+				return r
+			},
+			wantMode:   "basic",
+			wantReason: "wrong-creds",
+		},
+		{
+			name:  "basic malformed base64",
+			setup: func() http.Handler { return applyMiddleware(AuthBasic, "u", "p", "", okHandler) },
+			req: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+				r.Header.Set("Authorization", "Basic !!!not-b64!!!")
+				return r
+			},
+			wantMode:   "basic",
+			wantReason: "malformed-base64",
+		},
+		{
+			name:  "unknown mode",
+			setup: func() http.Handler { return applyMiddleware(AuthMode("Bearer"), "", "", "secret", okHandler) },
+			req: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+				r.Header.Set("Authorization", "Bearer "+offeredSecret)
+				return r
+			},
+			wantMode:   "Bearer",
+			wantReason: "unknown-mode",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := captureSlog(t)
+			handler := tc.setup()
+
+			handler.ServeHTTP(httptest.NewRecorder(), tc.req())
+
+			out := buf.String()
+			lines := nonEmptyLines(out)
+			if len(lines) != 1 {
+				t.Fatalf("want exactly one log line, got %d:\n%s", len(lines), out)
+			}
+			line := lines[0]
+			for _, want := range []string{
+				`level=WARN`,
+				`msg="auth failure"`,
+				`mode=` + quoteIfNeeded(tc.wantMode),
+				`reason=` + quoteIfNeeded(tc.wantReason),
+			} {
+				if !strings.Contains(line, want) {
+					t.Errorf("log line missing %q.\nfull line: %s", want, line)
+				}
+			}
+			if strings.Contains(out, offeredSecret) {
+				t.Fatalf("LOG LEAKED THE OFFERED CREDENTIAL — this is a security regression.\noutput:\n%s", out)
+			}
+		})
+	}
+}
+
+// TestAuth_NoLogOnSuccess asserts the happy path does not log — only
+// failures should be in the security event stream.
+func TestAuth_NoLogOnSuccess(t *testing.T) {
+	buf := captureSlog(t)
+	handler := applyMiddleware(AuthBearer, "", "", "secret", okHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if out := buf.String(); strings.Contains(out, "auth failure") {
+		t.Fatalf("happy path must not emit auth-failure log; got: %s", out)
+	}
+}
+
+// nonEmptyLines splits s on newlines and drops any empty trailing line
+// from a final \n. Avoids spurious "want 1 got 2" failures.
+func nonEmptyLines(s string) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// quoteIfNeeded wraps a value in double quotes if slog's TextHandler
+// would do so. slog quotes strings containing whitespace or special
+// characters; bare alphanumerics with hyphens are not quoted. Our
+// expected mode/reason values fall into the bare camp, but be defensive
+// in case future cases include spaces.
+func quoteIfNeeded(v string) string {
+	if strings.ContainsAny(v, " \t\"=") || v == "" {
+		return `"` + v + `"`
+	}
+	return v
 }


### PR DESCRIPTION
## Summary

- Every failed-auth code path now emits exactly one structured `slog.Warn` line so security monitoring (Loki alert rules, SIEM ingest) can detect scanners, brute-force attempts, and misconfigured clients.
- Closes the §8 audit MAJOR finding *"no audit-log channel for security events; failed auth attempts are silently 401'd; not even an slog.Warn in checkBasic/checkBearer."*
- The line **never** contains the offered credential or token. Mirrors the access_log invariant from PR #457: paths only, no query strings, no auth-header values.

## Log shape

```
level=WARN msg="auth failure" mode=bearer reason=missing-header method=GET path=/readyz remote=10.0.0.1:53221
level=WARN msg="auth failure" mode=basic  reason=wrong-creds      method=GET path=/agents remote=10.0.0.1:53222
```

| reason | meaning |
|---|---|
| `missing-header` | No `Authorization` header (likely scanner) |
| `wrong-scheme` | Header present but not `Basic ` / `Bearer ` |
| `malformed-base64` | Basic auth header didn't decode |
| `wrong-creds` | Basic user/pass mismatch (does NOT disclose which half) |
| `wrong-token` | Bearer token (header or `?token=` query) didn't match |
| `empty-configured-token` | Bearer mode with empty server-side token — should never fire (Validate rejects), so if you see this in production something bypassed Validate |
| `unknown-mode` | Middleware default branch fired (also a Validate-bypass smell) |

## Why a Warn-per-event and not aggregated

At scanner volumes this fires often. That's the point. If you want throttling, the right place to add it is `logAuthFailure` itself; reverting to silent 401s is the wrong direction. Loki/SIEM are designed for high-cardinality structured events.

## Test plan

- [x] `TestAuth_LogsFailures` — eight failure shapes (bearer missing-header, bearer wrong-header-token, bearer wrong-query-token, bearer empty-configured-token, basic missing-header, basic wrong-creds, basic malformed-base64, unknown-mode). Each asserts exactly one log line, the expected `mode` and `reason`, and that the offered secret **never** appears in the captured slog output.
- [x] `TestAuth_NoLogOnSuccess` — the happy path emits zero log lines.
- [x] `go test -race -count=1 ./...` passes all 11 packages
- [x] `gosec ./internal/server/...` is clean
- [ ] CI green
- [ ] Auto-merge fires once #457 lands and rebases this branch

## Stacking

Branched off `fix/atlas-v0.2.1-security` (PR #457). Independent of #458 (gosec required-check) and #459 (JSON size caps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)