### PR TITLE
fix(security): drop middleware.RealIP — Atlas exposes :3002 directly

### DIFF
--- a/dashboard/internal/server/realip_test.go
+++ b/dashboard/internal/server/realip_test.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/HomericIntelligence/atlas/internal/config"
+	"github.com/HomericIntelligence/atlas/internal/events"
+	"github.com/HomericIntelligence/atlas/internal/store"
+)
+
+// captureSlogForRealIPTest swaps slog.Default() for a buffered logger
+// for the duration of the calling test, restoring on cleanup. Inlined
+// here (rather than imported) because this PR is stacked off the v0.2.1
+// security base; PR #460 introduces a sibling helper of the same shape
+// in auth_test.go. After both merge, consolidate into a single
+// test-helper file.
+func captureSlogForRealIPTest(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	prev := slog.Default()
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// TestRoutes_DoesNotTrustForwardedFor is a regression test for the §8
+// audit MAJOR finding "middleware.RealIP trusts X-Forwarded-For
+// unconditionally." Atlas exposes :3002 directly in compose with no
+// upstream proxy stripping XFF — so trusting client-supplied XFF
+// would let any reachable client spoof the source IP that lands in
+// access logs and (post #460) in the auth-failure security event
+// stream.
+//
+// We exercise the real s.routes() middleware chain so this test
+// catches a future regression where someone re-adds
+// middleware.RealIP without realising the deployment shape.
+func TestRoutes_DoesNotTrustForwardedFor(t *testing.T) {
+	s := New(&config.Config{
+		AuthMode: "none", // pass-through; we want to exercise middleware not auth
+	}, events.NewBus(8), store.NewCache())
+
+	// Build a request with a spoofed X-Forwarded-For chain. /livez is
+	// unauthenticated and goes through the same middleware stack as
+	// every other route — so a successful regression test on /livez
+	// proves the property for all routes.
+	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
+	req.Header.Set("X-Forwarded-For", "1.2.3.4, 5.6.7.8")
+	req.Header.Set("X-Real-IP", "9.10.11.12")
+	req.RemoteAddr = "127.0.0.1:54321" // what the kernel sees
+
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("/livez expected 200, got %d", rr.Code)
+	}
+
+	// The downstream handler doesn't echo RemoteAddr, but the access
+	// log middleware does. Capture the slog output and assert that
+	// the log line carries the kernel-visible RemoteAddr, NOT the
+	// spoofed XFF / X-Real-IP values.
+	//
+	// We re-issue with slog captured this time. The first ServeHTTP
+	// call above also exercised the chain end-to-end; this second
+	// call gives us the inspectable log line.
+	buf := captureSlogForRealIPTest(t)
+	rr2 := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr2, req)
+
+	out := buf.String()
+	for _, spoofed := range []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"} {
+		if strings.Contains(out, spoofed) {
+			t.Errorf("access log contained spoofed IP %q — RealIP must not be trusted on a directly-exposed port.\nlog:\n%s", spoofed, out)
+		}
+	}
+	if !strings.Contains(out, "127.0.0.1:54321") {
+		t.Errorf("access log missing the kernel-visible RemoteAddr 127.0.0.1:54321.\nlog:\n%s", out)
+	}
+}

--- a/dashboard/internal/server/routes.go
+++ b/dashboard/internal/server/routes.go
@@ -10,7 +10,16 @@ import (
 
 func (s *Server) routes() http.Handler {
 	r := chi.NewRouter()
-	r.Use(middleware.RealIP)
+	// We deliberately do NOT use middleware.RealIP. RealIP rewrites
+	// r.RemoteAddr from any client-supplied X-Forwarded-For / X-Real-IP
+	// header — which is correct only when an upstream proxy strips and
+	// re-issues those headers from a trusted source. Atlas exposes :3002
+	// directly in compose with no upstream proxy, so trusting client-
+	// supplied XFF lets anyone spoof the source IP that ends up in
+	// access logs and (post #460) in auth-failure security events. If a
+	// future deployment runs Atlas behind nginx/Caddy/etc., the right
+	// fix is to gate this on an explicit ATLAS_TRUST_PROXY env var, not
+	// to re-enable RealIP unconditionally.
 	// accessLog replaces chi's default middleware.Logger to avoid leaking the
 	// SSE bearer token (passed as ?token=<secret>) into stdout/Loki. The
 	// default Logger formats the full RequestURI; accessLog logs r.URL.Path


### PR DESCRIPTION
## Summary

- Removes `middleware.RealIP` from the Atlas request chain. Closes the §8 audit MAJOR finding *"middleware.RealIP trusts X-Forwarded-For unconditionally."*
- Atlas is exposed directly in compose with no upstream proxy stripping `X-Forwarded-For` / `X-Real-IP`. RealIP rewrites `r.RemoteAddr` from any client-supplied header — so anyone reachable on `:3002` could spoof the source IP that lands in access logs and (after #460 rebases) in auth-failure security events.
- Single-line removal plus a documented comment block explaining why so a future contributor doesn't re-add it without thinking through the deployment shape.

## When would you re-enable it?

Only when Atlas runs behind a trusted reverse proxy (nginx, Caddy, Traefik, k8s ingress) that strips client-supplied XFF and re-issues it from the proxy's view. The right fix at that point is to gate the middleware on a new `ATLAS_TRUST_PROXY` env var. **Not** to re-enable it unconditionally — that would re-open the spoof for any non-proxied deployment that pulled the same image.

## Test plan

- [x] `TestRoutes_DoesNotTrustForwardedFor` — constructs a real `*Server`, sends a request with `X-Forwarded-For: 1.2.3.4, 5.6.7.8` and `X-Real-IP: 9.10.11.12`, captures the slog access log, asserts none of the spoofed IPs appear, and that the kernel-visible `RemoteAddr` (`127.0.0.1:54321`) does. Exercises the actual `s.routes()` chain so a future regression catches a re-added `middleware.RealIP`.
- [x] `go test -race -count=1 ./...` passes all 11 packages
- [x] `gosec ./...` is clean
- [ ] CI green
- [ ] Auto-merge fires once #457 lands and rebases this branch

## Test-helper duplication note

The new test inlines `captureSlogForRealIPTest`; PR #460 introduces a sibling `captureSlog` of the same shape in `auth_test.go`. Once both merge, consolidate them into a single test-helper file. Not done in either PR to keep the per-change diff minimal.

## Stacking

Branched off `fix/atlas-v0.2.1-security` (PR #457). Independent of #458 / #459 / #460; all four can land in any order on the security base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)