### PR TITLE
chore(dx): add gofmt + golangci-lint + templ-generate pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,52 @@ repos:
       - id: yamllint
         args: ["--config-file", ".yamllint.yaml"]
         files: \.(yml|yaml)$
+  # Go-aware hooks for the dashboard/ subtree. All three are local
+  # `language: system` hooks — they shell out to whatever's on $PATH and
+  # avoid pulling in third-party (often archived) wrapper repos. Required
+  # binaries:
+  #   * gofmt          — bundled with Go (>= 1.23, see dashboard/go.mod)
+  #   * golangci-lint  — v2.x (CI pins v2.12.2; see .github/workflows/ci.yml)
+  #   * templ          — v0.3.1001 (pin in dashboard/go.mod);
+  #                      install: go install github.com/a-h/templ/cmd/templ@v0.3.1001
+  - repo: local
+    hooks:
+      - id: gofmt
+        name: gofmt (dashboard/)
+        description: Run gofmt -s -w over dashboard Go files; fail if anything was rewritten.
+        entry: >-
+          bash -c 'set -euo pipefail;
+          command -v gofmt >/dev/null
+          || { echo "gofmt not found on PATH; install Go >= 1.23 (see dashboard/go.mod)"; exit 1; };
+          cd dashboard && gofmt -l -s -w . && cd .. &&
+          git diff --exit-code -- "dashboard/**/*.go"'
+        language: system
+        types: [go]
+        files: ^dashboard/.*\.go$
+        pass_filenames: false
+      - id: golangci-lint
+        name: golangci-lint (dashboard/)
+        description: Run golangci-lint v2 over dashboard packages; matches CI's authoritative gate.
+        entry: >-
+          bash -c 'set -euo pipefail;
+          command -v golangci-lint >/dev/null
+          || { echo "golangci-lint not found on PATH; install v2.12.2 with
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2"; exit 1; };
+          cd dashboard && golangci-lint run ./...'
+        language: system
+        types: [go]
+        files: ^dashboard/.*\.go$
+        pass_filenames: false
+      - id: templ-generate
+        name: templ generate diff (dashboard/)
+        description: Regenerate *_templ.go from *.templ; fail if committed output drifts from sources.
+        entry: >-
+          bash -c 'set -euo pipefail;
+          command -v templ >/dev/null
+          || { echo "templ not found on PATH; install the pinned version with
+          go install github.com/a-h/templ/cmd/templ@v0.3.1001"; exit 1; };
+          cd dashboard && templ generate ./... && cd .. &&
+          git diff --exit-code -- "dashboard/web/templates/*_templ.go"'
+        language: system
+        files: ^dashboard/web/templates/.*\.(templ|templ\.go)$
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,24 @@ just status
 just test-scrape
 ```
 
+### Pre-commit hooks
+
+We use [pre-commit](https://pre-commit.com/) to catch formatting, linting, and templ-generate
+drift before a commit lands. Install once per clone:
+
+```bash
+pixi run pre-commit install
+```
+
+The hooks defined in `.pre-commit-config.yaml` cover:
+
+- **YAML/JSON/whitespace** — trailing whitespace, end-of-file, merge conflicts, `yamllint`.
+- **Go (`dashboard/`)** — `gofmt -s -w`, `golangci-lint run` (v2.12.2 — matches CI), and a
+  `templ generate` diff check (requires `templ` v0.3.1001 — `go install
+  github.com/a-h/templ/cmd/templ@v0.3.1001`).
+- **CI parity** — the Go hooks shell out to the same binaries CI runs, so a clean local
+  pre-commit means a green Go-side CI; CI remains the authoritative gate.
+
 ## What You Can Contribute
 
 - **Prometheus scrape configs** — New targets and scrape intervals

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -216,6 +216,11 @@ Templates use [templ](https://templ.guide/). Generated `*_templ.go` files are co
 templ generate ./...
 ```
 
+The `templ-generate` pre-commit hook (see the repo's
+[`CONTRIBUTING.md`](../CONTRIBUTING.md#pre-commit-hooks)) runs this for you on every commit
+and fails if the committed `*_templ.go` files drift from the `.templ` sources — but the
+manual command above is still the fastest way to refresh during development.
+
 ## Operating Atlas
 
 - [`docs/architecture.md`](docs/architecture.md) — component composition, concurrency model, resource bounds, security posture.


### PR DESCRIPTION
## Summary

- Adds three Go-aware pre-commit hooks that enforce gofmt, golangci-lint, and templ-generate freshness BEFORE a commit lands — closing the §13 audit MAJOR finding "pre-commit hooks lack Go enforcement."
- All three are `local` `language: system` hooks; no third-party archived repos in the chain (notably avoiding `dnephin/pre-commit-golang`, which is archived). Required binaries are the same ones CI already runs: `gofmt` (Go >= 1.23, see `dashboard/go.mod`), `golangci-lint` v2.12.2 (matches the CI pin from #464), and `templ` v0.3.1001 (matches `dashboard/go.mod`).
- All three hooks are scoped to `dashboard/` (the only Go subtree) and use `pass_filenames: false` because gofmt-with-write needs the post-write `git diff --exit-code` UX, golangci-lint is per-package, and templ generation is per-tree.
- CI's existing checks remain the authoritative gate. The hooks just shorten the feedback loop on the developer's machine.
- `CONTRIBUTING.md` gets a "Pre-commit hooks" subsection; `dashboard/README.md` Template Generation section gets a one-liner pointing at the new hook.

## Test plan

- [x] YAML parses cleanly (`python3 -c 'import yaml; yaml.safe_load(open(".pre-commit-config.yaml"))'`)
- [x] `pre-commit validate-config` clean (verified in `python:3.12-alpine` container per spec)
- [x] No regressions in markdownlint on touched files (the only errors reported are pre-existing MD060 hits on lines 70/107/116/144/172/195 of `dashboard/README.md` that also fail on the base branch and predate this PR; the 5-line block I added at line 213+ is clean)
- [ ] Hook execution by inspection — runner doesn't have `golangci-lint` v2 / `templ` v0.3.1001 on PATH, so `pre-commit run --all-files` was not exercised end-to-end; structure verified by reading the schema and tracing each `entry:` shell pipeline by hand
- [ ] CI green
- [ ] Auto-merge fires once base lands

## Notes / deviations

- Used YAML `>-` folded scalars (rather than single-line `entry:` strings) for the three hook entries. Reason: YAML's plain-scalar parser treats `: ` inside an unquoted value as a mapping key when the value begins with `bash -c '…'` (single-quotes are not YAML quoting at the value start, only at the very beginning). Folded scalars side-step the ambiguity without needing to escape every `: ` inside the inline error messages.
- Did NOT modify `.golangci.yml` (Wave 5 territory per spec).
- Did NOT touch CI workflows.
- Did NOT add a `staticcheck` hook (already covered transitively by `golangci-lint`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)