### PR TITLE
fix(config): promote 13 hardcoded timeouts to ATLAS_* env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,35 @@ LOKI_AUTH_PASSWORD=changeme
 # and you accept that anyone on it can read /metrics, /readyz, and the UI.
 ATLAS_AUTH_MODE=bearer
 ATLAS_AUTH_BEARER_TOKEN=
+
+# Atlas HTTP server, poller, and tuning knobs. All values below are commented
+# out — Atlas falls back to the documented default when unset. Uncomment and
+# adjust only if your environment has unusual proxy, upstream, or workload
+# shape (slow upstreams, aggressive proxies, high event rates, large JetStream
+# streams). Bad/zero/negative input falls back silently to the default with a
+# slog Warn rather than failing startup.
+
+# HTTP server timeouts.
+# ATLAS_HTTP_READ_TIMEOUT=10s            # (default)
+# ATLAS_HTTP_IDLE_TIMEOUT=60s            # (default)
+
+# Upstream poller timeouts.
+# ATLAS_UPSTREAM_TIMEOUT=3s              # (default) Agamemnon + NATS monitoring
+# ATLAS_TAILSCALE_API_TIMEOUT=10s        # (default)
+# ATLAS_TAILSCALE_CLI_TIMEOUT=5s         # (default)
+
+# Loop / refresh intervals.
+# ATLAS_PROBE_INTERVAL=10s               # (default)
+# ATLAS_NATS_POLL_INTERVAL=5s            # (default)
+# ATLAS_TAILSCALE_REFRESH_INTERVAL=30s   # (default)
+
+# SSE tuning.
+# ATLAS_SSE_HEARTBEAT_INTERVAL=15s       # (default)
+# ATLAS_SSE_SUBSCRIBER_BUFFER=1000       # (default)
+
+# Event bus.
+# ATLAS_BUS_RING_CAPACITY=256            # (default)
+
+# NATS JetStream tuning.
+# ATLAS_NATS_ACK_WAIT=30s                # (default)
+# ATLAS_NATS_MAX_ACK_PENDING=1024        # (default)

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -118,6 +118,19 @@ All configuration is via environment variables with the `ATLAS_` prefix:
 | `ATLAS_MNEMOSYNE_SKILLS_DIR` | `/mnt/mnemosyne/skills` | Path to Mnemosyne skills directory (read by /mnemosyne page) |
 | `ATLAS_LOKI_URL` | `http://loki:3100` | Loki URL (included in CSP frame-src) |
 | `ATLAS_EXPORTER_URL` | `http://argus-exporter:9100` | Homeric exporter URL |
+| `ATLAS_HTTP_READ_TIMEOUT` | `10s` | HTTP server read timeout (`time.Duration` syntax: `750ms`, `2s`, `1h30m`). Bad/zero/negative values fall back to default. |
+| `ATLAS_HTTP_IDLE_TIMEOUT` | `60s` | HTTP server idle keep-alive timeout. |
+| `ATLAS_UPSTREAM_TIMEOUT` | `3s` | Per-request HTTP client timeout for the JSON-poll pollers (Agamemnon + NATS monitoring). |
+| `ATLAS_TAILSCALE_API_TIMEOUT` | `10s` | HTTP client timeout for the Tailscale REST API. |
+| `ATLAS_TAILSCALE_CLI_TIMEOUT` | `5s` | Wall-clock cap for the `tailscale status --json` subprocess. |
+| `ATLAS_PROBE_INTERVAL` | `10s` | Cadence at which the service prober re-checks each Tailscale device. |
+| `ATLAS_NATS_POLL_INTERVAL` | `5s` | Cadence of the NATS monitoring poller (/varz, /jsz, /connz). |
+| `ATLAS_TAILSCALE_REFRESH_INTERVAL` | `30s` | Cadence of the Tailscale device refresher loop. |
+| `ATLAS_SSE_HEARTBEAT_INTERVAL` | `15s` | Cadence of the keep-alive comment frame on the SSE event stream. |
+| `ATLAS_SSE_SUBSCRIBER_BUFFER` | `1000` | Per-SSE-client channel buffer size; slow clients drop events when this fills rather than back-pressuring the bus. |
+| `ATLAS_BUS_RING_CAPACITY` | `256` | events.Bus ring-buffer capacity used for the `replay=` SSE replay window. |
+| `ATLAS_NATS_ACK_WAIT` | `30s` | JetStream consumer AckWait — re-delivery window for un-acked messages. |
+| `ATLAS_NATS_MAX_ACK_PENDING` | `1024` | JetStream consumer MaxAckPending — cap on un-acked in-flight messages per consumer. |
 
 ## SSE Event Stream
 

--- a/dashboard/cmd/argus-dashboard/main.go
+++ b/dashboard/cmd/argus-dashboard/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/HomericIntelligence/atlas/internal/config"
 	"github.com/HomericIntelligence/atlas/internal/events"
@@ -31,7 +30,7 @@ func main() {
 	slog.Info("starting atlas", "version", version.Version, "addr", cfg.ListenAddr, "auth_mode", cfg.AuthMode)
 
 	cache := store.NewCache()
-	bus := events.NewBus(256)
+	bus := events.NewBus(cfg.BusRingCapacity)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -47,17 +46,16 @@ func main() {
 	// dropped cycle of headroom before a component is considered unready —
 	// avoids flapping while still surfacing genuine outages within a few
 	// seconds.
-	const natsPollInterval = 5 * time.Second
 	agamemnonReadyMaxAge := 2 * cfg.PollAgamemnon
-	natsReadyMaxAge := 2 * natsPollInterval
+	natsReadyMaxAge := 2 * cfg.NATSPollInterval
 
 	// Start Tailscale device refresher.
 	tsSrc := tailscale.NewSource(cfg)
-	tsRefresher := tailscale.NewRefresher(tsSrc, cache, 30*time.Second)
+	tsRefresher := tailscale.NewRefresher(tsSrc, cache, cfg.TailscaleRefreshInterval)
 	go tsRefresher.Start(ctx)
 
 	// Start probe runner.
-	prober := store.NewProber(cache, 10*time.Second)
+	prober := store.NewProber(cache, cfg.ProbeInterval)
 	go prober.Start(ctx)
 
 	// Start Agamemnon poller (agents + tasks at the configured interval) and
@@ -67,11 +65,11 @@ func main() {
 	ready.Register(server.PollerCheck(agamemnonPoller, agamemnonReadyMaxAge))
 	go agamemnonPoller.Start(ctx, cfg.PollAgamemnon)
 
-	// Start NATS monitoring poller (varz + jsz every 5s).
+	// Start NATS monitoring poller (varz + jsz at cfg.NATSPollInterval).
 	natsPoller := poller.NewNATSPoller(cfg, cache)
 	natsPoller.SetMetrics(metrics)
 	ready.Register(server.PollerCheck(natsPoller, natsReadyMaxAge))
-	go natsPoller.Start(ctx, natsPollInterval)
+	go natsPoller.Start(ctx, cfg.NATSPollInterval)
 
 	// Start the JetStream subscriber that bridges NATS events into events.Bus
 	// for the SSE fan-out. This is the central event spine of Atlas — without
@@ -82,8 +80,10 @@ func main() {
 	// dashboard remains operable. /readyz reflects the failure either way.
 	streams := atlnats.DefaultStreams()
 	natsSubscriber := atlnats.New(atlnats.Config{
-		NATSURL: cfg.NATSURL,
-		Streams: streams,
+		NATSURL:       cfg.NATSURL,
+		Streams:       streams,
+		AckWait:       cfg.NATSAckWait,
+		MaxAckPending: cfg.NATSMaxAckPending,
 	}, bus)
 	natsSubscriber.SetMetrics(metrics)
 	ready.Register(server.NATSCheck("nats-subscriber", natsSubscriber, len(streams)))

--- a/dashboard/internal/config/config.go
+++ b/dashboard/internal/config/config.go
@@ -54,6 +54,90 @@ type Config struct {
 	// retries comfortably fits. Setting this to 0 disables the limit on
 	// the liveness routes specifically.
 	LivezRateLimitPerMin int
+
+	// --- HTTP server timeouts ---
+
+	// HTTPReadTimeout caps how long the HTTP server will wait to read a
+	// request (headers + body). Sourced from ATLAS_HTTP_READ_TIMEOUT
+	// (default 10s). Increase behind aggressive proxies that may pause
+	// mid-request; decrease to reject slow-loris clients more aggressively.
+	// NOTE: Server.WriteTimeout is intentionally NOT exposed — it is held
+	// at 0 so the SSE long-poll endpoint is not killed mid-stream.
+	HTTPReadTimeout time.Duration
+
+	// HTTPIdleTimeout caps how long an idle keep-alive HTTP connection is
+	// held open. Sourced from ATLAS_HTTP_IDLE_TIMEOUT (default 60s).
+	HTTPIdleTimeout time.Duration
+
+	// --- Upstream poller timeouts ---
+
+	// UpstreamTimeout is the per-request HTTP client timeout used by the
+	// JSON-poll pollers (Agamemnon, NATS monitoring). Sourced from
+	// ATLAS_UPSTREAM_TIMEOUT (default 3s). Bump this on slow upstreams or
+	// large /jsz?detail=1 responses; lower it to fail-fast more eagerly.
+	UpstreamTimeout time.Duration
+
+	// TailscaleAPITimeout is the HTTP client timeout used when querying the
+	// Tailscale REST API. Sourced from ATLAS_TAILSCALE_API_TIMEOUT
+	// (default 10s).
+	TailscaleAPITimeout time.Duration
+
+	// TailscaleCLITimeout caps the duration of the
+	// `tailscale status --json` subprocess invocation. Sourced from
+	// ATLAS_TAILSCALE_CLI_TIMEOUT (default 5s).
+	TailscaleCLITimeout time.Duration
+
+	// --- Loop / refresh intervals ---
+
+	// ProbeInterval is the cadence at which the service prober re-checks
+	// each Tailscale device. Sourced from ATLAS_PROBE_INTERVAL
+	// (default 10s).
+	ProbeInterval time.Duration
+
+	// NATSPollInterval is the cadence of the NATS monitoring poller
+	// (/varz, /jsz, /connz). Sourced from ATLAS_NATS_POLL_INTERVAL
+	// (default 5s).
+	NATSPollInterval time.Duration
+
+	// TailscaleRefreshInterval is the cadence of the Tailscale device
+	// refresher loop. Sourced from ATLAS_TAILSCALE_REFRESH_INTERVAL
+	// (default 30s).
+	TailscaleRefreshInterval time.Duration
+
+	// --- SSE tuning ---
+
+	// SSEHeartbeatInterval is the cadence of the keep-alive comment frame
+	// sent by the SSE handler when no real events are flowing. Sourced
+	// from ATLAS_SSE_HEARTBEAT_INTERVAL (default 15s). Lower this if a
+	// proxy is killing idle connections; raise it to reduce client wakeups.
+	SSEHeartbeatInterval time.Duration
+
+	// SSESubscriberBuffer is the size of each SSE client's per-subscriber
+	// channel buffer. Sourced from ATLAS_SSE_SUBSCRIBER_BUFFER
+	// (default 1000). Slow clients that exceed this buffer drop events
+	// rather than back-pressuring the bus; raise this for ultra-bursty
+	// workloads, lower it to reclaim memory on small deployments.
+	SSESubscriberBuffer int
+
+	// --- Event bus ---
+
+	// BusRingCapacity is the size of the events.Bus snapshot ring buffer
+	// (used to replay recent events to newly-connected SSE clients).
+	// Sourced from ATLAS_BUS_RING_CAPACITY (default 256).
+	BusRingCapacity int
+
+	// --- NATS JetStream tuning ---
+
+	// NATSAckWait is the JetStream consumer AckWait — how long the server
+	// waits for an Ack before re-delivering a message. Sourced from
+	// ATLAS_NATS_ACK_WAIT (default 30s).
+	NATSAckWait time.Duration
+
+	// NATSMaxAckPending is the JetStream consumer MaxAckPending — the cap
+	// on un-acked in-flight messages per consumer. Sourced from
+	// ATLAS_NATS_MAX_ACK_PENDING (default 1024). Raise on high-throughput
+	// streams; lower to reduce memory pressure on a slow subscriber.
+	NATSMaxAckPending int
 }
 
 func getenv(key, def string) string {
@@ -61,6 +145,34 @@ func getenv(key, def string) string {
 		return v
 	}
 	return def
+}
+
+// loadDuration reads key from the environment and parses it as a time.Duration.
+// Empty / unparsable / non-positive values fall back to def with a Warn log
+// line so a typo does not refuse to start; operators will mistype.
+func loadDuration(key, defaultStr string, def time.Duration) time.Duration {
+	raw := getenv(key, defaultStr)
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		slog.Warn("config: invalid duration; falling back to default",
+			"key", key, "value", raw, "default", def)
+		return def
+	}
+	return d
+}
+
+// loadPositiveInt reads key from the environment and parses it as a positive
+// int. Empty / unparsable / non-positive values fall back to def with a Warn
+// log line.
+func loadPositiveInt(key, defaultStr string, def int) int {
+	raw := getenv(key, defaultStr)
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		slog.Warn("config: invalid int; falling back to default",
+			"key", key, "value", raw, "default", def)
+		return def
+	}
+	return n
 }
 
 // Load reads ATLAS_* environment variables into a Config. It does not validate
@@ -119,6 +231,31 @@ func Load() *Config {
 		PollAgamemnon:        time.Duration(pollMs) * time.Millisecond,
 		RateLimitPerMin:      rate,
 		LivezRateLimitPerMin: livezRate,
+
+		// HTTP server timeouts.
+		HTTPReadTimeout: loadDuration("ATLAS_HTTP_READ_TIMEOUT", "10s", 10*time.Second),
+		HTTPIdleTimeout: loadDuration("ATLAS_HTTP_IDLE_TIMEOUT", "60s", 60*time.Second),
+
+		// Upstream poller timeouts.
+		UpstreamTimeout:     loadDuration("ATLAS_UPSTREAM_TIMEOUT", "3s", 3*time.Second),
+		TailscaleAPITimeout: loadDuration("ATLAS_TAILSCALE_API_TIMEOUT", "10s", 10*time.Second),
+		TailscaleCLITimeout: loadDuration("ATLAS_TAILSCALE_CLI_TIMEOUT", "5s", 5*time.Second),
+
+		// Loop / refresh intervals.
+		ProbeInterval:            loadDuration("ATLAS_PROBE_INTERVAL", "10s", 10*time.Second),
+		NATSPollInterval:         loadDuration("ATLAS_NATS_POLL_INTERVAL", "5s", 5*time.Second),
+		TailscaleRefreshInterval: loadDuration("ATLAS_TAILSCALE_REFRESH_INTERVAL", "30s", 30*time.Second),
+
+		// SSE tuning.
+		SSEHeartbeatInterval: loadDuration("ATLAS_SSE_HEARTBEAT_INTERVAL", "15s", 15*time.Second),
+		SSESubscriberBuffer:  loadPositiveInt("ATLAS_SSE_SUBSCRIBER_BUFFER", "1000", 1000),
+
+		// Event bus.
+		BusRingCapacity: loadPositiveInt("ATLAS_BUS_RING_CAPACITY", "256", 256),
+
+		// NATS JetStream tuning.
+		NATSAckWait:       loadDuration("ATLAS_NATS_ACK_WAIT", "30s", 30*time.Second),
+		NATSMaxAckPending: loadPositiveInt("ATLAS_NATS_MAX_ACK_PENDING", "1024", 1024),
 	}
 }
 

--- a/dashboard/internal/config/config_test.go
+++ b/dashboard/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 )
 
 func discardLogger() *slog.Logger {
@@ -119,6 +120,146 @@ func TestValidate_EmptyOptionalURL(t *testing.T) {
 // Defense-in-depth: server.Middleware now also fails closed on unknown modes
 // (see TestMiddleware_UnknownModeFailsClosed). Either fix alone closes the
 // bypass; both together make the bug structurally hard to reintroduce.
+// TestLoadDuration_FallsBackToDefault exercises the parse-or-fallback contract
+// for every ATLAS_* time.Duration env var promoted in the Bucket-4 §4 audit.
+// Operators will mistype; we'd rather degrade silently to the documented
+// default than refuse to start.
+func TestLoadDuration_FallsBackToDefault(t *testing.T) {
+	cases := []struct {
+		key  string
+		def  time.Duration
+		read func(*Config) time.Duration
+	}{
+		{"ATLAS_HTTP_READ_TIMEOUT", 10 * time.Second, func(c *Config) time.Duration { return c.HTTPReadTimeout }},
+		{"ATLAS_HTTP_IDLE_TIMEOUT", 60 * time.Second, func(c *Config) time.Duration { return c.HTTPIdleTimeout }},
+		{"ATLAS_UPSTREAM_TIMEOUT", 3 * time.Second, func(c *Config) time.Duration { return c.UpstreamTimeout }},
+		{"ATLAS_TAILSCALE_API_TIMEOUT", 10 * time.Second, func(c *Config) time.Duration { return c.TailscaleAPITimeout }},
+		{"ATLAS_TAILSCALE_CLI_TIMEOUT", 5 * time.Second, func(c *Config) time.Duration { return c.TailscaleCLITimeout }},
+		{"ATLAS_PROBE_INTERVAL", 10 * time.Second, func(c *Config) time.Duration { return c.ProbeInterval }},
+		{"ATLAS_NATS_POLL_INTERVAL", 5 * time.Second, func(c *Config) time.Duration { return c.NATSPollInterval }},
+		{"ATLAS_TAILSCALE_REFRESH_INTERVAL", 30 * time.Second, func(c *Config) time.Duration { return c.TailscaleRefreshInterval }},
+		{"ATLAS_SSE_HEARTBEAT_INTERVAL", 15 * time.Second, func(c *Config) time.Duration { return c.SSEHeartbeatInterval }},
+		{"ATLAS_NATS_ACK_WAIT", 30 * time.Second, func(c *Config) time.Duration { return c.NATSAckWait }},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.key+"/positive_750ms", func(t *testing.T) {
+			t.Setenv(tc.key, "750ms")
+			c := Load()
+			if got := tc.read(c); got != 750*time.Millisecond {
+				t.Fatalf("%s=750ms parsed as %v; want 750ms", tc.key, got)
+			}
+		})
+		t.Run(tc.key+"/garbage_falls_back", func(t *testing.T) {
+			t.Setenv(tc.key, "not-a-duration")
+			c := Load()
+			if got := tc.read(c); got != tc.def {
+				t.Fatalf("%s=garbage parsed as %v; want default %v", tc.key, got, tc.def)
+			}
+		})
+		t.Run(tc.key+"/negative_falls_back", func(t *testing.T) {
+			t.Setenv(tc.key, "-5s")
+			c := Load()
+			if got := tc.read(c); got != tc.def {
+				t.Fatalf("%s=-5s parsed as %v; want default %v", tc.key, got, tc.def)
+			}
+		})
+		t.Run(tc.key+"/zero_falls_back", func(t *testing.T) {
+			t.Setenv(tc.key, "0s")
+			c := Load()
+			if got := tc.read(c); got != tc.def {
+				t.Fatalf("%s=0s parsed as %v; want default %v", tc.key, got, tc.def)
+			}
+		})
+	}
+}
+
+// TestLoadDuration_DefaultsWhenUnset asserts that with no env var set the
+// documented default lands in the Config field.
+func TestLoadDuration_DefaultsWhenUnset(t *testing.T) {
+	c := Load()
+	cases := []struct {
+		name string
+		got  time.Duration
+		want time.Duration
+	}{
+		{"HTTPReadTimeout", c.HTTPReadTimeout, 10 * time.Second},
+		{"HTTPIdleTimeout", c.HTTPIdleTimeout, 60 * time.Second},
+		{"UpstreamTimeout", c.UpstreamTimeout, 3 * time.Second},
+		{"TailscaleAPITimeout", c.TailscaleAPITimeout, 10 * time.Second},
+		{"TailscaleCLITimeout", c.TailscaleCLITimeout, 5 * time.Second},
+		{"ProbeInterval", c.ProbeInterval, 10 * time.Second},
+		{"NATSPollInterval", c.NATSPollInterval, 5 * time.Second},
+		{"TailscaleRefreshInterval", c.TailscaleRefreshInterval, 30 * time.Second},
+		{"SSEHeartbeatInterval", c.SSEHeartbeatInterval, 15 * time.Second},
+		{"NATSAckWait", c.NATSAckWait, 30 * time.Second},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("%s default = %v; want %v", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+// TestLoadInt_FallsBackToDefault covers the int-typed promotions
+// (ATLAS_SSE_SUBSCRIBER_BUFFER, ATLAS_BUS_RING_CAPACITY, ATLAS_NATS_MAX_ACK_PENDING).
+func TestLoadInt_FallsBackToDefault(t *testing.T) {
+	cases := []struct {
+		key  string
+		def  int
+		read func(*Config) int
+	}{
+		{"ATLAS_SSE_SUBSCRIBER_BUFFER", 1000, func(c *Config) int { return c.SSESubscriberBuffer }},
+		{"ATLAS_BUS_RING_CAPACITY", 256, func(c *Config) int { return c.BusRingCapacity }},
+		{"ATLAS_NATS_MAX_ACK_PENDING", 1024, func(c *Config) int { return c.NATSMaxAckPending }},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.key+"/positive", func(t *testing.T) {
+			t.Setenv(tc.key, "42")
+			c := Load()
+			if got := tc.read(c); got != 42 {
+				t.Fatalf("%s=42 parsed as %d; want 42", tc.key, got)
+			}
+		})
+		t.Run(tc.key+"/garbage_falls_back", func(t *testing.T) {
+			t.Setenv(tc.key, "not-an-int")
+			c := Load()
+			if got := tc.read(c); got != tc.def {
+				t.Fatalf("%s=garbage parsed as %d; want default %d", tc.key, got, tc.def)
+			}
+		})
+		t.Run(tc.key+"/zero_falls_back", func(t *testing.T) {
+			t.Setenv(tc.key, "0")
+			c := Load()
+			if got := tc.read(c); got != tc.def {
+				t.Fatalf("%s=0 parsed as %d; want default %d", tc.key, got, tc.def)
+			}
+		})
+		t.Run(tc.key+"/negative_falls_back", func(t *testing.T) {
+			t.Setenv(tc.key, "-7")
+			c := Load()
+			if got := tc.read(c); got != tc.def {
+				t.Fatalf("%s=-7 parsed as %d; want default %d", tc.key, got, tc.def)
+			}
+		})
+	}
+}
+
+func TestLoadInt_DefaultsWhenUnset(t *testing.T) {
+	c := Load()
+	if c.SSESubscriberBuffer != 1000 {
+		t.Errorf("SSESubscriberBuffer default = %d; want 1000", c.SSESubscriberBuffer)
+	}
+	if c.BusRingCapacity != 256 {
+		t.Errorf("BusRingCapacity default = %d; want 256", c.BusRingCapacity)
+	}
+	if c.NATSMaxAckPending != 1024 {
+		t.Errorf("NATSMaxAckPending default = %d; want 1024", c.NATSMaxAckPending)
+	}
+}
+
 func TestValidate_NormalizesAuthMode(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/dashboard/internal/handlers/sse.go
+++ b/dashboard/internal/handlers/sse.go
@@ -13,10 +13,20 @@ import (
 
 // heartbeatNanos stores the heartbeat interval in nanoseconds.
 // Access via HeartbeatInterval / SetHeartbeatInterval for race safety.
+//
+// The composition root populates this from cfg.SSEHeartbeatInterval
+// (ATLAS_SSE_HEARTBEAT_INTERVAL, default 15s) at startup. Tests use the
+// SetHeartbeatInterval helper to override the value temporarily.
 var heartbeatNanos atomic.Int64
+
+// subscriberBufferAtomic stores the per-SSE-client channel buffer size.
+// The composition root populates this from cfg.SSESubscriberBuffer
+// (ATLAS_SSE_SUBSCRIBER_BUFFER, default 1000) at startup.
+var subscriberBufferAtomic atomic.Int64
 
 func init() {
 	heartbeatNanos.Store(int64(15 * time.Second))
+	subscriberBufferAtomic.Store(1000)
 }
 
 // HeartbeatInterval returns the current heartbeat interval.
@@ -24,9 +34,27 @@ func HeartbeatInterval() time.Duration {
 	return time.Duration(heartbeatNanos.Load())
 }
 
-// SetHeartbeatInterval sets the heartbeat interval. Safe for concurrent use; intended for tests.
+// SetHeartbeatInterval sets the heartbeat interval. Safe for concurrent use;
+// called once at startup from the composition root with cfg.SSEHeartbeatInterval
+// and otherwise used by tests that need a faster cadence.
 func SetHeartbeatInterval(d time.Duration) {
 	heartbeatNanos.Store(int64(d))
+}
+
+// SubscriberBuffer returns the current per-client channel buffer size.
+func SubscriberBuffer() int {
+	return int(subscriberBufferAtomic.Load())
+}
+
+// SetSubscriberBuffer sets the per-client channel buffer. Safe for concurrent
+// use; called once at startup from the composition root with
+// cfg.SSESubscriberBuffer. Values <= 0 are ignored so a typo does not produce
+// an unbuffered channel.
+func SetSubscriberBuffer(n int) {
+	if n <= 0 {
+		return
+	}
+	subscriberBufferAtomic.Store(int64(n))
 }
 
 // SSEMetrics is the metric-recording surface the SSE handler uses. The server
@@ -106,7 +134,7 @@ func (h *SSE) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// while draining the replay window. Doing it the other way round
 	// (Snapshot then Subscribe) loses any event published between the two
 	// calls — see audit finding "SSE replay race vs new publishes".
-	ch := h.bus.Subscribe(1000)
+	ch := h.bus.Subscribe(SubscriberBuffer())
 	defer h.bus.Unsubscribe(ch)
 
 	// Track this connection in the gauge so /metrics reflects live load.

--- a/dashboard/internal/nats/subscriber.go
+++ b/dashboard/internal/nats/subscriber.go
@@ -28,6 +28,14 @@ type Config struct {
 	NATSURL string
 	// Streams is the list of JetStream stream configurations to subscribe to.
 	Streams []StreamConfig
+	// AckWait is the JetStream consumer AckWait — how long the server waits
+	// for an Ack before re-delivering a message. Sourced from
+	// ATLAS_NATS_ACK_WAIT (default 30s when zero).
+	AckWait time.Duration
+	// MaxAckPending is the JetStream consumer MaxAckPending — the cap on
+	// un-acked in-flight messages per consumer. Sourced from
+	// ATLAS_NATS_MAX_ACK_PENDING (default 1024 when zero).
+	MaxAckPending int
 }
 
 // StreamConfig describes a single JetStream stream and the durable consumer
@@ -233,12 +241,20 @@ func (s *Subscriber) attach(js natsgo.JetStreamContext) error {
 // filter.
 func (s *Subscriber) subscribeStream(js natsgo.JetStreamContext, sc StreamConfig) (*natsgo.Subscription, error) {
 	handler := s.makeHandler(sc)
+	ackWait := s.cfg.AckWait
+	if ackWait <= 0 {
+		ackWait = 30 * time.Second
+	}
+	maxAckPending := s.cfg.MaxAckPending
+	if maxAckPending <= 0 {
+		maxAckPending = 1024
+	}
 	opts := []natsgo.SubOpt{
 		natsgo.Durable(sc.Durable),
 		natsgo.DeliverNew(),
 		natsgo.AckExplicit(),
-		natsgo.AckWait(30 * time.Second),
-		natsgo.MaxAckPending(1024),
+		natsgo.AckWait(ackWait),
+		natsgo.MaxAckPending(maxAckPending),
 	}
 	if len(sc.Subjects) <= 1 {
 		subject := ""

--- a/dashboard/internal/poller/agamemnon.go
+++ b/dashboard/internal/poller/agamemnon.go
@@ -42,10 +42,15 @@ type AgamemnonPoller struct {
 	url   string
 }
 
-// NewAgamemnonPoller constructs an AgamemnonPoller with a 3-second HTTP timeout.
+// NewAgamemnonPoller constructs an AgamemnonPoller using the upstream HTTP
+// timeout from cfg.UpstreamTimeout (ATLAS_UPSTREAM_TIMEOUT, default 3s).
 func NewAgamemnonPoller(cfg *config.Config, cache *store.Cache) *AgamemnonPoller {
+	timeout := cfg.UpstreamTimeout
+	if timeout <= 0 {
+		timeout = 3 * time.Second
+	}
 	return &AgamemnonPoller{
-		base:  newBase("agamemnon", &http.Client{Timeout: 3 * time.Second}),
+		base:  newBase("agamemnon", &http.Client{Timeout: timeout}),
 		cache: cache,
 		url:   cfg.AgamemnonURL,
 	}

--- a/dashboard/internal/poller/nats.go
+++ b/dashboard/internal/poller/nats.go
@@ -71,10 +71,15 @@ type NATSPoller struct {
 	url   string
 }
 
-// NewNATSPoller constructs a NATSPoller with a 3-second HTTP timeout.
+// NewNATSPoller constructs a NATSPoller using the upstream HTTP timeout from
+// cfg.UpstreamTimeout (ATLAS_UPSTREAM_TIMEOUT, default 3s).
 func NewNATSPoller(cfg *config.Config, cache *store.Cache) *NATSPoller {
+	timeout := cfg.UpstreamTimeout
+	if timeout <= 0 {
+		timeout = 3 * time.Second
+	}
 	return &NATSPoller{
-		base:  newBase("nats", &http.Client{Timeout: 3 * time.Second}),
+		base:  newBase("nats", &http.Client{Timeout: timeout}),
 		cache: cache,
 		url:   cfg.NATSMonURL,
 	}

--- a/dashboard/internal/server/server.go
+++ b/dashboard/internal/server/server.go
@@ -26,6 +26,13 @@ type Server struct {
 
 func New(cfg *config.Config, bus *events.Bus, cache *store.Cache) *Server {
 	metrics := newAtlasMetrics()
+	// Apply SSE tunables from cfg before constructing the handler so the
+	// first ServeHTTP call sees the operator-configured values. These are
+	// process-wide atomics; the SSE handler reads them on every connect.
+	if cfg.SSEHeartbeatInterval > 0 {
+		handlers.SetHeartbeatInterval(cfg.SSEHeartbeatInterval)
+	}
+	handlers.SetSubscriberBuffer(cfg.SSESubscriberBuffer)
 	sse := handlers.NewSSE(bus)
 	sse.SetMetrics(metrics)
 
@@ -44,9 +51,9 @@ func New(cfg *config.Config, bus *events.Bus, cache *store.Cache) *Server {
 	s.srv = &http.Server{
 		Addr:         cfg.ListenAddr,
 		Handler:      s.routes(),
-		ReadTimeout:  10 * time.Second,
+		ReadTimeout:  cfg.HTTPReadTimeout,
 		WriteTimeout: 0, // SSE connections are long-lived; disable write timeout.
-		IdleTimeout:  60 * time.Second,
+		IdleTimeout:  cfg.HTTPIdleTimeout,
 	}
 	return s
 }

--- a/dashboard/internal/tailscale/api.go
+++ b/dashboard/internal/tailscale/api.go
@@ -38,11 +38,13 @@ type apiDevice struct {
 
 // APISource fetches devices from the Tailscale HTTP API.
 // The HTTPClient field allows injection of a test server client; if nil, a
-// default client with a 10-second timeout is used.
+// default client is built using Timeout (or 10s if Timeout is zero / negative).
+// Timeout is sourced from ATLAS_TAILSCALE_API_TIMEOUT.
 type APISource struct {
 	APIKey     string
 	Tailnet    string
 	HTTPClient *http.Client
+	Timeout    time.Duration
 }
 
 // Devices calls GET https://api.tailscale.com/api/v2/tailnet/{tailnet}/devices
@@ -50,7 +52,11 @@ type APISource struct {
 func (a APISource) Devices(ctx context.Context) ([]Device, error) {
 	client := a.HTTPClient
 	if client == nil {
-		client = &http.Client{Timeout: 10 * time.Second}
+		timeout := a.Timeout
+		if timeout <= 0 {
+			timeout = 10 * time.Second
+		}
+		client = &http.Client{Timeout: timeout}
 	}
 
 	url := fmt.Sprintf("https://api.tailscale.com/api/v2/tailnet/%s/devices", a.Tailnet)

--- a/dashboard/internal/tailscale/auto.go
+++ b/dashboard/internal/tailscale/auto.go
@@ -20,6 +20,9 @@ type AutoSource struct {
 func (a AutoSource) Devices(ctx context.Context) ([]Device, error) {
 	// 1. Try CLI source.
 	cli := CLISource{}
+	if a.Cfg != nil {
+		cli.Timeout = a.Cfg.TailscaleCLITimeout
+	}
 	if devices, err := cli.Devices(ctx); err == nil {
 		return devices, nil
 	} else {
@@ -31,6 +34,7 @@ func (a AutoSource) Devices(ctx context.Context) ([]Device, error) {
 		api := APISource{
 			APIKey:  a.Cfg.TailscaleAPIKey,
 			Tailnet: a.Cfg.TailnetName,
+			Timeout: a.Cfg.TailscaleAPITimeout,
 		}
 		if devices, err := api.Devices(ctx); err == nil {
 			return devices, nil

--- a/dashboard/internal/tailscale/cli.go
+++ b/dashboard/internal/tailscale/cli.go
@@ -24,12 +24,20 @@ type cliPeer struct {
 
 // CLISource invokes `tailscale status --json` to enumerate devices.
 // If the binary is not found or the socket is not present, Devices returns
-// an error immediately.
-type CLISource struct{}
+// an error immediately. Timeout is the subprocess wall-clock cap (default 5s
+// when zero), sourced from ATLAS_TAILSCALE_CLI_TIMEOUT.
+type CLISource struct {
+	Timeout time.Duration
+}
 
-// Devices runs `tailscale status --json` with a 5-second timeout.
+// Devices runs `tailscale status --json` with the configured subprocess
+// timeout (default 5s when c.Timeout is zero or negative).
 func (c CLISource) Devices(ctx context.Context) ([]Device, error) {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	timeout := c.Timeout
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "tailscale", "status", "--json")

--- a/dashboard/internal/tailscale/source.go
+++ b/dashboard/internal/tailscale/source.go
@@ -17,11 +17,12 @@ import (
 func NewSource(cfg *config.Config) Source {
 	switch cfg.TailscaleSource {
 	case "cli":
-		return CLISource{}
+		return CLISource{Timeout: cfg.TailscaleCLITimeout}
 	case "api":
 		return APISource{
 			APIKey:  cfg.TailscaleAPIKey,
 			Tailnet: cfg.TailnetName,
+			Timeout: cfg.TailscaleAPITimeout,
 		}
 	case "static":
 		return StaticSource{}


### PR DESCRIPTION
## Summary

- Promotes 13 hardcoded timeouts, intervals, and capacities to `ATLAS_*` env vars so operators can tune without rebuilding. Closes the Bucket-4 §4 audit MAJOR finding "magic-number HTTP/poll timeouts not in config."
- All 13 default to their previous values; no behaviour change for an operator who sets nothing. Bad/negative input falls back to the documented default with a slog Warn rather than failing startup.
- New env vars listed in `dashboard/README.md`'s configuration table and `.env.example`.

## Promoted vars

| Field | Env var | Default | Type |
|---|---|---|---|
| HTTP server read timeout | `ATLAS_HTTP_READ_TIMEOUT` | `10s` | `time.Duration` |
| HTTP server idle timeout | `ATLAS_HTTP_IDLE_TIMEOUT` | `60s` | `time.Duration` |
| Upstream JSON-poll HTTP timeout (Agamemnon + NATS) | `ATLAS_UPSTREAM_TIMEOUT` | `3s` | `time.Duration` |
| Tailscale API HTTP timeout | `ATLAS_TAILSCALE_API_TIMEOUT` | `10s` | `time.Duration` |
| Tailscale CLI subprocess timeout | `ATLAS_TAILSCALE_CLI_TIMEOUT` | `5s` | `time.Duration` |
| Service-prober loop interval | `ATLAS_PROBE_INTERVAL` | `10s` | `time.Duration` |
| NATS poll interval | `ATLAS_NATS_POLL_INTERVAL` | `5s` | `time.Duration` |
| Tailscale refresh interval | `ATLAS_TAILSCALE_REFRESH_INTERVAL` | `30s` | `time.Duration` |
| SSE heartbeat interval | `ATLAS_SSE_HEARTBEAT_INTERVAL` | `15s` | `time.Duration` |
| SSE subscriber channel buffer | `ATLAS_SSE_SUBSCRIBER_BUFFER` | `1000` | `int` |
| events.Bus ring capacity | `ATLAS_BUS_RING_CAPACITY` | `256` | `int` |
| NATS JetStream AckWait | `ATLAS_NATS_ACK_WAIT` | `30s` | `time.Duration` |
| NATS JetStream MaxAckPending | `ATLAS_NATS_MAX_ACK_PENDING` | `1024` | `int` |

`Server.WriteTimeout` is intentionally NOT promoted — it stays at 0 so the SSE long-poll endpoint is not killed mid-stream. The existing load-bearing comment on that field is preserved.

## Constructor signatures touched (low blast radius)

- `tailscale.APISource` gains an optional `Timeout time.Duration` field. Existing callers that supply `HTTPClient` are unaffected; the new field is only consulted when `HTTPClient` is nil.
- `tailscale.CLISource` gains an optional `Timeout time.Duration` field. Existing callers that construct it as a zero-value struct are unaffected — zero falls back to the previous 5s default.
- `nats.Config` gains optional `AckWait time.Duration` and `MaxAckPending int` fields. Zero values fall back to the previous 30s / 1024 defaults, so existing callers (test suite, integration tests) keep working unmodified.

No public function signatures were changed. The SSE handler still has `NewSSE(bus)`; the heartbeat + subscriber-buffer values are applied via package-level setters called from `server.New`, with `SetHeartbeatInterval` retaining its existing test-override semantics.

## Test plan

- [x] `go test -race -count=1 ./...` — all 12 packages green
- [x] `go test -tags=integration -race -count=3 ./tests/integration/...` — clean across 3 iterations
- [x] `gosec ./...` — clean
- [x] Config-parse tests cover positive (`"750ms"` → 750ms), invalid (`"not-a-duration"` → default), zero (`"0s"` → default), and negative (`"-5s"` → default) shapes for every Duration field. Equivalent positive/zero/negative/garbage coverage for each int field.
- [x] Markdownlint clean on README + .env.example
- [ ] CI green
- [ ] Auto-merge fires once base lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)