### PR TITLE
fix(poller): NATSPoller readyz must reflect all three endpoints

### DIFF
--- a/dashboard/internal/poller/metrics_wiring_test.go
+++ b/dashboard/internal/poller/metrics_wiring_test.go
@@ -9,14 +9,22 @@ import (
 
 // countingMetrics is a concurrent-safe MetricsSink that records call counts.
 type countingMetrics struct {
-	pollErrors      atomic.Int64
+	pollErrors       atomic.Int64
+	endpointErrors   atomic.Int64
 	durationObserves atomic.Int64
-	lastSource      atomic.Value // string
+	lastSource       atomic.Value // string
+	lastEndpoint     atomic.Value // string
 }
 
 func (c *countingMetrics) IncPollError(source string) {
 	c.pollErrors.Add(1)
 	c.lastSource.Store(source)
+}
+
+func (c *countingMetrics) IncEndpointError(source, endpoint string) {
+	c.endpointErrors.Add(1)
+	c.lastSource.Store(source)
+	c.lastEndpoint.Store(endpoint)
 }
 
 func (c *countingMetrics) ObservePollDuration(source string, _ float64) {

--- a/dashboard/internal/poller/nats.go
+++ b/dashboard/internal/poller/nats.go
@@ -2,6 +2,8 @@ package poller
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -96,31 +98,46 @@ func (p *NATSPoller) Start(ctx context.Context, interval time.Duration) {
 	}
 }
 
-// fetch retrieves stats from /varz and /jsz and updates the cache.
-// /varz and /jsz failures gate poll-success (readiness); detail-endpoint
-// failures (/jsz?detail=1, /connz) are logged but do not gate.
+// fetch retrieves stats from /varz, /jsz?detail=1, and /connz and updates the
+// cache. ALL three endpoints gate poll-success: any failure surfaces in
+// LastError (and therefore /readyz) via errors.Join, naming which endpoint(s)
+// failed. The successful endpoints still update their cache slices — partial
+// freshness is fine; what's NOT fine is misreporting "everything fresh" to
+// /readyz while one of the caches is silently stale.
+//
+// Per-endpoint failures also increment atlas_poll_endpoint_errors_total via
+// MetricsSink.IncEndpointError so operators can attribute failures to a
+// specific endpoint without inflating the cycle-level atlas_poll_errors_total
+// counter (which still increments exactly once per failed cycle, regardless
+// of how many of the three endpoints failed).
 func (p *NATSPoller) fetch(ctx context.Context) {
 	start := time.Now()
-	err := p.fetchInner(ctx)
-	if err != nil {
-		slog.Warn("nats poller: fetch failed", "err", err)
+	errs := []error{
+		p.fetchVarzJsz(ctx),
+		p.fetchStreams(ctx),
+		p.fetchConns(ctx),
 	}
-	p.recordResult(err, time.Since(start))
-
-	// Detail endpoints are best-effort: their failures must not mark the
-	// poller unready, since the primary varz/jsz cache is already populated.
-	p.fetchDetail(ctx)
+	joined := errors.Join(errs...)
+	if joined != nil {
+		slog.Warn("nats poller: one or more endpoints failed", "err", joined)
+	}
+	p.recordResult(joined, time.Since(start))
 }
 
-func (p *NATSPoller) fetchInner(ctx context.Context) error {
+// fetchVarzJsz polls /varz and /jsz and writes the aggregate NATSStats slice.
+// /jsz here is the lightweight summary endpoint; the detail endpoint is polled
+// separately by fetchStreams.
+func (p *NATSPoller) fetchVarzJsz(ctx context.Context) error {
 	var varz varzResponse
 	if err := p.getJSON(ctx, p.url+"/varz", &varz); err != nil {
-		return err
+		p.incEndpointError("varz")
+		return fmt.Errorf("varz: %w", err)
 	}
 
 	var jsz jszResponse
 	if err := p.getJSON(ctx, p.url+"/jsz", &jsz); err != nil {
-		return err
+		p.incEndpointError("jsz")
+		return fmt.Errorf("jsz: %w", err)
 	}
 
 	p.cache.SetNATSStats(store.NATSStats{
@@ -132,42 +149,52 @@ func (p *NATSPoller) fetchInner(ctx context.Context) error {
 	return nil
 }
 
-// fetchDetail polls /jsz?detail=1 for stream list and /connz for connections.
-// Errors on any sub-request are logged and that section of the cache is left intact.
-func (p *NATSPoller) fetchDetail(ctx context.Context) {
+// fetchStreams polls /jsz?detail=1 for the stream list. On error the
+// stream-list section of the cache is left intact (the previous values stay
+// in place rather than being cleared) but the failure is reported to the
+// caller so /readyz reflects the staleness.
+func (p *NATSPoller) fetchStreams(ctx context.Context) error {
 	var jszDetail jszDetailResponse
 	if err := p.getJSON(ctx, p.url+"/jsz?detail=1", &jszDetail); err != nil {
-		slog.Warn("nats poller: failed to fetch /jsz?detail=1", "err", err)
-	} else {
-		streams := make([]store.NATSStreamInfo, 0, len(jszDetail.Streams))
-		for _, s := range jszDetail.Streams {
-			streams = append(streams, store.NATSStreamInfo{
-				Name:      s.Config.Name,
-				Subjects:  s.Config.Subjects,
-				Messages:  s.State.Messages,
-				Bytes:     s.State.Bytes,
-				Consumers: s.State.Consumers,
-				Created:   s.Created,
-			})
-		}
-		p.cache.SetNATSStreams(streams)
+		p.incEndpointError("jsz_detail")
+		return fmt.Errorf("jsz_detail: %w", err)
 	}
+	streams := make([]store.NATSStreamInfo, 0, len(jszDetail.Streams))
+	for _, s := range jszDetail.Streams {
+		streams = append(streams, store.NATSStreamInfo{
+			Name:      s.Config.Name,
+			Subjects:  s.Config.Subjects,
+			Messages:  s.State.Messages,
+			Bytes:     s.State.Bytes,
+			Consumers: s.State.Consumers,
+			Created:   s.Created,
+		})
+	}
+	p.cache.SetNATSStreams(streams)
+	return nil
+}
 
+// fetchConns polls /connz for the active client connection list. On error the
+// connection-list section of the cache is left intact and the failure is
+// reported to the caller so /readyz reflects the staleness — closes the §3
+// audit MAJOR finding "NATSPoller readiness asymmetry."
+func (p *NATSPoller) fetchConns(ctx context.Context) error {
 	var connz connzResponse
 	if err := p.getJSON(ctx, p.url+"/connz", &connz); err != nil {
-		slog.Warn("nats poller: failed to fetch /connz", "err", err)
-	} else {
-		conns := make([]store.NATSConnInfo, 0, len(connz.Connections))
-		for _, c := range connz.Connections {
-			conns = append(conns, store.NATSConnInfo{
-				Name:          c.Name,
-				IP:            c.IP,
-				Subscriptions: c.Subscriptions,
-				InMsgs:        c.InMsgs,
-				OutMsgs:       c.OutMsgs,
-				Uptime:        c.Uptime,
-			})
-		}
-		p.cache.SetNATSConns(conns)
+		p.incEndpointError("connz")
+		return fmt.Errorf("connz: %w", err)
 	}
+	conns := make([]store.NATSConnInfo, 0, len(connz.Connections))
+	for _, c := range connz.Connections {
+		conns = append(conns, store.NATSConnInfo{
+			Name:          c.Name,
+			IP:            c.IP,
+			Subscriptions: c.Subscriptions,
+			InMsgs:        c.InMsgs,
+			OutMsgs:       c.OutMsgs,
+			Uptime:        c.Uptime,
+		})
+	}
+	p.cache.SetNATSConns(conns)
+	return nil
 }

--- a/dashboard/internal/poller/nats_readyz_test.go
+++ b/dashboard/internal/poller/nats_readyz_test.go
@@ -1,0 +1,249 @@
+package poller
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/HomericIntelligence/atlas/internal/store"
+)
+
+// canonical successful payloads reused across the per-endpoint failure cases.
+const (
+	canonicalVarzJSON       = `{"connections":5,"in_msgs":1000,"out_msgs":800}`
+	canonicalJszJSON        = `{"num_streams":3}`
+	canonicalJszDetailJSON  = `{"streams":[{"config":{"name":"S1","subjects":["s.>"]},"state":{"messages":1,"bytes":2,"consumer_count":3},"created":"2024-01-01T00:00:00Z"}]}`
+	canonicalConnzJSON      = `{"connections":[{"name":"c1","ip":"127.0.0.1","subscriptions":1,"in_msgs":1,"out_msgs":2,"uptime":"1s"}]}`
+)
+
+// natsHandler is a configurable httptest handler that returns 500 for any
+// endpoint listed in `failing` and the canonical successful payload for the
+// rest. Endpoints are matched by the test-friendly key strings ("varz",
+// "jsz", "jsz_detail", "connz") that mirror the IncEndpointError labels.
+func natsHandler(failing map[string]bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var key string
+		switch r.URL.Path {
+		case "/varz":
+			key = "varz"
+		case "/jsz":
+			if r.URL.Query().Get("detail") == "1" {
+				key = "jsz_detail"
+			} else {
+				key = "jsz"
+			}
+		case "/connz":
+			key = "connz"
+		default:
+			http.NotFound(w, r)
+			return
+		}
+		if failing[key] {
+			http.Error(w, "synthetic failure", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch key {
+		case "varz":
+			_, _ = w.Write([]byte(canonicalVarzJSON))
+		case "jsz":
+			_, _ = w.Write([]byte(canonicalJszJSON))
+		case "jsz_detail":
+			_, _ = w.Write([]byte(canonicalJszDetailJSON))
+		case "connz":
+			_, _ = w.Write([]byte(canonicalConnzJSON))
+		}
+	}
+}
+
+// endpointCountingMetrics counts both cycle-level and per-endpoint failures
+// so the regression tests can assert the dedicated-method wiring works.
+type endpointCountingMetrics struct {
+	pollErrors      atomic.Int64
+	endpointErrors  sync.Map // endpoint string -> *atomic.Int64
+}
+
+func (c *endpointCountingMetrics) IncPollError(string) {
+	c.pollErrors.Add(1)
+}
+
+func (c *endpointCountingMetrics) IncEndpointError(_, endpoint string) {
+	v, _ := c.endpointErrors.LoadOrStore(endpoint, &atomic.Int64{})
+	v.(*atomic.Int64).Add(1)
+}
+
+func (c *endpointCountingMetrics) ObservePollDuration(string, float64) {}
+
+func (c *endpointCountingMetrics) endpointCount(endpoint string) int64 {
+	v, ok := c.endpointErrors.Load(endpoint)
+	if !ok {
+		return 0
+	}
+	return v.(*atomic.Int64).Load()
+}
+
+// TestNATSPoller_AllEndpointsSucceed_LastErrorNil is test case 1: every
+// endpoint returns 200, so recordResult(nil, _) — LastError() must be nil and
+// LastSuccess() must advance.
+func TestNATSPoller_AllEndpointsSucceed_LastErrorNil(t *testing.T) {
+	srv := httptest.NewServer(natsHandler(nil))
+	defer srv.Close()
+
+	cache := store.NewCache()
+	cfg := makeConfig("", srv.URL)
+	p := NewNATSPoller(cfg, cache)
+	m := &endpointCountingMetrics{}
+	p.SetMetrics(m)
+
+	p.fetch(context.Background())
+
+	if err := p.LastError(); err != nil {
+		t.Fatalf("LastError must be nil when all three endpoints succeed; got %v", err)
+	}
+	if p.LastSuccess().IsZero() {
+		t.Error("LastSuccess must advance when all three endpoints succeed")
+	}
+	if got := m.pollErrors.Load(); got != 0 {
+		t.Errorf("pollErrors: got %d, want 0", got)
+	}
+
+	// All three caches should reflect the canonical payloads.
+	if stats := cache.GetNATSStats(); stats.Connections != 5 || stats.Streams != 3 {
+		t.Errorf("stats cache: got %+v, want connections=5 streams=3", stats)
+	}
+	if streams := cache.GetNATSStreams(); len(streams) != 1 || streams[0].Name != "S1" {
+		t.Errorf("streams cache: got %+v, want one stream named S1", streams)
+	}
+	if conns := cache.GetNATSConns(); len(conns) != 1 || conns[0].Name != "c1" {
+		t.Errorf("conns cache: got %+v, want one connection named c1", conns)
+	}
+}
+
+// TestNATSPoller_VarzFails_LastErrorMentionsVarz is test case 2.
+func TestNATSPoller_VarzFails_LastErrorMentionsVarz(t *testing.T) {
+	srv := httptest.NewServer(natsHandler(map[string]bool{"varz": true}))
+	defer srv.Close()
+
+	cache := store.NewCache()
+	cfg := makeConfig("", srv.URL)
+	p := NewNATSPoller(cfg, cache)
+	m := &endpointCountingMetrics{}
+	p.SetMetrics(m)
+
+	p.fetch(context.Background())
+
+	err := p.LastError()
+	if err == nil {
+		t.Fatal("LastError must be non-nil when /varz fails")
+	}
+	if !strings.Contains(err.Error(), "varz") {
+		t.Errorf("LastError must mention varz; got %q", err.Error())
+	}
+	if got := m.endpointCount("varz"); got != 1 {
+		t.Errorf("IncEndpointError(varz): got %d, want 1", got)
+	}
+}
+
+// TestNATSPoller_JszDetailFails_LastErrorMentionsJsz is test case 3 — the
+// detail endpoint failure must now gate readiness.
+func TestNATSPoller_JszDetailFails_LastErrorMentionsJsz(t *testing.T) {
+	srv := httptest.NewServer(natsHandler(map[string]bool{"jsz_detail": true}))
+	defer srv.Close()
+
+	cache := store.NewCache()
+	cfg := makeConfig("", srv.URL)
+	p := NewNATSPoller(cfg, cache)
+	m := &endpointCountingMetrics{}
+	p.SetMetrics(m)
+
+	p.fetch(context.Background())
+
+	err := p.LastError()
+	if err == nil {
+		t.Fatal("LastError must be non-nil when /jsz?detail=1 fails")
+	}
+	if !strings.Contains(err.Error(), "jsz") {
+		t.Errorf("LastError must mention jsz; got %q", err.Error())
+	}
+	if got := m.endpointCount("jsz_detail"); got != 1 {
+		t.Errorf("IncEndpointError(jsz_detail): got %d, want 1", got)
+	}
+
+	// /varz+/jsz still succeeded so stats cache is fresh; /connz also still
+	// succeeded so its cache is fresh too. Streams cache is the one left
+	// untouched (verified by absence of the canonical "S1" entry).
+	if streams := cache.GetNATSStreams(); len(streams) != 0 {
+		t.Errorf("streams cache should be untouched on /jsz?detail=1 failure; got %+v", streams)
+	}
+}
+
+// TestNATSPoller_ConnzFails_LastErrorMentionsConnz is the regression case for
+// the §3 audit MAJOR finding.
+func TestNATSPoller_ConnzFails_LastErrorMentionsConnz(t *testing.T) {
+	srv := httptest.NewServer(natsHandler(map[string]bool{"connz": true}))
+	defer srv.Close()
+
+	cache := store.NewCache()
+	cfg := makeConfig("", srv.URL)
+	p := NewNATSPoller(cfg, cache)
+	m := &endpointCountingMetrics{}
+	p.SetMetrics(m)
+
+	p.fetch(context.Background())
+
+	err := p.LastError()
+	if err == nil {
+		t.Fatal("REGRESSION: /connz failure must surface in LastError; before the fix, only /varz+/jsz failures gated readiness, so /readyz would say OK while the connection list went stale")
+	}
+	if !strings.Contains(err.Error(), "connz") {
+		t.Errorf("LastError must mention connz; got %q", err.Error())
+	}
+	if got := m.endpointCount("connz"); got != 1 {
+		t.Errorf("IncEndpointError(connz): got %d, want 1", got)
+	}
+	if got := m.pollErrors.Load(); got != 1 {
+		t.Errorf("cycle-level pollErrors: got %d, want 1", got)
+	}
+}
+
+// TestNATSPoller_TwoEndpointsFail_JoinedErrorMentionsBoth is test case 5.
+func TestNATSPoller_TwoEndpointsFail_JoinedErrorMentionsBoth(t *testing.T) {
+	srv := httptest.NewServer(natsHandler(map[string]bool{"varz": true, "connz": true}))
+	defer srv.Close()
+
+	cache := store.NewCache()
+	cfg := makeConfig("", srv.URL)
+	p := NewNATSPoller(cfg, cache)
+	m := &endpointCountingMetrics{}
+	p.SetMetrics(m)
+
+	p.fetch(context.Background())
+
+	err := p.LastError()
+	if err == nil {
+		t.Fatal("LastError must be non-nil when two endpoints fail")
+	}
+	if !strings.Contains(err.Error(), "varz") {
+		t.Errorf("joined LastError must mention varz; got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "connz") {
+		t.Errorf("joined LastError must mention connz; got %q", err.Error())
+	}
+	// Cycle-level counter increments exactly once per failed cycle, even
+	// though two endpoints failed. The endpoint-level counter increments
+	// once per failing endpoint.
+	if got := m.pollErrors.Load(); got != 1 {
+		t.Errorf("cycle-level pollErrors: got %d, want 1 (one cycle, regardless of how many endpoints failed)", got)
+	}
+	if got := m.endpointCount("varz"); got != 1 {
+		t.Errorf("endpoint varz: got %d, want 1", got)
+	}
+	if got := m.endpointCount("connz"); got != 1 {
+		t.Errorf("endpoint connz: got %d, want 1", got)
+	}
+}

--- a/dashboard/internal/poller/poller.go
+++ b/dashboard/internal/poller/poller.go
@@ -31,8 +31,16 @@ var maxResponseBytes int64 = 16 << 20 // 16 MiB
 // satisfies this interface; tests can pass a no-op or a counting fake. Pollers
 // take this through SetMetrics rather than at construction so the Server can
 // finalise the metric set after composing other dependencies.
+//
+// IncEndpointError is emitted on a separate metric series (atlas_poll_endpoint_errors_total)
+// for pollers that fan out to multiple HTTP endpoints in a single cycle (e.g.
+// NATSPoller hitting /varz, /jsz?detail=1, /connz). It is keyed by both the
+// poller source name and the per-endpoint label so operators can answer "is
+// /connz consistently failing or just /jsz?" without affecting the existing
+// atlas_poll_errors_total{source} series or its alert rules.
 type MetricsSink interface {
 	IncPollError(source string)
+	IncEndpointError(source, endpoint string)
 	ObservePollDuration(source string, seconds float64)
 }
 
@@ -40,7 +48,8 @@ type MetricsSink interface {
 // value so callers that never call SetMetrics still work.
 type noopMetrics struct{}
 
-func (noopMetrics) IncPollError(string)              {}
+func (noopMetrics) IncPollError(string)               {}
+func (noopMetrics) IncEndpointError(string, string)   {}
 func (noopMetrics) ObservePollDuration(string, float64) {}
 
 // base is a shared helper for HTTP-based pollers. It tracks per-instance
@@ -118,6 +127,16 @@ func (b *base) recordResult(err error, elapsed time.Duration) {
 	if elapsed > 0 {
 		sink.ObservePollDuration(b.name, elapsed.Seconds())
 	}
+}
+
+// incEndpointError emits a per-endpoint failure metric without disturbing the
+// poll-cycle accounting. Used by pollers that fan out to multiple HTTP
+// endpoints in a single cycle so operators can attribute failures to the
+// specific endpoint that broke. recordResult still tallies the cycle-level
+// outcome via IncPollError.
+func (b *base) incEndpointError(endpoint string) {
+	sink := *b.metrics.Load()
+	sink.IncEndpointError(b.name, endpoint)
 }
 
 // getJSON performs a GET request to url and JSON-decodes the response body into dst.

--- a/dashboard/internal/server/metrics.go
+++ b/dashboard/internal/server/metrics.go
@@ -16,6 +16,12 @@ import (
 // reliably from the moment Atlas starts.
 var pollSources = []string{"agamemnon", "nestor", "hermes", "nats"}
 
+// natsEndpoints are the per-endpoint label values emitted by NATSPoller into
+// atlas_poll_endpoint_errors_total. Pre-registered with value 0 at boot so
+// dashboards and alerts can match labels from start-up rather than waiting
+// for the first failure to materialise the time series.
+var natsEndpoints = []string{"varz", "jsz", "jsz_detail", "connz"}
+
 // histogramBuckets are the upper bounds (in seconds) for
 // atlas_poll_duration_seconds. The set covers sub-second polls (typical
 // Agamemnon/Nestor) up to 5s near the 3s HTTP client timeout the pollers use.
@@ -33,6 +39,7 @@ type AtlasMetrics struct {
 	natsConnected       prometheus.Gauge
 	sseConnectedClients prometheus.Gauge
 	pollErrors          *prometheus.CounterVec
+	pollEndpointErrors  *prometheus.CounterVec
 	sseDropped          *prometheus.CounterVec
 	eventParseErrors    *prometheus.CounterVec
 	natsMessages        *prometheus.CounterVec
@@ -67,6 +74,13 @@ func newAtlasMetrics() *AtlasMetrics {
 			Name: "atlas_poll_errors_total",
 			Help: "Total number of poller errors by source.",
 		}, []string{"source"}),
+		pollEndpointErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "atlas_poll_endpoint_errors_total",
+			Help: "Total number of poller endpoint failures by source and endpoint. " +
+				"Emitted by pollers that fan out to multiple HTTP endpoints in a single cycle " +
+				"(e.g. NATSPoller hitting /varz, /jsz, /jsz?detail=1, /connz). Independent of " +
+				"atlas_poll_errors_total which counts cycle-level failures.",
+		}, []string{"source", "endpoint"}),
 		sseDropped: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "atlas_sse_dropped_total",
 			Help: "Total number of SSE events dropped for slow subscribers.",
@@ -91,6 +105,7 @@ func newAtlasMetrics() *AtlasMetrics {
 		m.natsConnected,
 		m.sseConnectedClients,
 		m.pollErrors,
+		m.pollEndpointErrors,
 		m.sseDropped,
 		m.eventParseErrors,
 		m.natsMessages,
@@ -105,6 +120,11 @@ func newAtlasMetrics() *AtlasMetrics {
 	for _, src := range pollSources {
 		m.pollErrors.WithLabelValues(src)
 		m.pollDuration.WithLabelValues(src)
+	}
+	// Pre-instantiate the NATS per-endpoint failure counter so the time
+	// series exist (with value 0) before the first failure occurs.
+	for _, ep := range natsEndpoints {
+		m.pollEndpointErrors.WithLabelValues("nats", ep)
 	}
 
 	return m
@@ -127,6 +147,16 @@ func (m *AtlasMetrics) SetSSEConnectedClients(n int64) {
 // IncPollError increments atlas_poll_errors_total for the given source label.
 func (m *AtlasMetrics) IncPollError(source string) {
 	m.pollErrors.WithLabelValues(source).Inc()
+}
+
+// IncEndpointError increments atlas_poll_endpoint_errors_total for the given
+// (source, endpoint) label pair. Emitted by pollers that fan out to multiple
+// HTTP endpoints in a single cycle so operators can attribute failures to the
+// specific endpoint that broke (e.g. {source="nats", endpoint="connz"}). This
+// is independent of atlas_poll_errors_total: cycle-level failures still
+// increment IncPollError exactly once per cycle.
+func (m *AtlasMetrics) IncEndpointError(source, endpoint string) {
+	m.pollEndpointErrors.WithLabelValues(source, endpoint).Inc()
 }
 
 // IncSSEDropped increments atlas_sse_dropped_total for the given subscriber label.


### PR DESCRIPTION
## Summary

- NATSPoller polls three endpoints (`/varz`, `/jsz?detail=1`, `/connz`) per cycle but previously only `/varz` and `/jsz` failures gated `recordResult`. A `/connz` failure left `lastSuccess` advancing — `/readyz` said OK while the dashboard's connection list (`handlers/pages.go` `GetNATSConns`) went stale forever. Closes the §3 audit MAJOR finding "NATSPoller readiness asymmetry."
- Now: any endpoint failure produces a joined error via `errors.Join`, naming which endpoint(s) failed (`fmt.Errorf("<endpoint>: %w", err)` wraps). `/readyz` returns 503 with a clear `last_error` until ALL three recover. Successful endpoints still update their cache slices — partial freshness is fine; what was NOT fine was misreporting "everything fresh" to `/readyz`.
- Per-endpoint failure metrics: chose a **dedicated `IncEndpointError(source, endpoint)` method** writing to a new `atlas_poll_endpoint_errors_total{source,endpoint}` counter, rather than a sub-source label on `atlas_poll_errors_total`. Reasoning: the existing `AtlasUpstreamDown` and `AtlasPollErrorsHigh` rules in `rules/atlas-alerts.yml` use the `source` label directly; sub-sourcing (`source="nats:connz"`) would either inflate alert firing (one cycle failure → up to three label-distinct increments) or require alert-rule edits. Keeping cycle-level `IncPollError(b.name)` with exactly-once-per-failed-cycle semantics preserves the existing alert behaviour while the new sibling counter answers "is /connz consistently failing or just /jsz?". No alert-rule changes needed.
- The four NATS endpoint label combinations are pre-instantiated at boot in `newAtlasMetrics` so the `atlas_poll_endpoint_errors_total{source="nats", endpoint=…}` series exist with value 0 from start-up — same warm-up pattern the existing `pollSources` loop uses for `atlas_poll_errors_total`.

## Test plan

- [x] `nats_readyz_test.go` covers all four endpoint-failure permutations (`/varz`, `/jsz?detail=1`, `/connz` alone, and a two-endpoint case) plus the all-succeed baseline. The `/connz`-fails case is explicitly tagged as the regression.
- [x] Existing poller tests still green (`metrics_wiring_test.go` updated to satisfy the widened `MetricsSink` interface; existing NATS tests in `poller_test.go` unchanged and still pass)
- [x] `go test -race -count=1 ./...` passes (golang:1.25-alpine container, all 11 packages green)
- [x] `gosec -quiet ./...` clean
- [ ] CI green
- [ ] Auto-merge fires once base lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)