### PR TITLE
fix(events): copy-on-write subscriber set so Publish takes no write lock

### DIFF
--- a/dashboard/internal/events/bus.go
+++ b/dashboard/internal/events/bus.go
@@ -60,68 +60,131 @@ func (r *ringBuffer) Snapshot(n int) []Event {
 
 // Bus is an in-process pub/sub event bus with a ring-buffer history and
 // non-blocking fan-out to registered subscribers.
+//
+// The subscriber set is stored as an immutable slice behind an
+// atomic.Pointer (copy-on-write). Publish reads the slice with a single
+// atomic load and iterates it lock-free; only the ring-buffer push uses a
+// narrow mutex. Subscribe and Unsubscribe take a small mutex (subsMu),
+// build a NEW slice, and Store it. This eliminates the contention
+// bottleneck where N concurrent publishers would otherwise serialize on a
+// single write-lock during fan-out.
+//
+// Concurrency invariants:
+//
+//   - Subscribe stores the new slice before returning, so any Publish that
+//     starts after Subscribe returns will observe the new subscriber.
+//   - Unsubscribe atomically swaps in a new slice without the channel; any
+//     Publish whose Load() preceded the Store may still send one final event
+//     to the channel. Unsubscribe does NOT close the channel — closing while
+//     a concurrent Publish is mid-send would race. The caller is expected to
+//     drop the channel reference; the channel will be GC'd once no goroutine
+//     holds it. (The existing SSE handler exits its read loop before
+//     Unsubscribe runs, so this is the natural pattern.)
+//   - The drops counter is updated atomically and not protected by any lock.
 type Bus struct {
-	mu   sync.RWMutex
-	subs map[chan Event]struct{}
-	ring *ringBuffer
+	// subs is an *atomic.Pointer to an immutable []chan Event. Reads in
+	// Publish are lock-free.
+	subs atomic.Pointer[[]chan Event]
+	// subsMu serializes Subscribe / Unsubscribe writers building the new
+	// slice. It is never held during fan-out.
+	subsMu sync.Mutex
+
+	// ringMu protects the ring buffer; held only during Push/Snapshot.
+	ringMu sync.Mutex
+	ring   *ringBuffer
+
 	// drops counts events not delivered due to a full subscriber channel.
 	drops int64
 }
 
 // NewBus returns a new Bus whose ring buffer holds at most ringCap events.
 func NewBus(ringCap int) *Bus {
-	return &Bus{
-		subs: make(map[chan Event]struct{}),
+	b := &Bus{
 		ring: newRingBuffer(ringCap),
 	}
+	empty := make([]chan Event, 0)
+	b.subs.Store(&empty)
+	return b
 }
 
 // Subscribe returns a new channel that will receive published events.
 // bufSize is the channel's buffer depth; use 0 for an unbuffered channel.
+//
+// Any Publish call that begins after Subscribe returns is guaranteed to see
+// the new subscriber.
 func (b *Bus) Subscribe(bufSize int) <-chan Event {
 	ch := make(chan Event, bufSize)
-	b.mu.Lock()
-	b.subs[ch] = struct{}{}
-	b.mu.Unlock()
+	b.subsMu.Lock()
+	cur := b.subs.Load()
+	next := make([]chan Event, len(*cur)+1)
+	copy(next, *cur)
+	next[len(*cur)] = ch
+	b.subs.Store(&next)
+	b.subsMu.Unlock()
 	return ch
 }
 
-// Unsubscribe removes ch from the subscriber set and closes it.
+// Unsubscribe removes ch from the subscriber set.
+//
+// Note: Unsubscribe does NOT close the channel. Closing while a concurrent
+// Publish (whose atomic Load preceded our Store) is mid-send would race and
+// could panic with "send on closed channel". Instead, after Unsubscribe
+// returns, any in-flight Publish that already loaded the previous slice may
+// deliver one final event; subsequent Publishes will not. Once the
+// caller's read loop exits and no goroutine retains the channel, GC
+// reclaims it.
 func (b *Bus) Unsubscribe(ch <-chan Event) {
-	b.mu.Lock()
-	// The map key type must be chan Event (bidirectional) so we need to
-	// recover it. We iterate to find the matching channel.
-	for k := range b.subs {
-		if k == ch {
-			delete(b.subs, k)
-			close(k)
+	b.subsMu.Lock()
+	cur := b.subs.Load()
+	idx := -1
+	for i, c := range *cur {
+		if c == ch {
+			idx = i
 			break
 		}
 	}
-	b.mu.Unlock()
+	if idx < 0 {
+		b.subsMu.Unlock()
+		return
+	}
+	next := make([]chan Event, 0, len(*cur)-1)
+	next = append(next, (*cur)[:idx]...)
+	next = append(next, (*cur)[idx+1:]...)
+	b.subs.Store(&next)
+	b.subsMu.Unlock()
 }
 
 // Publish records e in the ring buffer and attempts a non-blocking send to
-// every registered subscriber. Events dropped due to a full channel increment
-// the drop counter atomically.
+// every registered subscriber. Events dropped due to a full channel
+// increment the drop counter atomically.
+//
+// Publish takes a narrow lock for the ring-buffer push only; the fan-out
+// loop reads the subscriber slice via a single atomic Load and runs
+// lock-free, so concurrent Publishes do not serialize on the subscriber
+// set.
 func (b *Bus) Publish(e Event) {
-	b.mu.Lock()
+	// Ring buffer push is a separate concern with its own narrow lock.
+	b.ringMu.Lock()
 	b.ring.Push(e)
-	for ch := range b.subs {
+	b.ringMu.Unlock()
+
+	// Fan-out: load the immutable subscriber slice and iterate without any
+	// lock. Each send is non-blocking; full channels increment drops.
+	subs := b.subs.Load()
+	for _, ch := range *subs {
 		select {
 		case ch <- e:
 		default:
 			atomic.AddInt64(&b.drops, 1)
 		}
 	}
-	b.mu.Unlock()
 }
 
 // Snapshot returns up to n of the most-recent events in chronological
 // (oldest-first) order.
 func (b *Bus) Snapshot(n int) []Event {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
+	b.ringMu.Lock()
+	defer b.ringMu.Unlock()
 	return b.ring.Snapshot(n)
 }
 

--- a/dashboard/internal/events/bus_test.go
+++ b/dashboard/internal/events/bus_test.go
@@ -3,6 +3,7 @@ package events_test
 import (
 	"encoding/json"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -216,6 +217,171 @@ func TestBusDropCounter(t *testing.T) {
 
 	if got := b.Drops(); got != 5 {
 		t.Errorf("Drops() = %d, want 5", got)
+	}
+}
+
+// TestBus_ConcurrentPublishSubscribeUnsubscribe is a race-stress test for the
+// copy-on-write subscriber set. It runs many publishers concurrently with
+// many subscribers that subscribe, drain a bounded number of events, and
+// unsubscribe, repeatedly. Run with:
+//
+//	go test -race -count=10 -run TestBus_ConcurrentPublishSubscribeUnsubscribe ./internal/events/...
+//
+// The test is genuinely race-free: Publish reads the subscriber slice via
+// an atomic Load and iterates without any lock, Subscribe/Unsubscribe
+// build new slices under a small mutex, and Unsubscribe never closes the
+// channel (so a stale Publish that already loaded the prior slice may
+// deliver one last event without panicking).
+//
+// The test asserts:
+//   - completion within a reasonable time bound (no deadlock under
+//     contention),
+//   - that some lower bound of events was delivered to subscribers (proving
+//     Publish is not dropping everything to lock contention or losing all
+//     deliveries to the COW slice swap).
+func TestBus_ConcurrentPublishSubscribeUnsubscribe(t *testing.T) {
+	t.Parallel()
+
+	const (
+		numPublishers     = 100
+		eventsPerPub      = 100
+		numSubscribers    = 100
+		subsLifetimeReads = 25 // events drained per subscription cycle
+		ringCap           = 256
+	)
+
+	b := events.NewBus(ringCap)
+
+	var (
+		wgPublishers  sync.WaitGroup
+		wgSubscribers sync.WaitGroup
+		stopSubs      atomic.Bool
+		delivered     atomic.Int64
+	)
+
+	// Publishers: each emits a bounded number of events.
+	wgPublishers.Add(numPublishers)
+	for i := range numPublishers {
+		go func(id int) {
+			defer wgPublishers.Done()
+			ev := makeEvent("agent", "hi.agents.stress.heartbeat")
+			for j := range eventsPerPub {
+				b.Publish(ev)
+				_ = j
+			}
+			_ = id
+		}(i)
+	}
+
+	// Subscribers: subscribe, drain up to subsLifetimeReads events (or
+	// short timeout), unsubscribe, repeat. They keep churning until
+	// publishers finish.
+	wgSubscribers.Add(numSubscribers)
+	for i := range numSubscribers {
+		go func(id int) {
+			defer wgSubscribers.Done()
+			for !stopSubs.Load() {
+				ch := b.Subscribe(8)
+				deadline := time.NewTimer(50 * time.Millisecond)
+				received := 0
+			drain:
+				for received < subsLifetimeReads {
+					select {
+					case _, ok := <-ch:
+						if !ok {
+							// Channel was closed by some other path —
+							// not expected with COW Unsubscribe but
+							// handle defensively.
+							break drain
+						}
+						delivered.Add(1)
+						received++
+					case <-deadline.C:
+						break drain
+					}
+				}
+				if !deadline.Stop() {
+					select {
+					case <-deadline.C:
+					default:
+					}
+				}
+				b.Unsubscribe(ch)
+			}
+			_ = id
+		}(i)
+	}
+
+	// Bound the test runtime: if publishers don't finish in 30s under
+	// -race, something is deadlocked or pathologically slow.
+	publishersDone := make(chan struct{})
+	go func() {
+		wgPublishers.Wait()
+		close(publishersDone)
+	}()
+
+	select {
+	case <-publishersDone:
+		// fast path
+	case <-time.After(30 * time.Second):
+		t.Fatal("publishers did not finish within 30s — possible deadlock or contention regression")
+	}
+
+	// Signal subscribers to wind down and wait for them.
+	stopSubs.Store(true)
+	subscribersDone := make(chan struct{})
+	go func() {
+		wgSubscribers.Wait()
+		close(subscribersDone)
+	}()
+	select {
+	case <-subscribersDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("subscribers did not wind down within 30s")
+	}
+
+	// Sanity: at least SOME events were delivered while subscribers were
+	// connected. We don't assert a tight lower bound because the test is
+	// inherently racy by design (subscribers come and go), but zero
+	// deliveries would indicate a serious regression where Publish drops
+	// everything.
+	if delivered.Load() == 0 {
+		t.Errorf("delivered 0 events across %d publishers and %d churning subscribers; "+
+			"Publish appears to be dropping everything", numPublishers, numSubscribers)
+	}
+
+	// Drops counter must remain coherent (atomic) — just read it; if there
+	// were a torn read under -race the detector would have fired.
+	_ = b.Drops()
+
+	// Ring buffer must still be coherent.
+	snap := b.Snapshot(ringCap + 1)
+	if len(snap) > ringCap {
+		t.Errorf("Snapshot returned %d events, want <= %d (ringCap)", len(snap), ringCap)
+	}
+}
+
+// TestBus_SubscribeBeforePublishDelivers asserts that an event published
+// after Subscribe returns is observed by the new subscriber. This is the
+// "subscribe-then-publish must deliver" invariant for the COW pattern.
+func TestBus_SubscribeBeforePublishDelivers(t *testing.T) {
+	t.Parallel()
+
+	b := events.NewBus(16)
+
+	// Run many iterations to shake out any ordering bug between Store and
+	// Load of the subscriber slice.
+	const iters = 1000
+	for range iters {
+		ch := b.Subscribe(1)
+		b.Publish(makeEvent("agent", "hi.agents.subscribe.before.publish"))
+		select {
+		case <-ch:
+			// OK
+		case <-time.After(time.Second):
+			t.Fatal("subscriber did not receive event published after Subscribe returned")
+		}
+		b.Unsubscribe(ch)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replaces `Bus.Publish`'s write-lock-during-fan-out with a copy-on-write subscriber slice loaded via `atomic.Pointer`. Closes the §3 audit MAJOR finding "`Bus.Publish` holds write-mutex during fan-out — contention bottleneck under N publishers + M subscribers."
- `Subscribe` / `Unsubscribe` build a new slice and `Store` it under a small mutex; `Publish` `Load()`s the slice and iterates lock-free with the same non-blocking `select { case ch <- e: default: drops++ }`.
- Ring-buffer push keeps its own narrow lock (`ringMu`); `Snapshot` semantics are unchanged.
- `Unsubscribe` no longer closes the channel — closing while a stale `Publish` (whose `Load()` preceded our `Store()`) is mid-send would race. Existing callers (SSE handler, integration tests) exit their read loops before calling `Unsubscribe` and drop the channel reference, so behavior is preserved. `TestBusUnsubscribe` already accepted both "nothing received" and "channel closed" outcomes.
- Drops counter is unchanged (already atomic).

## Test plan

- [x] `go test -race -count=10 -run TestBus ./internal/events/...` — clean (~4.4s)
- [x] `go test -race -count=1 ./...` — all packages green
- [x] `gosec ./...` — clean
- [x] New `TestBus_ConcurrentPublishSubscribeUnsubscribe`: 100 publishers × 100 events each + 100 subscribers churning in/out, with a 30s deadlock guard and non-zero-deliveries assertion
- [x] New `TestBus_SubscribeBeforePublishDelivers`: 1000-iteration assertion that an event published after `Subscribe` returns is observed (subscribe-then-publish-must-deliver invariant)
- [x] Existing `TestBusRingBufferConcurrent`, `TestBusFanOut`, `TestBusSlowSubscriberDrop`, `TestBusUnsubscribe`, `TestBusSnapshot`, `TestBusSnapshotN`, `TestBusDropCounter`, `TestBusZeroSubscribers` all still green
- [ ] CI green
- [ ] Auto-merge fires once base lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)