### PR TITLE
fix(ci): pin golangci-lint v2.12.2, fix markdownlint, add concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["main"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: Validate configs
@@ -122,7 +126,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v2.12.2
           working-directory: dashboard
 
       - name: govulncheck (SCA)

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -52,7 +52,8 @@ A fresh `nats-server -js` has no streams provisioned, so `attached=0` and the su
 reports not-ready until you create them. To bring up just one for a smoke test:
 
 ```bash
-nats stream add homeric-agents --subjects 'hi.agents.>' --storage memory --retention limits --discard old --max-msgs=1000 --defaults
+nats stream add homeric-agents --subjects 'hi.agents.>' --storage memory \
+  --retention limits --discard old --max-msgs=1000 --defaults
 nats pub hi.agents.demo '{"id":"demo","status":"ok"}'
 ```
 

--- a/dashboard/docs/architecture.md
+++ b/dashboard/docs/architecture.md
@@ -26,11 +26,21 @@ Mnemosyne browser
 
 ## Concurrency model
 
-- **Cache**: `sync.RWMutex`-protected; writers are poller goroutines, readers are HTTP handlers. Every getter returns a defensive copy so map/slice mutation cannot leak across the lock (`internal/store/cache.go`)
-- **Event Bus**: `sync.RWMutex`-protected subscriber map (`internal/events/bus.go`). Subscribers receive `chan events.Event` (the typed event payload, not raw bytes); the per-subscriber buffer size is the caller-provided argument to `Bus.Subscribe(buf)` — the SSE handler uses `1000` (`internal/handlers/sse.go`)
-- **Ring Buffer**: a single `sync.Mutex`-guarded ring of `events.Event` values across **all** topics — not one buffer per topic. Capacity is set at process startup via `events.NewBus(256)` in `cmd/argus-dashboard/main.go` and replayed on SSE connect (clamped to the buffer length)
-- **Slow consumers**: `Bus.Publish` performs non-blocking fan-out (`select { case ch <- e: default: atomic.AddInt64(&drops, 1) }`); a slow SSE client drops events rather than blocking the bus
-- **Metrics**: an isolated `prometheus.Registry` per process (`internal/server/metrics.go`); counters and gauges from `prometheus/client_golang` are inherently goroutine-safe
+- **Cache**: `sync.RWMutex`-protected; writers are poller goroutines, readers are HTTP handlers.
+  Every getter returns a defensive copy so map/slice mutation cannot leak across the lock
+  (`internal/store/cache.go`)
+- **Event Bus**: `sync.RWMutex`-protected subscriber map (`internal/events/bus.go`). Subscribers
+  receive `chan events.Event` (the typed event payload, not raw bytes); the per-subscriber buffer
+  size is the caller-provided argument to `Bus.Subscribe(buf)` — the SSE handler uses `1000`
+  (`internal/handlers/sse.go`)
+- **Ring Buffer**: a single `sync.Mutex`-guarded ring of `events.Event` values across **all**
+  topics — not one buffer per topic. Capacity is set at process startup via `events.NewBus(256)`
+  in `cmd/argus-dashboard/main.go` and replayed on SSE connect (clamped to the buffer length)
+- **Slow consumers**: `Bus.Publish` performs non-blocking fan-out
+  (`select { case ch <- e: default: atomic.AddInt64(&drops, 1) }`); a slow SSE client drops
+  events rather than blocking the bus
+- **Metrics**: an isolated `prometheus.Registry` per process (`internal/server/metrics.go`);
+  counters and gauges from `prometheus/client_golang` are inherently goroutine-safe
 
 ## Resource bounds
 
@@ -51,23 +61,46 @@ The values below are hardcoded at v0.2.0 — operators sizing memory should acco
 
 ## Tailscale device discovery
 
-The `internal/tailscale` package provides four interchangeable `Source` implementations (selected via `ATLAS_TAILSCALE_SOURCE`):
+The `internal/tailscale` package provides four interchangeable `Source` implementations
+(selected via `ATLAS_TAILSCALE_SOURCE`):
 
-- **`static`** — devices come from `ATLAS_WORKER_HOST_IP` and `ATLAS_CONTROL_HOST_IP`. No network calls. Smallest blast radius; use when running off-tailnet (CI, dev, single-host).
-- **`cli`** — shells out to `tailscale status --json` via `exec.CommandContext` with a fixed argv. Requires the `tailscale` binary on `PATH` and a logged-in tailnet daemon.
-- **`api`** — calls the Tailscale Central API at `api.tailscale.com/api/v2/tailnet/{name}/devices` using `ATLAS_TAILSCALE_API_KEY`. Requires `ATLAS_TAILNET_NAME`. Rate-limited by Tailscale.
-- **`auto`** — tries `cli` first, falls back to `api` on error. Useful when Atlas is sometimes on the tailnet and sometimes not.
+- **`static`** — devices come from `ATLAS_WORKER_HOST_IP` and `ATLAS_CONTROL_HOST_IP`. No network
+  calls. Smallest blast radius; use when running off-tailnet (CI, dev, single-host).
+- **`cli`** — shells out to `tailscale status --json` via `exec.CommandContext` with a fixed
+  argv. Requires the `tailscale` binary on `PATH` and a logged-in tailnet daemon.
+- **`api`** — calls the Tailscale Central API at
+  `api.tailscale.com/api/v2/tailnet/{name}/devices` using `ATLAS_TAILSCALE_API_KEY`. Requires
+  `ATLAS_TAILNET_NAME`. Rate-limited by Tailscale.
+- **`auto`** — tries `cli` first, falls back to `api` on error. Useful when Atlas is sometimes
+  on the tailnet and sometimes not.
 
-The active `Source` is wrapped in a `Refresher` (`internal/tailscale/refresher.go`) that polls every 30 s and writes results into `store.Cache` via a local `DeviceStore` interface — this avoids a tailscale↔store import cycle.
+The active `Source` is wrapped in a `Refresher` (`internal/tailscale/refresher.go`) that polls
+every 30 s and writes results into `store.Cache` via a local `DeviceStore` interface — this
+avoids a tailscale↔store import cycle.
 
 ## Security
 
-- All HTML responses include `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy: strict-origin-when-cross-origin`
-- CSP `frame-src` is built statically at startup from `ATLAS_GRAFANA_URL`, `ATLAS_LOKI_URL`, and optionally `ATLAS_NATS_DASHBOARD_URL`. Each URL is validated by `config.Validate` (rejects whitespace, semicolons, quotes, non-`http(s)` schemes) before being interpolated into the header — no user input reaches CSP at runtime
-- Only `/livez` and its alias `/healthz` are unauthenticated. **`/readyz` and `/metrics` ARE auth-gated** (see `internal/server/routes.go` — both endpoints sit inside the `r.Group` that applies the configured auth middleware) so component error strings and internal counters cannot be read anonymously. Configure your scrape targets accordingly.
-- Auth modes are `none` / `basic` / `bearer`; the default since v0.2.0 is `bearer`. Bearer tokens are compared with `subtle.ConstantTimeCompare`; an empty configured token rejects all requests
-- SSE/EventSource bearer fallback via `?token=` allows browsers' built-in `EventSource` (which cannot set custom headers) to authenticate
-- Mnemosyne markdown rendering uses goldmark with `Unsafe=false` (the default) — raw HTML and `javascript:` URLs in skill files are stripped. The `render.go` source carries a comment forbidding `goldmark.WithUnsafe()`
-- Mnemosyne reader resolves the requested path with `filepath.EvalSymlinks` and verifies it stays under the configured skills root — defends against symlink-escape path traversal
-- Grafana `from`/`to` query params validated against `^(now(-[0-9]+(s|m|h|d|w|y))?|[0-9]{13})$` before embedding in iframe URLs
-- iframe sandbox: `allow-scripts allow-popups` only — never `allow-same-origin` alongside `allow-scripts`
+- All HTML responses include `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`,
+  `Referrer-Policy: strict-origin-when-cross-origin`
+- CSP `frame-src` is built statically at startup from `ATLAS_GRAFANA_URL`, `ATLAS_LOKI_URL`, and
+  optionally `ATLAS_NATS_DASHBOARD_URL`. Each URL is validated by `config.Validate` (rejects
+  whitespace, semicolons, quotes, non-`http(s)` schemes) before being interpolated into the
+  header — no user input reaches CSP at runtime
+- Only `/livez` and its alias `/healthz` are unauthenticated. **`/readyz` and `/metrics` ARE
+  auth-gated** (see `internal/server/routes.go` — both endpoints sit inside the `r.Group` that
+  applies the configured auth middleware) so component error strings and internal counters
+  cannot be read anonymously. Configure your scrape targets accordingly.
+- Auth modes are `none` / `basic` / `bearer`; the default since v0.2.0 is `bearer`. Bearer
+  tokens are compared with `subtle.ConstantTimeCompare`; an empty configured token rejects all
+  requests
+- SSE/EventSource bearer fallback via `?token=` allows browsers' built-in `EventSource` (which
+  cannot set custom headers) to authenticate
+- Mnemosyne markdown rendering uses goldmark with `Unsafe=false` (the default) — raw HTML and
+  `javascript:` URLs in skill files are stripped. The `render.go` source carries a comment
+  forbidding `goldmark.WithUnsafe()`
+- Mnemosyne reader resolves the requested path with `filepath.EvalSymlinks` and verifies it
+  stays under the configured skills root — defends against symlink-escape path traversal
+- Grafana `from`/`to` query params validated against `^(now(-[0-9]+(s|m|h|d|w|y))?|[0-9]{13})$`
+  before embedding in iframe URLs
+- iframe sandbox: `allow-scripts allow-popups` only — never `allow-same-origin` alongside
+  `allow-scripts`

--- a/dashboard/docs/runbook.md
+++ b/dashboard/docs/runbook.md
@@ -102,11 +102,13 @@ interval** (default poll = 5 s, so the budget is ~10 s). Beyond that, `/readyz` 
 **Likely causes & checks**
 
 1. **Upstream service is down.** Atlas reads via plain HTTP — try the same URL Atlas uses:
+
    ```bash
    curl -fsS "$ATLAS_AGAMEMNON_URL/v1/agents"
    curl -fsS "$ATLAS_NATS_MON_URL/varz"
    curl -fsS "$ATLAS_NATS_MON_URL/jsz"
    ```
+
    If those fail from the Atlas host, fix the upstream first.
 2. **Slow upstream.** Atlas uses 3 s HTTP timeouts on outbound polls. A consistently slow
    upstream (>3 s response) will look like a permanent error in metrics. Increase
@@ -136,9 +138,11 @@ This is almost always one of:
   (`agent`, `task`, `myrmidon`, `research`, `pipeline`, `log`) all originate there.
 - **No upstream activity** — Atlas only fans out events that arrive from NATS or from its
   own pollers. If nothing is publishing, nothing arrives. Verify by publishing a test event:
+
   ```bash
   nats pub hi.agents.demo '{"id":"demo","status":"ok"}'
   ```
+
   An attached subscriber should immediately fan that out as `event: agent`.
 - **Topic filter excluding everything** — clients can constrain via `?topics=agent,task`.
   Drop the parameter to subscribe to all eight topics (six NATS-derived plus `nats`/`host`


### PR DESCRIPTION
## Summary

- Bumps `golangci/golangci-lint-action@v6`'s `version:` pin to **v2.12.2** so it ships a Go 1.25-built binary that can load the dashboard's v2-schema `.golangci.yml`. Closes the failing `Atlas dashboard (Go)` check that has been blocking every PR in the v0.2.1 chain. The previous `latest` resolved to v1.64.8 (Go 1.24-built) and errored: `can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.8)`.
- Fixes **22** markdownlint violations introduced by commit `5275ff0` (the v0.2.1 doc-fixes commit): line-length and blanks-around-fences. No prose semantics changed.
  - `dashboard/docs/architecture.md` — 17 MD013/line-length (Concurrency model, Tailscale device discovery, Security sections), hard-wrapped at ~100 cols
  - `dashboard/docs/runbook.md` — 4 MD031/blanks-around-fences (lines 105/109 and 139/141), blank lines added around two nested fenced code blocks
  - `dashboard/README.md` — 1 MD013/line-length, wrapped the long `nats stream add` example with a `\` continuation
- Adds `concurrency: cancel-in-progress` to `ci.yml`, matching `_required.yml`'s pattern (lines 9-11). Prevents racing CI runs from corrupting the `coverage.out` artifact when pushes arrive close together.

## Test plan

- [x] `markdownlint-cli2 v0.17.2 "**/*.md"` exits 0 for repo-tracked files (only ignored `.pixi/` env docs report errors)
- [x] `check-jsonschema --schemafile json.schemastore.org/github-workflow .github/workflows/ci.yml` returns `ok -- validation done`
- [x] `go test -race -count=1 ./...` green for all dashboard packages
- [ ] CI green
- [ ] Auto-merge fires once #457 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)