### PR TITLE
chore(lint): enable revive and fix findings (5a/5e)

### DIFF
--- a/dashboard/.golangci.yml
+++ b/dashboard/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - gosec
     - errorlint   # require errors.Is / errors.As / %w wrapping
     - bodyclose   # ensure HTTP response bodies are closed
+    - revive      # modern golint replacement: naming, comments, control flow
 
 # G401 (weak crypto, e.g. md5/sha1) and G501 (md5 import) are intentionally
 # NOT excluded. Atlas does not use weak crypto in production code; if a future

--- a/dashboard/cmd/argus-dashboard/main.go
+++ b/dashboard/cmd/argus-dashboard/main.go
@@ -1,3 +1,6 @@
+// Command argus-dashboard is the Atlas dashboard binary: it loads
+// configuration, wires the cache/bus/pollers/HTTP server, and serves the
+// observability UI for the HomericIntelligence mesh.
 package main
 
 import (

--- a/dashboard/internal/catalog/probe.go
+++ b/dashboard/internal/catalog/probe.go
@@ -1,3 +1,5 @@
+// Package catalog enumerates the well-known Atlas backing services and probes
+// each host for their availability.
 package catalog
 
 import (

--- a/dashboard/internal/catalog/probe_test.go
+++ b/dashboard/internal/catalog/probe_test.go
@@ -26,7 +26,7 @@ func TestProbeAll_Healthy(t *testing.T) {
 	svcs := make([]ServiceDef, numServices)
 
 	for i := 0; i < numServices; i++ {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
 		t.Cleanup(srv.Close)
@@ -72,7 +72,7 @@ func TestProbeAll_Healthy(t *testing.T) {
 // TestProbeAll_Unhealthy: server returns 503, assert OK:false.
 // Sequential (not t.Parallel) to avoid race on KnownServices.
 func TestProbeAll_Unhealthy(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 	t.Cleanup(srv.Close)
@@ -110,7 +110,7 @@ func TestProbeAll_ConcurrentWallTime(t *testing.T) {
 
 	svcs := make([]ServiceDef, numSvcs)
 	for i := 0; i < numSvcs; i++ {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			time.Sleep(probeDelay)
 			w.WriteHeader(http.StatusOK)
 		}))

--- a/dashboard/internal/catalog/services.go
+++ b/dashboard/internal/catalog/services.go
@@ -1,5 +1,8 @@
 package catalog
 
+// ServiceDef describes a single backing service Atlas knows how to poll.
+// It captures the wire-level coordinates (port, protocol) plus the path used
+// for liveness checks and the optional UI path advertised on the dashboard.
 type ServiceDef struct {
 	Name       string
 	Port       int
@@ -8,6 +11,8 @@ type ServiceDef struct {
 	Proto      string
 }
 
+// KnownServices is the canonical, hard-coded service catalog used when no
+// dynamic discovery source is configured.
 var KnownServices = []ServiceDef{
 	{Name: "nats", Port: 4222, HealthPath: "/varz", Proto: "http"},
 	{Name: "nats-mon", Port: 8222, HealthPath: "/varz", Proto: "http"},

--- a/dashboard/internal/config/config.go
+++ b/dashboard/internal/config/config.go
@@ -1,3 +1,5 @@
+// Package config loads and validates the ATLAS_* environment variables that
+// drive the Atlas dashboard runtime configuration.
 package config
 
 import (
@@ -11,6 +13,9 @@ import (
 	"time"
 )
 
+// Config holds the runtime-tunable knobs for the Atlas dashboard. Every
+// field is sourced from an ATLAS_* environment variable in Load and may be
+// validated by Validate before use.
 type Config struct {
 	ListenAddr         string
 	LogLevel           slog.Level

--- a/dashboard/internal/events/bus.go
+++ b/dashboard/internal/events/bus.go
@@ -1,3 +1,5 @@
+// Package events implements an in-process pub/sub event bus with a fixed-size
+// ring-buffer history and lock-free fan-out to registered subscribers.
 package events
 
 import (
@@ -15,13 +17,13 @@ type ringBuffer struct {
 	size int
 }
 
-func newRingBuffer(cap int) *ringBuffer {
-	if cap <= 0 {
-		cap = 1
+func newRingBuffer(capacity int) *ringBuffer {
+	if capacity <= 0 {
+		capacity = 1
 	}
 	return &ringBuffer{
-		buf: make([]Event, cap),
-		cap: cap,
+		buf: make([]Event, capacity),
+		cap: capacity,
 	}
 }
 

--- a/dashboard/internal/grafana/panels.go
+++ b/dashboard/internal/grafana/panels.go
@@ -1,3 +1,5 @@
+// Package grafana describes the Grafana panels Atlas embeds via d-solo
+// iframes and helpers for constructing their URLs.
 package grafana
 
 // Panel describes a single Grafana panel that Atlas embeds via d-solo iframe.

--- a/dashboard/internal/handlers/api.go
+++ b/dashboard/internal/handlers/api.go
@@ -1,3 +1,6 @@
+// Package handlers contains the HTTP request handlers exposed by the Atlas
+// dashboard: REST/JSON API endpoints, the SSE event stream, and the host
+// detail pages.
 package handlers
 
 import (
@@ -21,7 +24,7 @@ func NewHosts(cache *store.Cache) *Hosts {
 }
 
 // ServeHTTP implements http.Handler.
-func (h *Hosts) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *Hosts) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	views := store.BuildHostViews(h.cache)
 
 	w.Header().Set("Content-Type", "application/json")

--- a/dashboard/internal/handlers/sse_test.go
+++ b/dashboard/internal/handlers/sse_test.go
@@ -315,7 +315,7 @@ type blockingResponseWriter struct {
 	ctx context.Context
 }
 
-func (b *blockingResponseWriter) Write(p []byte) (int, error) {
+func (b *blockingResponseWriter) Write(_ []byte) (int, error) {
 	<-b.ctx.Done()
 	return 0, b.ctx.Err()
 }

--- a/dashboard/internal/mnemosyne/reader.go
+++ b/dashboard/internal/mnemosyne/reader.go
@@ -1,3 +1,5 @@
+// Package mnemosyne reads Mnemosyne skill markdown files (YAML frontmatter +
+// body) from disk and exposes them to the Atlas dashboard.
 package mnemosyne
 
 import (
@@ -10,6 +12,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Reader loads Mnemosyne skill markdown files from a directory and caches the
+// parsed result for ttl. It is safe for concurrent use.
 type Reader struct {
 	dir      string
 	mu       sync.RWMutex
@@ -18,10 +22,15 @@ type Reader struct {
 	ttl      time.Duration
 }
 
+// NewReader returns a Reader that scans dir for *.md skill files. The default
+// cache TTL is 5 minutes.
 func NewReader(dir string) *Reader {
 	return &Reader{dir: dir, ttl: 5 * time.Minute}
 }
 
+// Skills returns the cached skill set, reloading from disk if the cached copy
+// is older than the Reader's TTL. The returned slice is a copy and may be
+// mutated by the caller without affecting subsequent calls.
 func (r *Reader) Skills() ([]Skill, error) {
 	r.mu.RLock()
 	if !r.loadedAt.IsZero() && time.Since(r.loadedAt) < r.ttl {

--- a/dashboard/internal/mnemosyne/search.go
+++ b/dashboard/internal/mnemosyne/search.go
@@ -2,6 +2,9 @@ package mnemosyne
 
 import "strings"
 
+// Filter returns the subset of skills whose Name, Description, Category, or
+// Tags contain every whitespace-separated token in query (case-insensitive).
+// An empty query returns the input slice unchanged.
 func Filter(skills []Skill, query string) []Skill {
 	if query == "" {
 		return skills

--- a/dashboard/internal/mnemosyne/types.go
+++ b/dashboard/internal/mnemosyne/types.go
@@ -1,5 +1,7 @@
 package mnemosyne
 
+// Skill is a parsed Mnemosyne skill markdown file: YAML frontmatter fields
+// plus the raw markdown body that followed the closing fence.
 type Skill struct {
 	Name         string   `yaml:"name"`
 	Description  string   `yaml:"description"`

--- a/dashboard/internal/poller/agamemnon.go
+++ b/dashboard/internal/poller/agamemnon.go
@@ -1,3 +1,5 @@
+// Package poller implements the periodic JSON-poll loops that fetch state
+// from Atlas's upstream services (Agamemnon, NATS monitoring) into the cache.
 package poller
 
 import (

--- a/dashboard/internal/poller/cap_test.go
+++ b/dashboard/internal/poller/cap_test.go
@@ -26,7 +26,7 @@ func TestGetJSON_BoundedByMaxResponseBytes(t *testing.T) {
 
 	// Server streams a JSON array of stringified zeros that is much
 	// larger than the cap (~10 KiB > 256 B).
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`[`))
@@ -57,7 +57,7 @@ func TestGetJSON_BoundedByMaxResponseBytes(t *testing.T) {
 // JSON response decodes fine. Locks in that the LimitReader does not
 // regress correct behaviour on realistic payloads.
 func TestGetJSON_AcceptsPayloadsUnderCap(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`["alpha","beta","gamma"]`))
 	}))

--- a/dashboard/internal/poller/metrics_wiring_test.go
+++ b/dashboard/internal/poller/metrics_wiring_test.go
@@ -91,7 +91,7 @@ func TestRecordResult_ZeroElapsedSkipsHistogram(t *testing.T) {
 	}
 }
 
-func TestSetMetrics_Concurrent(t *testing.T) {
+func TestSetMetrics_Concurrent(_ *testing.T) {
 	b := newBase("test", nil)
 	done := make(chan struct{})
 	go func() {
@@ -106,7 +106,7 @@ func TestSetMetrics_Concurrent(t *testing.T) {
 	<-done
 }
 
-func TestNoopMetrics_IsDefault(t *testing.T) {
+func TestNoopMetrics_IsDefault(_ *testing.T) {
 	b := newBase("test", nil)
 	// recordResult must not panic even though we never set a real sink.
 	b.recordResult(nil, time.Millisecond)

--- a/dashboard/internal/poller/poller_test.go
+++ b/dashboard/internal/poller/poller_test.go
@@ -72,7 +72,7 @@ func TestAgamemnonPoller_FetchUpdatesCache(t *testing.T) {
 }
 
 func TestAgamemnonPoller_HTTP500_CacheNotUpdated(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 	}))
 	defer srv.Close()
@@ -216,7 +216,7 @@ func TestNATSPoller_FetchUpdatesCache(t *testing.T) {
 }
 
 func TestNATSPoller_VarzHTTP500_CacheNotUpdated(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "error", http.StatusInternalServerError)
 	}))
 	defer srv.Close()

--- a/dashboard/internal/server/access_log.go
+++ b/dashboard/internal/server/access_log.go
@@ -1,3 +1,6 @@
+// Package server constructs the Atlas HTTP server: routes, middleware
+// (auth, rate-limit, access log, security headers), and the readiness
+// registry that the composition root populates.
 package server
 
 import (

--- a/dashboard/internal/server/access_log_test.go
+++ b/dashboard/internal/server/access_log_test.go
@@ -26,7 +26,7 @@ func TestAccessLog_DoesNotLeakQueryString(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
 
-	handler := accessLog(logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := accessLog(logger)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -56,7 +56,7 @@ func TestAccessLog_DoesNotLeakQueryString(t *testing.T) {
 func TestAccessLog_LogsPathAndStatus(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
-	handler := accessLog(logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := accessLog(logger)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusTeapot)
 	}))
 

--- a/dashboard/internal/server/auth.go
+++ b/dashboard/internal/server/auth.go
@@ -11,6 +11,7 @@ import (
 // AuthMode represents the authentication scheme for the Atlas dashboard.
 type AuthMode string
 
+// AuthMode constants are the canonical values accepted by ATLAS_AUTH_MODE.
 const (
 	AuthNone   AuthMode = "none"
 	AuthBasic  AuthMode = "basic"

--- a/dashboard/internal/server/auth_test.go
+++ b/dashboard/internal/server/auth_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // okHandler returns 200 OK for any request; used as the downstream handler in tests.
-var okHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+var okHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 })
 

--- a/dashboard/internal/server/middleware_test.go
+++ b/dashboard/internal/server/middleware_test.go
@@ -28,7 +28,7 @@ func minimalServer(t *testing.T, grafana, loki, natsDash string) *Server {
 func runMiddleware(t *testing.T, s *Server) *httptest.ResponseRecorder {
 	t.Helper()
 	rr := httptest.NewRecorder()
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 	s.securityHeaders(next).ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))

--- a/dashboard/internal/server/readyz.go
+++ b/dashboard/internal/server/readyz.go
@@ -171,7 +171,7 @@ func itoa(i int) string {
 // registry. 200 with a per-component JSON body if every check is OK; 503 with
 // the same body shape if any check fails.
 func MakeReadyzHandler(reg *ReadyRegistry) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
 		snap := reg.Snapshot()
 		body := map[string]any{
 			"ok":         true,

--- a/dashboard/internal/server/routes.go
+++ b/dashboard/internal/server/routes.go
@@ -83,13 +83,13 @@ func (s *Server) routes() http.Handler {
 // handleLivez is the unauthenticated liveness probe. It returns 200 if the
 // process is up — it does NOT validate upstream connectivity. Use /readyz for
 // component-level readiness aggregation.
-func (s *Server) handleLivez(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleLivez(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("ok"))
 }
 
-func (s *Server) handleOverview(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleOverview(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_, _ = w.Write(overviewHTML)
 }

--- a/dashboard/internal/server/server.go
+++ b/dashboard/internal/server/server.go
@@ -13,6 +13,8 @@ import (
 	"github.com/HomericIntelligence/atlas/internal/store"
 )
 
+// Server wires together the HTTP server, event bus, SSE handler, API
+// handlers, metrics, and readiness registry that make up the Atlas dashboard.
 type Server struct {
 	cfg          *config.Config
 	srv          *http.Server
@@ -24,6 +26,9 @@ type Server struct {
 	ready        *ReadyRegistry
 }
 
+// New constructs a Server, applying the SSE tunables from cfg, wiring the
+// HTTP routes, and assembling the API handlers backed by cache. The returned
+// Server is not yet listening; call Run to start serving.
 func New(cfg *config.Config, bus *events.Bus, cache *store.Cache) *Server {
 	metrics := newAtlasMetrics()
 	// Apply SSE tunables from cfg before constructing the handler so the
@@ -70,6 +75,9 @@ func (s *Server) Ready() *ReadyRegistry {
 	return s.ready
 }
 
+// Run starts the HTTP listener and blocks until ctx is cancelled or the
+// listener returns a non-ErrServerClosed error. On context cancellation the
+// server is gracefully shut down with a 10-second deadline.
 func (s *Server) Run(ctx context.Context) error {
 	errCh := make(chan error, 1)
 	go func() {

--- a/dashboard/internal/store/cache.go
+++ b/dashboard/internal/store/cache.go
@@ -1,3 +1,5 @@
+// Package store provides the in-memory cache that backs the Atlas dashboard's
+// API responses, populated by the various pollers and the NATS subscriber.
 package store
 
 import (

--- a/dashboard/internal/store/cache_test.go
+++ b/dashboard/internal/store/cache_test.go
@@ -183,7 +183,7 @@ func TestSetAndGet_NATSConns(t *testing.T) {
 // many concurrent writers against the cache while concurrent readers
 // snapshot every accessor. The race detector (go test -race) is the
 // primary assertion; this test passes if no race is reported.
-func TestConcurrentSetGet_NoRaces(t *testing.T) {
+func TestConcurrentSetGet_NoRaces(_ *testing.T) {
 	c := NewCache()
 	var wg sync.WaitGroup
 

--- a/dashboard/internal/tailscale/api.go
+++ b/dashboard/internal/tailscale/api.go
@@ -1,3 +1,6 @@
+// Package tailscale discovers Tailscale device inventory via the CLI, the
+// REST API, or a static configuration source, with an auto-source that tries
+// each in priority order.
 package tailscale
 
 import (

--- a/dashboard/internal/tailscale/auto.go
+++ b/dashboard/internal/tailscale/auto.go
@@ -23,11 +23,11 @@ func (a AutoSource) Devices(ctx context.Context) ([]Device, error) {
 	if a.Cfg != nil {
 		cli.Timeout = a.Cfg.TailscaleCLITimeout
 	}
-	if devices, err := cli.Devices(ctx); err == nil {
+	devices, err := cli.Devices(ctx)
+	if err == nil {
 		return devices, nil
-	} else {
-		slog.Debug("tailscale auto: CLI source failed, trying next", "err", err)
 	}
+	slog.Debug("tailscale auto: CLI source failed, trying next", "err", err)
 
 	// 2. Try API source if credentials are available.
 	if a.Cfg != nil && a.Cfg.TailscaleAPIKey != "" && a.Cfg.TailnetName != "" {
@@ -36,11 +36,11 @@ func (a AutoSource) Devices(ctx context.Context) ([]Device, error) {
 			Tailnet: a.Cfg.TailnetName,
 			Timeout: a.Cfg.TailscaleAPITimeout,
 		}
-		if devices, err := api.Devices(ctx); err == nil {
-			return devices, nil
-		} else {
-			slog.Debug("tailscale auto: API source failed, falling back to static", "err", err)
+		apiDevices, apiErr := api.Devices(ctx)
+		if apiErr == nil {
+			return apiDevices, nil
 		}
+		slog.Debug("tailscale auto: API source failed, falling back to static", "err", apiErr)
 	}
 
 	// 3. Fall back to static -- never errors.

--- a/dashboard/internal/tailscale/cap_test.go
+++ b/dashboard/internal/tailscale/cap_test.go
@@ -23,7 +23,7 @@ func TestAPISource_BoundedByMaxResponseBytes(t *testing.T) {
 	maxResponseBytes = 256
 	t.Cleanup(func() { maxResponseBytes = prev })
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		// Stream ~10 KiB of valid-looking device array — well over the cap.
 		_, _ = w.Write([]byte(`{"devices":[{"hostname":"`))

--- a/dashboard/internal/version/version.go
+++ b/dashboard/internal/version/version.go
@@ -1,3 +1,6 @@
+// Package version exposes the build-injected Atlas version string.
 package version
 
+// Version is the Atlas build version. It defaults to "dev" and is overridden
+// at link time via -ldflags "-X .../version.Version=<value>".
 var Version = "dev"


### PR DESCRIPTION
## Summary

- Enables the `revive` linter in `dashboard/.golangci.yml`. First of five planned linter-expansion PRs (5a/5e). Closes part of the §4 audit MAJOR finding "thin lint config — no revive, gocyclo, funlen, dupl, gofumpt."
- Fixed ~46 findings: 13x exported-without-comment, 12x package-comments, 2x redefines-builtin-id, ~19x unused-parameter (test handlers + 4 production handlers), 2x indent-error-flow.
- Pure cleanup: no behaviour change. Existing tests unchanged.

## Findings fixed (categories)

- **13x exported-without-comment** -> added Go-doc comments on exported types/functions/methods/vars (`ServiceDef`, `KnownServices`, `Config`, `Reader`, `NewReader`, `(Reader).Skills`, `Filter`, `Skill`, the `AuthMode` const block, `Server`, `New`, `(Server).Run`, `Version`).
- **12x package-comments** -> added package doc comments to `events`, `grafana`, `version`, `config`, `mnemosyne`, `store`, `catalog`, `poller`, `tailscale`, `handlers`, `server`, and the `argus-dashboard` main command.
- **2x redefines-builtin-id** -> renamed shadowing `cap` parameter to `capacity` in `events/bus.go` `newRingBuffer`.
- **~19x unused-parameter** -> renamed unused `r *http.Request`, `p []byte`, and `t *testing.T` params to `_` across handler closures and test helpers. Verified interface signatures (`http.Handler`, `io.Writer`, Go's `func(t *testing.T)` testing convention) all remain intact — only the parameter NAME changes.
- **2x indent-error-flow** -> flattened if/else-after-return in `tailscale/auto.go` by hoisting the variable declaration out of the if-init.

No `//nolint` additions were necessary.

## Test plan

- [x] `golangci-lint run` -> silent on revive (2 pre-existing gosec G101 findings in `auth_test.go` / `access_log_test.go` constants are deliberate test fixtures, baseline-confirmed before this change, out of scope).
- [x] `go test -race -count=1 ./...` -> all 12 packages green.
- [x] `go test -tags=integration -race -count=1 ./tests/integration/...` -> clean.
- [x] `gosec -quiet ./...` -> clean.
- [ ] CI green
- [ ] Auto-merge fires once base lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)