### PR TITLE
fix(sse): subscribe-then-snapshot to close replay-vs-live gap

### DIFF
--- a/dashboard/internal/events/bus.go
+++ b/dashboard/internal/events/bus.go
@@ -95,6 +95,10 @@ type Bus struct {
 
 	// drops counts events not delivered due to a full subscriber channel.
 	drops int64
+	// seq is a monotonically-increasing counter used to stamp Event.ID inside
+	// Publish so that consumers (e.g. the SSE handler) can de-duplicate events
+	// that appear in BOTH a ring-buffer snapshot and a live subscriber channel.
+	seq uint64
 }
 
 // NewBus returns a new Bus whose ring buffer holds at most ringCap events.
@@ -155,14 +159,21 @@ func (b *Bus) Unsubscribe(ch <-chan Event) {
 }
 
 // Publish records e in the ring buffer and attempts a non-blocking send to
-// every registered subscriber. Events dropped due to a full channel
-// increment the drop counter atomically.
+// every registered subscriber. Events dropped due to a full channel increment
+// the drop counter atomically.
 //
-// Publish takes a narrow lock for the ring-buffer push only; the fan-out
-// loop reads the subscriber slice via a single atomic Load and runs
-// lock-free, so concurrent Publishes do not serialize on the subscriber
-// set.
+// Publish stamps e.ID with a monotonically-increasing per-Bus sequence number
+// BEFORE pushing into the ring or fanning out to subscribers, overwriting any
+// value the caller provided. The ID stamped on the event in the ring buffer
+// matches the ID delivered to subscribers, allowing consumers (e.g. the SSE
+// handler) to de-duplicate events that appear in both a snapshot and the live
+// channel.
+//
+// Publish takes a narrow lock for the ring-buffer push only; the fan-out loop
+// reads the subscriber slice via a single atomic Load and runs lock-free, so
+// concurrent Publishes do not serialize on the subscriber set.
 func (b *Bus) Publish(e Event) {
+	e.ID = atomic.AddUint64(&b.seq, 1)
 	// Ring buffer push is a separate concern with its own narrow lock.
 	b.ringMu.Lock()
 	b.ring.Push(e)

--- a/dashboard/internal/events/topics.go
+++ b/dashboard/internal/events/topics.go
@@ -8,7 +8,14 @@ import (
 // Event is a single observable occurrence within the Atlas dashboard.
 // Topic identifies the broad category (e.g. "agent", "task", "nats") and
 // Subject is the fully-qualified NATS-style subject string.
+//
+// ID is a monotonically-increasing per-Bus identity stamped by Bus.Publish.
+// Callers MUST NOT set ID — any value supplied by the caller is overwritten
+// inside Publish. The ID is used by SSE replay to de-duplicate events that
+// appear in BOTH the ring-buffer snapshot and the live subscriber channel
+// during the subscribe-then-snapshot replay window.
 type Event struct {
+	ID      uint64
 	Topic   string
 	Subject string
 	Payload json.RawMessage

--- a/dashboard/internal/handlers/sse.go
+++ b/dashboard/internal/handlers/sse.go
@@ -98,17 +98,14 @@ func (h *SSE) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if replayStr := r.URL.Query().Get("replay"); replayStr != "" {
-		if n, err := strconv.Atoi(replayStr); err == nil && n > 0 {
-			for _, e := range h.bus.Snapshot(n) {
-				if err := writeEvent(w, e); err != nil {
-					return
-				}
-				flusher.Flush()
-			}
-		}
-	}
-
+	// Subscribe FIRST so that any event published from this point onward is
+	// captured on the live channel. We then take a snapshot AFTER the
+	// subscription is registered: events published in the small window
+	// between Subscribe and Snapshot will appear in BOTH the snapshot and
+	// the live channel, which is fine because we de-duplicate by Event.ID
+	// while draining the replay window. Doing it the other way round
+	// (Snapshot then Subscribe) loses any event published between the two
+	// calls — see audit finding "SSE replay race vs new publishes".
 	ch := h.bus.Subscribe(1000)
 	defer h.bus.Unsubscribe(ch)
 
@@ -119,6 +116,37 @@ func (h *SSE) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		cur := h.connected.Add(-1)
 		(*h.metrics.Load()).SetSSEConnectedClients(cur)
 	}()
+
+	// maxReplayedID is the highest Event.ID written to the wire during the
+	// replay phase. While maxReplayedID > 0 we are still inside the replay
+	// window and skip any live-channel event whose ID is <= maxReplayedID
+	// (it was already delivered as part of the snapshot). Once we receive a
+	// live event with ID > maxReplayedID the de-dup logic disengages.
+	var maxReplayedID uint64
+	dedupActive := false
+
+	if replayStr := r.URL.Query().Get("replay"); replayStr != "" {
+		if n, err := strconv.Atoi(replayStr); err == nil && n > 0 {
+			snapshot := h.bus.Snapshot(n)
+			for _, e := range snapshot {
+				if len(topicFilter) > 0 {
+					if _, pass := topicFilter[e.Topic]; !pass {
+						continue
+					}
+				}
+				if err := writeEvent(w, e); err != nil {
+					return
+				}
+				flusher.Flush()
+				if e.ID > maxReplayedID {
+					maxReplayedID = e.ID
+				}
+			}
+			if maxReplayedID > 0 {
+				dedupActive = true
+			}
+		}
+	}
 
 	ticker := time.NewTicker(HeartbeatInterval())
 	defer ticker.Stop()
@@ -139,6 +167,15 @@ func (h *SSE) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if !ok {
 				// Channel was closed (unsubscribed).
 				return
+			}
+			// Skip events that were already delivered during the replay
+			// phase. Once we see an ID strictly greater than the highest
+			// replayed ID we are past the dedup window for good.
+			if dedupActive {
+				if e.ID <= maxReplayedID {
+					continue
+				}
+				dedupActive = false
 			}
 			// Apply topic filter.
 			if len(topicFilter) > 0 {

--- a/dashboard/internal/handlers/sse_test.go
+++ b/dashboard/internal/handlers/sse_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -481,6 +482,178 @@ func TestSSEMultipleTopics(t *testing.T) {
 	}
 	if received["nats"] {
 		t.Error("received topic \"nats\"; want it filtered out (topics=agent,task)")
+	}
+}
+
+// TestSSE_NoReplayGap is the regression test for the §3 audit MAJOR
+// "SSE replay race vs new publishes." It proves that no event is silently
+// lost in the gap between the bus snapshot and the live subscriber channel
+// that the handler opens for an SSE connection.
+//
+// Strategy:
+//  1. Pre-publish a handful of events so the ring buffer is non-empty when
+//     the client connects (exercises the replay branch).
+//  2. Open an SSE connection with `?replay=N`.
+//  3. While the connection is live, hammer Publish from a goroutine with
+//     monotonically-increasing payload seq values.
+//  4. After the publisher finishes and the connection has had a moment to
+//     drain, collect every payload `seq` written to the wire.
+//  5. Assert that the delivered seq values form a contiguous range
+//     [min..max] with no holes (no gap) and no duplicates (de-dup works).
+//
+// With the buggy ordering (Snapshot then Subscribe) this test will fail
+// because any seq published in the race window between the two calls is
+// missing from BOTH the snapshot and the live channel, producing a hole
+// in the delivered range.
+func TestSSE_NoReplayGap(t *testing.T) {
+	t.Parallel()
+
+	// Ring capacity larger than the burst of publishes done before connect,
+	// so the snapshot is well-defined and not truncated.
+	const (
+		preBurst   = 5
+		liveBurst  = 1000
+		ringCap    = 1024
+		replayN    = 256
+		drainGrace = 200 * time.Millisecond
+	)
+
+	bus := events.NewBus(ringCap)
+	h := handlers.NewSSE(bus)
+
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	// 1. Pre-publish a handful of events so the snapshot is non-empty.
+	for i := 1; i <= preBurst; i++ {
+		bus.Publish(makeEvt(t, "agent", map[string]int{"seq": i}))
+	}
+
+	// 2. Open the SSE connection. We give the handler a generous request
+	// timeout — we will close the body explicitly once we have collected
+	// enough events.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		srv.URL+"/events?replay="+strconv.Itoa(replayN), nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// 3. Hammer Publish from a separate goroutine. We start the publisher
+	// immediately to maximise the chance that some publishes land in the
+	// race window between Subscribe and Snapshot inside the handler. The
+	// publisher numbers events with payload seq starting from preBurst+1
+	// so the full sequence on the bus is 1..preBurst+liveBurst.
+	pubDone := make(chan struct{})
+	go func() {
+		defer close(pubDone)
+		for i := preBurst + 1; i <= preBurst+liveBurst; i++ {
+			bus.Publish(makeEvt(t, "agent", map[string]int{"seq": i}))
+		}
+	}()
+
+	// 4. Drain the SSE response. We track distinct seq values seen in
+	// payloads. Once we have observed the final published seq we close
+	// the connection. A safety timeout protects against a stuck stream.
+	final := preBurst + liveBurst
+	seen := make(map[int]int) // seq -> count (count > 1 means duplicate)
+	scanner := bufio.NewScanner(resp.Body)
+	// Larger buffer; default 64KB is fine but be defensive about long lines.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	scanCtx, scanCancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer scanCancel()
+
+	scanDone := make(chan struct{})
+	go func() {
+		defer close(scanDone)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			raw := strings.TrimPrefix(line, "data: ")
+			var m map[string]int
+			if err := json.Unmarshal([]byte(raw), &m); err != nil {
+				continue
+			}
+			seq, ok := m["seq"]
+			if !ok {
+				continue
+			}
+			seen[seq]++
+			// Once the publisher is done AND we have seen the last seq,
+			// we can stop scanning. We also stop early once we have the
+			// final seq even if pubDone hasn't been read yet (it implies
+			// the publisher is done).
+			if seq == final {
+				return
+			}
+		}
+	}()
+
+	// Wait for the publisher to finish, then give the SSE goroutine a
+	// brief grace period to flush the final events through.
+	select {
+	case <-pubDone:
+	case <-scanCtx.Done():
+		t.Fatalf("publisher did not finish within timeout")
+	}
+
+	select {
+	case <-scanDone:
+	case <-time.After(drainGrace):
+		// Force the scanner to exit by closing the body.
+		_ = resp.Body.Close()
+		<-scanDone
+	}
+
+	// 5. Validate: the seq values seen must form a contiguous range and
+	// must have no duplicates.
+	if len(seen) == 0 {
+		t.Fatalf("no events delivered to SSE client")
+	}
+
+	// Find the range observed.
+	minSeq, maxSeq := -1, -1
+	for s := range seen {
+		if minSeq == -1 || s < minSeq {
+			minSeq = s
+		}
+		if s > maxSeq {
+			maxSeq = s
+		}
+	}
+
+	// No duplicates — the de-dup logic must collapse events that appeared
+	// in BOTH the snapshot and the live channel during the replay window.
+	for s, c := range seen {
+		if c != 1 {
+			t.Errorf("seq %d delivered %d times; want exactly 1 (de-dup failure)", s, c)
+		}
+	}
+
+	// No gap — every integer in [minSeq, maxSeq] must be present. The
+	// race-window bug manifests as missing entries in this contiguous
+	// span.
+	for s := minSeq; s <= maxSeq; s++ {
+		if _, ok := seen[s]; !ok {
+			t.Errorf("seq %d missing from delivered range [%d..%d] (replay-vs-live gap)",
+				s, minSeq, maxSeq)
+		}
+	}
+
+	// Sanity: the final published seq must be among the delivered ones.
+	// If not, the test did not actually exercise the live-stream phase.
+	if _, ok := seen[final]; !ok {
+		t.Errorf("final seq %d not delivered; live-stream phase not exercised", final)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Re-orders SSE-handler initialization from \`Snapshot\` -> \`Subscribe\` (which silently lost any event published in the window between the two calls) to \`Subscribe\` -> \`Snapshot\` -> de-dup. Closes the §3 audit MAJOR finding **\"SSE replay race vs new publishes.\"**
- Adds a monotonic \`uint64 ID\` field to \`events.Event\`, populated by \`atomic.AddUint64\` inside \`Bus.Publish\`, used to de-duplicate events that appear in BOTH the snapshot and the live stream during the (now-narrow, intentional) overlap window. Callers cannot interfere — \`Publish\` overwrites the ID; the only existing direct construction site (\`internal/nats/subscriber.go\`) is unaffected.
- Regression test \`TestSSE_NoReplayGap\` proves a contiguous seq range is delivered under concurrent publishes; clean under \`-race -count=10\`. The test was confirmed to fail on the buggy ordering (with a small artificial widening of the race window) before being pointed at the fix.

## Test plan

- [x] \`TestSSE_NoReplayGap\` — race-free, asserts no gap and no dup
- [x] \`go test -race -count=10 -run TestSSE_\` ./internal/handlers/... green
- [x] \`go test -race -count=1 ./...\` all packages green
- [x] \`gosec ./...\` clean
- [ ] CI green
- [ ] Auto-merge fires once base lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)