### PR TITLE
chore(lint): enable gocyclo and fix findings (threshold=15)

### DIFF
--- a/dashboard/.golangci.yml
+++ b/dashboard/.golangci.yml
@@ -17,6 +17,21 @@ linters:
     - errorlint   # require errors.Is / errors.As / %w wrapping
     - bodyclose   # ensure HTTP response bodies are closed
     - revive      # modern golint replacement: naming, comments, control flow
+    - gocyclo     # cyclomatic complexity ceiling — keeps functions testable
+  settings:
+    gocyclo:
+      # Industry-conventional ceiling for "well-tested" code. Anything above 15
+      # is hard to reason about and harder to test. PR #473 already split the
+      # known worst offender (Subscriber.Start), so this should be quiet.
+      min-complexity: 15
+  exclusions:
+    rules:
+      # gocyclo measures branch-density of production functions — table-driven
+      # tests legitimately have many cases and high branch counts and that is
+      # the desired pattern, not a smell. Skip _test.go for this linter.
+      - path: _test\.go
+        linters:
+          - gocyclo
 
 # G401 (weak crypto, e.g. md5/sha1) and G501 (md5 import) are intentionally
 # NOT excluded. Atlas does not use weak crypto in production code; if a future

--- a/dashboard/internal/handlers/sse.go
+++ b/dashboard/internal/handlers/sse.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -101,30 +102,12 @@ func (h *SSE) Connected() int64 {
 // subscriber channel on the bus and receives all matching events until the
 // client disconnects or the request context is cancelled.
 func (h *SSE) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("X-Accel-Buffering", "no")
-
-	flusher, ok := w.(http.Flusher)
+	flusher, ok := prepareSSEResponse(w)
 	if !ok {
-		http.Error(w, "streaming not supported", http.StatusInternalServerError)
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
-	flusher.Flush()
-
-	ctx := r.Context()
-
-	topicFilter := make(map[string]struct{})
-	if raw := r.URL.Query().Get("topics"); raw != "" {
-		for _, t := range strings.Split(raw, ",") {
-			t = strings.TrimSpace(t)
-			if allowedTopic(t) {
-				topicFilter[t] = struct{}{}
-			}
-		}
-	}
+	topicFilter := parseTopicFilter(r.URL.Query().Get("topics"))
 
 	// Subscribe FIRST so that any event published from this point onward is
 	// captured on the live channel. We then take a snapshot AFTER the
@@ -150,31 +133,90 @@ func (h *SSE) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// window and skip any live-channel event whose ID is <= maxReplayedID
 	// (it was already delivered as part of the snapshot). Once we receive a
 	// live event with ID > maxReplayedID the de-dup logic disengages.
-	var maxReplayedID uint64
-	dedupActive := false
+	maxReplayedID, ok := h.replaySnapshot(w, flusher, r.URL.Query().Get("replay"), topicFilter)
+	if !ok {
+		return
+	}
 
-	if replayStr := r.URL.Query().Get("replay"); replayStr != "" {
-		if n, err := strconv.Atoi(replayStr); err == nil && n > 0 {
-			snapshot := h.bus.Snapshot(n)
-			for _, e := range snapshot {
-				if len(topicFilter) > 0 {
-					if _, pass := topicFilter[e.Topic]; !pass {
-						continue
-					}
-				}
-				if err := writeEvent(w, e); err != nil {
-					return
-				}
-				flusher.Flush()
-				if e.ID > maxReplayedID {
-					maxReplayedID = e.ID
-				}
-			}
-			if maxReplayedID > 0 {
-				dedupActive = true
-			}
+	h.streamLoop(r.Context(), w, flusher, ch, topicFilter, maxReplayedID)
+}
+
+// prepareSSEResponse writes the SSE response headers and returns the flusher,
+// or false if the writer does not support flushing (in which case an error
+// response has already been written).
+func prepareSSEResponse(w http.ResponseWriter) (http.Flusher, bool) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return nil, false
+	}
+
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+	return flusher, true
+}
+
+// parseTopicFilter parses the comma-separated topic list from the "topics"
+// query parameter and returns a set of allowed topics. An empty result means
+// "no filter — accept all topics."
+func parseTopicFilter(raw string) map[string]struct{} {
+	topicFilter := make(map[string]struct{})
+	if raw == "" {
+		return topicFilter
+	}
+	for _, t := range strings.Split(raw, ",") {
+		t = strings.TrimSpace(t)
+		if allowedTopic(t) {
+			topicFilter[t] = struct{}{}
 		}
 	}
+	return topicFilter
+}
+
+// replaySnapshot drains a bus snapshot of size derived from replayStr,
+// applying the topic filter. It returns the highest Event.ID written to the
+// wire (0 if no replay happened) and false if the client connection broke
+// during replay (caller should return).
+func (h *SSE) replaySnapshot(w http.ResponseWriter, flusher http.Flusher, replayStr string, topicFilter map[string]struct{}) (uint64, bool) {
+	if replayStr == "" {
+		return 0, true
+	}
+	n, err := strconv.Atoi(replayStr)
+	if err != nil || n <= 0 {
+		return 0, true
+	}
+	var maxReplayedID uint64
+	for _, e := range h.bus.Snapshot(n) {
+		if !topicAllowed(topicFilter, e.Topic) {
+			continue
+		}
+		if err := writeEvent(w, e); err != nil {
+			return 0, false
+		}
+		flusher.Flush()
+		if e.ID > maxReplayedID {
+			maxReplayedID = e.ID
+		}
+	}
+	return maxReplayedID, true
+}
+
+// streamLoop is the main per-client event loop: it forwards live bus events
+// to the SSE wire, emits periodic heartbeats, and de-duplicates events whose
+// IDs were already delivered during replay.
+func (h *SSE) streamLoop(
+	ctx context.Context,
+	w http.ResponseWriter,
+	flusher http.Flusher,
+	ch <-chan events.Event,
+	topicFilter map[string]struct{},
+	maxReplayedID uint64,
+) {
+	dedupActive := maxReplayedID > 0
 
 	ticker := time.NewTicker(HeartbeatInterval())
 	defer ticker.Stop()
@@ -205,11 +247,8 @@ func (h *SSE) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				dedupActive = false
 			}
-			// Apply topic filter.
-			if len(topicFilter) > 0 {
-				if _, pass := topicFilter[e.Topic]; !pass {
-					continue
-				}
+			if !topicAllowed(topicFilter, e.Topic) {
+				continue
 			}
 			if err := writeEvent(w, e); err != nil {
 				return
@@ -217,6 +256,16 @@ func (h *SSE) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			flusher.Flush()
 		}
 	}
+}
+
+// topicAllowed reports whether topic passes the (possibly empty) filter set.
+// An empty filter means "accept all topics."
+func topicAllowed(filter map[string]struct{}, topic string) bool {
+	if len(filter) == 0 {
+		return true
+	}
+	_, pass := filter[topic]
+	return pass
 }
 
 // allowedTopics is the server-side whitelist for SSE topic subscriptions.


### PR DESCRIPTION
## Summary

- Enables `gocyclo` in `dashboard/.golangci.yml` with `min-complexity: 15`. Second of five planned linter-expansion PRs (5b/5e). Addresses part of the §4 audit MAJOR finding "thin lint config — no revive, gocyclo, funlen, dupl, gofumpt."
- Refactored 1 function (`(*SSE).ServeHTTP`, complexity 25) into four behaviour-preserving helpers. Zero `//nolint` directives added.
- After refactor, every function in production code sits at complexity ≤ 12, well under the threshold.

## Findings (threshold = 15)

| Function | File:line | Complexity | Action |
|---|---|---|---|
| `(*SSE).ServeHTTP` | `internal/handlers/sse.go:103` | 25 | Refactored — split into `prepareSSEResponse`, `parseTopicFilter`, `replaySnapshot`, `streamLoop`, plus a small `topicAllowed` predicate. |

The refactor is a pure behaviour-preserving extract:

- `prepareSSEResponse` writes SSE headers and returns the `http.Flusher`.
- `parseTopicFilter` parses the `topics` query parameter into a set.
- `replaySnapshot` drains a bus snapshot for the `replay` query parameter, returning the highest replayed event ID.
- `streamLoop` is the main per-client `select` loop (heartbeat + dedup + forward).
- `topicAllowed` de-duplicates the "is this topic in the filter?" check that previously appeared in two places.

Every existing SSE test (`sse_test.go`, the replay-gap test added in PR #472, the headers test) passes unchanged.

## Test exclusion

`*_test.go` is excluded from `gocyclo` via an `exclusions.rules` entry. Branch-density in table-driven tests is the desired pattern, not a smell. Two existing test functions (`TestBus_ConcurrentPublishSubscribeUnsubscribe`, `TestSSE_NoReplayGap`) legitimately exceed the threshold and the per-task brief explicitly forbade touching tests.

## Test plan

- [x] `golangci-lint run --timeout 5m ./...` — silent on `gocyclo`. The two `gosec` G101 hits in `*_test.go` are pre-existing on `fix/atlas-v0.2.1-security` and unrelated to this PR.
- [x] `go test -race -count=1 ./...` — all 12 packages green.
- [x] `go test -tags=integration -race -count=1 ./tests/integration/...` — green.
- [x] `gosec ./...` — clean.
- [ ] CI green
- [ ] Auto-merge fires once base lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)