### PR TITLE
refactor(store): collapse cache Set/Get pairs into a generic helper

### DIFF
--- a/dashboard/internal/store/cache.go
+++ b/dashboard/internal/store/cache.go
@@ -31,7 +31,34 @@ type Cache struct {
 // NewCache returns an empty Cache.
 func NewCache() *Cache { return &Cache{} }
 
+// setSlice writes a defensive copy of src to *dst under mu's write lock.
+// All slice-typed Cache setters delegate here; the indirection keeps
+// mutex/copy discipline in one place so a future accessor can't drift.
+func setSlice[T any](mu *sync.RWMutex, dst *[]T, src []T) {
+	cp := make([]T, len(src))
+	copy(cp, src)
+	mu.Lock()
+	*dst = cp
+	mu.Unlock()
+}
+
+// getSlice returns a defensive copy of *src under mu's read lock.
+// Returns nil (not an empty non-nil slice) when *src is empty, matching
+// the pre-refactor zero-value behaviour exercised by TestNewCache_EmptyState.
+func getSlice[T any](mu *sync.RWMutex, src *[]T) []T {
+	mu.RLock()
+	defer mu.RUnlock()
+	if len(*src) == 0 {
+		return nil
+	}
+	cp := make([]T, len(*src))
+	copy(cp, *src)
+	return cp
+}
+
 // SetProbes replaces the stored probe results and records the timestamp.
+// Not routed through setSlice because it has the additional probesAt
+// side effect (and historically does not defensive-copy on input).
 func (c *Cache) SetProbes(p []catalog.ProbeResult) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -60,70 +87,25 @@ func (c *Cache) ProbesAge() time.Duration {
 }
 
 // SetDevices replaces the cached Tailscale device list.
-func (c *Cache) SetDevices(d []tailscale.Device) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	cp := make([]tailscale.Device, len(d))
-	copy(cp, d)
-	c.devices = cp
-}
+func (c *Cache) SetDevices(d []tailscale.Device) { setSlice(&c.mu, &c.devices, d) }
 
 // GetDevices returns a snapshot of the cached Tailscale device list.
 // The returned slice is a copy; mutations do not affect the cache.
-func (c *Cache) GetDevices() []tailscale.Device {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if len(c.devices) == 0 {
-		return nil
-	}
-	cp := make([]tailscale.Device, len(c.devices))
-	copy(cp, c.devices)
-	return cp
-}
+func (c *Cache) GetDevices() []tailscale.Device { return getSlice(&c.mu, &c.devices) }
 
 // SetAgents replaces the cached Agamemnon agent list.
-func (c *Cache) SetAgents(agents []AgentRecord) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	cp := make([]AgentRecord, len(agents))
-	copy(cp, agents)
-	c.agents = cp
-}
+func (c *Cache) SetAgents(agents []AgentRecord) { setSlice(&c.mu, &c.agents, agents) }
 
 // GetAgents returns a snapshot of the cached agent list.
 // The returned slice is a copy; mutations do not affect the cache.
-func (c *Cache) GetAgents() []AgentRecord {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if len(c.agents) == 0 {
-		return nil
-	}
-	cp := make([]AgentRecord, len(c.agents))
-	copy(cp, c.agents)
-	return cp
-}
+func (c *Cache) GetAgents() []AgentRecord { return getSlice(&c.mu, &c.agents) }
 
 // SetTasks replaces the cached Agamemnon task list.
-func (c *Cache) SetTasks(tasks []TaskRecord) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	cp := make([]TaskRecord, len(tasks))
-	copy(cp, tasks)
-	c.tasks = cp
-}
+func (c *Cache) SetTasks(tasks []TaskRecord) { setSlice(&c.mu, &c.tasks, tasks) }
 
 // GetTasks returns a snapshot of the cached task list.
 // The returned slice is a copy; mutations do not affect the cache.
-func (c *Cache) GetTasks() []TaskRecord {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if len(c.tasks) == 0 {
-		return nil
-	}
-	cp := make([]TaskRecord, len(c.tasks))
-	copy(cp, c.tasks)
-	return cp
-}
+func (c *Cache) GetTasks() []TaskRecord { return getSlice(&c.mu, &c.tasks) }
 
 // SetNATSStats replaces the cached NATS statistics.
 func (c *Cache) SetNATSStats(s NATSStats) {
@@ -140,6 +122,8 @@ func (c *Cache) GetNATSStats() NATSStats {
 }
 
 // SetAgentEvents replaces the full event history slice for agentID.
+// Not routed through setSlice because the slice lives inside a map keyed
+// by agentID rather than as a top-level field.
 func (c *Cache) SetAgentEvents(agentID string, events []RawEvent) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -181,67 +165,24 @@ func (c *Cache) AppendAgentEvent(agentID string, e RawEvent) {
 }
 
 // SetNATSStreams replaces the cached JetStream stream list.
-func (c *Cache) SetNATSStreams(streams []NATSStreamInfo) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	cp := make([]NATSStreamInfo, len(streams))
-	copy(cp, streams)
-	c.natsStreams = cp
-}
+func (c *Cache) SetNATSStreams(streams []NATSStreamInfo) { setSlice(&c.mu, &c.natsStreams, streams) }
 
 // GetNATSStreams returns a snapshot of the cached JetStream stream list.
 // The returned slice is a copy; mutations do not affect the cache.
-func (c *Cache) GetNATSStreams() []NATSStreamInfo {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if len(c.natsStreams) == 0 {
-		return nil
-	}
-	cp := make([]NATSStreamInfo, len(c.natsStreams))
-	copy(cp, c.natsStreams)
-	return cp
-}
+func (c *Cache) GetNATSStreams() []NATSStreamInfo { return getSlice(&c.mu, &c.natsStreams) }
 
 // SetNATSConsumers replaces the cached JetStream consumer list.
 func (c *Cache) SetNATSConsumers(consumers []NATSConsumerInfo) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	cp := make([]NATSConsumerInfo, len(consumers))
-	copy(cp, consumers)
-	c.natsConsumers = cp
+	setSlice(&c.mu, &c.natsConsumers, consumers)
 }
 
 // GetNATSConsumers returns a snapshot of the cached JetStream consumer list.
 // The returned slice is a copy; mutations do not affect the cache.
-func (c *Cache) GetNATSConsumers() []NATSConsumerInfo {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if len(c.natsConsumers) == 0 {
-		return nil
-	}
-	cp := make([]NATSConsumerInfo, len(c.natsConsumers))
-	copy(cp, c.natsConsumers)
-	return cp
-}
+func (c *Cache) GetNATSConsumers() []NATSConsumerInfo { return getSlice(&c.mu, &c.natsConsumers) }
 
 // SetNATSConns replaces the cached NATS connection list.
-func (c *Cache) SetNATSConns(conns []NATSConnInfo) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	cp := make([]NATSConnInfo, len(conns))
-	copy(cp, conns)
-	c.natsConns = cp
-}
+func (c *Cache) SetNATSConns(conns []NATSConnInfo) { setSlice(&c.mu, &c.natsConns, conns) }
 
 // GetNATSConns returns a snapshot of the cached NATS connection list.
 // The returned slice is a copy; mutations do not affect the cache.
-func (c *Cache) GetNATSConns() []NATSConnInfo {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if len(c.natsConns) == 0 {
-		return nil
-	}
-	cp := make([]NATSConnInfo, len(c.natsConns))
-	copy(cp, c.natsConns)
-	return cp
-}
+func (c *Cache) GetNATSConns() []NATSConnInfo { return getSlice(&c.mu, &c.natsConns) }


### PR DESCRIPTION
## Summary

- Replaces six mechanically-identical `Set*/Get*` slice-accessor pairs in `internal/store/cache.go` with a single `setSlice[T]` / `getSlice[T]` generic helper. Closes the Bucket-4 audit MAJOR finding "12x near-identical Set/Get pairs (DRY violation)."
- Pure refactor: no behaviour change. Defensive-copy semantics preserved on every getter; `RLock` / `Lock` discipline preserved; `nil`-on-empty zero-value contract (asserted by `TestNewCache_EmptyState`) preserved by an explicit guard inside `getSlice`.
- File shrinks from **247 LoC to 188 LoC** (-59, -24%).

## Outliers deliberately left as-is

- `SetProbes` / `GetProbes` — `SetProbes` has the `probesAt` timestamp side effect and (historically) does not defensive-copy on input; routing it through `setSlice` would change observable behaviour.
- `SetNATSStats` / `GetNATSStats` — value type, not a slice.
- `SetAgentEvents` / `GetAgentEvents` — slice lives inside a `map[string][]RawEvent`, not a top-level field.
- `AppendAgentEvent` — append + cap-at-50 logic, not a Set/Get pair.

## Test plan

- [x] `go test -race -count=1 ./...` — all 12 packages green
- [x] `TestConcurrentSetGet_NoRaces` and `TestCache_*` — clean under `-race -count=10`
- [x] `gosec ./...` — clean
- [ ] CI green
- [ ] Auto-merge fires

Generated with [Claude Code](https://claude.com/claude-code)