### PR TITLE
chore(dx): add 'just dev' hot-reload recipe (templ + air)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ data/
 secrets/
 configs/nginx/htpasswd
 configs/nginx/htpasswd.generated
+
+# air hot-reload build artifacts (see `just dev` / dashboard/.air.toml)
+dashboard/tmp/
+dashboard/build-errors.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,12 @@ just status
 just test-scrape
 ```
 
+### Dashboard hot-reload
+
+For iterating on the Go/templ dashboard, `just dev` runs `templ generate --watch` and
+[`air`](https://github.com/air-verse/air) in parallel so saves auto-rebuild and reload
+the binary. See `dashboard/README.md` ("Hot-reload dev loop") for prerequisites.
+
 ### Pre-commit hooks
 
 We use [pre-commit](https://pre-commit.com/) to catch formatting, linting, and templ-generate

--- a/dashboard/.air.toml
+++ b/dashboard/.air.toml
@@ -1,0 +1,63 @@
+# air config for the Atlas dashboard.
+# https://github.com/air-verse/air
+#
+# Pair this with `templ generate --watch` (run from `dashboard/` in a
+# separate process). air watches GENERATED Go files (including
+# web/templates/*_templ.go that templ rewrites on .templ changes) and
+# rebuilds + restarts the binary; templ owns the .templ -> _templ.go
+# pipeline. The two watchers stay in their own lanes.
+#
+# Run via `just dev` from the repo root.
+
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  # Build the dashboard entry point.
+  cmd = "go build -o ./tmp/main ./cmd/argus-dashboard"
+  bin = "./tmp/main"
+  full_bin = "./tmp/main"
+
+  # Watch source roots that produce the binary.
+  include_dir = ["cmd", "internal", "web/templates"]
+  include_ext = ["go"]
+
+  # Don't react to .templ source edits — templ generate --watch handles
+  # those and writes _templ.go which we *do* watch (above).
+  exclude_regex = ["_test\\.go$", ".*\\.templ$"]
+
+  # Keep test directories, lint cache, and coverage out of the rebuild loop.
+  exclude_dir = ["tests", "tmp", ".golangci-cache", "web/static", "docs", "scripts"]
+  exclude_file = ["coverage.out"]
+
+  # Only react to actual content writes, not stat-only events.
+  exclude_unchanged = true
+  follow_symlink = false
+
+  # Coalesce a burst of saves into a single rebuild (editors may write
+  # multiple times in a few ms when saving).
+  delay = 200  # ms
+
+  # Surface build errors but don't kill the watcher.
+  stop_on_error = false
+  send_interrupt = true
+  kill_delay = "500ms"
+
+  log = "build-errors.log"
+
+[log]
+  time = true
+
+[color]
+  # Colorize when stdout is a TTY; air falls back to plain on pipes.
+  main = "magenta"
+  watcher = "cyan"
+  build = "yellow"
+  runner = "green"
+
+[misc]
+  clean_on_exit = true
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -10,6 +10,30 @@ The default `ATLAS_AUTH_MODE=bearer` requires `ATLAS_AUTH_BEARER_TOKEN`. The sim
 get going locally is to set both, or to switch off auth explicitly with `ATLAS_AUTH_MODE=none`
 (strictly local — Atlas will log a warning).
 
+### Hot-reload dev loop
+
+Once you've run `./scripts/setup.sh && pixi shell` and have
+[`templ`](https://templ.guide/) and [`air`](https://github.com/air-verse/air) on your
+`$PATH`, a single command runs the whole edit/build/reload cycle:
+
+```bash
+just dev
+```
+
+This starts `templ generate --watch` and `air` in parallel (output is prefixed `[templ]`
+and `[air]`). Edit a `.templ` or `.go` file and the dashboard rebuilds and restarts
+automatically; Ctrl-C tears both watchers down.
+
+If the install hints flag a missing tool:
+
+```bash
+go install github.com/a-h/templ/cmd/templ@v0.3.1001
+go install github.com/air-verse/air@latest
+```
+
+`air` is intentionally not pinned in `pixi.toml` or `scripts/setup.sh` — it's an opt-in
+dev tool. The non-watch flow below still works unchanged.
+
 ```bash
 # Local dev, auth off (logs a warning)
 ATLAS_AUTH_MODE=none go run ./cmd/argus-dashboard
@@ -210,7 +234,8 @@ go build -ldflags "-X github.com/HomericIntelligence/atlas/internal/version.Vers
 
 ## Template Generation
 
-Templates use [templ](https://templ.guide/). Generated `*_templ.go` files are committed. To regenerate:
+Templates use [templ](https://templ.guide/). Generated `*_templ.go` files are committed.
+To regenerate (or use `just dev` for hot-reload):
 
 ```bash
 templ generate ./...

--- a/justfile
+++ b/justfile
@@ -48,6 +48,13 @@ validate:
     {{compose_cmd}} config --quiet
     @echo "Config is valid."
 
+# Hot-reload dev loop for the dashboard (templ generate --watch + air in parallel)
+dev:
+    @command -v templ >/dev/null 2>&1 || { echo "templ not found on PATH. Install: go install github.com/a-h/templ/cmd/templ@v0.3.1001"; exit 1; }
+    @command -v air >/dev/null 2>&1 || { echo "air not found on PATH. Install: go install github.com/air-verse/air@latest"; exit 1; }
+    @test -f .env || { echo ".env missing. Run ./scripts/setup.sh first."; exit 1; }
+    @./scripts/dev-watch.sh
+
 # Run local test suite
 test:
     python3 -m pytest tests/ -v 2>/dev/null || python3 -m unittest discover -s tests -v

--- a/scripts/dev-watch.sh
+++ b/scripts/dev-watch.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Run `templ generate --watch` and `air` in parallel from dashboard/.
+# Tees both children's output with a [templ]/[air] prefix so the
+# contributor can tell which pipeline yelled.
+#
+# Ctrl-C (or any signal) tears down the whole process group: the trap
+# below sends INT/TERM to every child via `kill 0`, and the `wait`
+# returns. Used by the `just dev` recipe.
+#
+# Pre-flight (PATH for air/templ, .env existence) is done in the
+# justfile recipe, not here, so this script can be linted in isolation
+# without those side effects.
+
+set -euo pipefail
+
+# Resolve repo root (this script lives in <repo>/scripts/).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DASHBOARD_DIR="${REPO_ROOT}/dashboard"
+
+if [[ ! -d "${DASHBOARD_DIR}" ]]; then
+  echo "dev-watch: dashboard/ not found at ${DASHBOARD_DIR}" >&2
+  exit 1
+fi
+
+cd "${DASHBOARD_DIR}"
+
+# Make sure tmp/ exists for air's build artifact.
+mkdir -p tmp
+
+echo "dev-watch: starting templ + air from ${DASHBOARD_DIR}"
+echo "dev-watch: Ctrl-C tears both watchers down."
+
+# Tear-down trap. `kill 0` signals the whole process group, including
+# any descendants the watchers spawned (go build, the rebuilt binary,
+# etc.). Using INT first gives them a chance to flush; the EXIT branch
+# is a belt-and-braces fallback.
+cleanup() {
+  trap - INT TERM EXIT
+  echo
+  echo "dev-watch: stopping watchers..."
+  kill 0 2>/dev/null || true
+}
+trap cleanup INT TERM EXIT
+
+# Run each watcher in its own subshell so we capture stderr alongside
+# stdout and can prefix every line. `stdbuf -oL` keeps the output
+# line-buffered through the pipe so prefixes appear in real time.
+( stdbuf -oL templ generate --watch 2>&1 | sed -u 's/^/[templ] /' ) &
+TEMPL_PID=$!
+
+( stdbuf -oL air -c .air.toml 2>&1 | sed -u 's/^/[air]   /' ) &
+AIR_PID=$!
+
+# Block on either child. Whichever exits first triggers the trap and
+# brings the other down with it.
+wait -n "${TEMPL_PID}" "${AIR_PID}"


### PR DESCRIPTION
## Summary

- Adds `just dev` — a single command that starts `templ generate --watch` and `air` concurrently from `dashboard/`, so a contributor edits a `.templ` or `.go` file and the binary rebuilds + reloads without manual intervention. Closes the §13 audit MAJOR finding "no hot-reload for Go dashboard."
- New `dashboard/.air.toml` watches `cmd/`, `internal/`, and the GENERATED `web/templates/*_templ.go`; excludes the `.templ` source (handled by the templ watcher) and tests.
- Pre-flight checks for `air`, `templ`, and `.env` with one-line install hints (`go install github.com/air-verse/air@latest`, `go install github.com/a-h/templ/cmd/templ@v0.3.1001`).
- Parallel-watcher bash extracted to `scripts/dev-watch.sh` so it's shellcheck-clean; recipe just dispatches. Ctrl-C tears both children down via `trap cleanup INT TERM EXIT` + `kill 0` (sends to whole process group, including any descendants air/templ spawn).
- Documents the recipe in `dashboard/README.md`'s Quick Start and Template Generation sections; adds a one-line pointer in `CONTRIBUTING.md`.
- `.gitignore` excludes air's `dashboard/tmp/main` artifact and `build-errors.log`.
- No new dependencies in `pixi.toml` or `scripts/setup.sh` — air and templ stay opt-in dev tools.

## Test plan

- [x] `just --evaluate` parses
- [x] `just --list` shows `dev`
- [x] `dashboard/.air.toml` is valid TOML (verified with `tomli.load`)
- [x] `markdownlint-cli2` clean across all 13 markdown files
- [x] `shellcheck` clean on `scripts/dev-watch.sh`
- [ ] Hot-reload smoke test (manual; reviewer please verify by running `just dev`, editing `dashboard/web/templates/agents.templ` and `dashboard/internal/handlers/sse.go`, and observing both pipelines fire)
- [ ] CI green
- [ ] Auto-merge fires once base lands

Verified by inspection of the air config + justfile recipe; please smoke-test locally — sub-agent runner can't actually start `air`/`templ` (no real terminal, no writable Go cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)