### PR TITLE
chore(lint): enable funlen (lines=80 statements=50)

### DIFF
--- a/dashboard/.golangci.yml
+++ b/dashboard/.golangci.yml
@@ -18,20 +18,29 @@ linters:
     - bodyclose   # ensure HTTP response bodies are closed
     - revive      # modern golint replacement: naming, comments, control flow
     - gocyclo     # cyclomatic complexity ceiling — keeps functions testable
+    - funlen      # function length ceiling — complements gocyclo
   settings:
     gocyclo:
       # Industry-conventional ceiling for "well-tested" code. Anything above 15
       # is hard to reason about and harder to test. PR #473 already split the
       # known worst offender (Subscriber.Start), so this should be quiet.
       min-complexity: 15
+    funlen:
+      # Industry-conventional thresholds. Complements gocyclo: a function can
+      # be long without being branchy (and vice versa). PR #473 split the
+      # longest offender (Subscriber.Start) and PR #477 fixed gocyclo's
+      # findings, so most functions should already be under these limits.
+      lines: 80
+      statements: 50
   exclusions:
     rules:
-      # gocyclo measures branch-density of production functions — table-driven
-      # tests legitimately have many cases and high branch counts and that is
-      # the desired pattern, not a smell. Skip _test.go for this linter.
+      # gocyclo/funlen measure production functions — table-driven tests
+      # legitimately have many cases / are long, and that is the desired
+      # pattern, not a smell. Skip _test.go for these linters.
       - path: _test\.go
         linters:
           - gocyclo
+          - funlen
 
 # G401 (weak crypto, e.g. md5/sha1) and G501 (md5 import) are intentionally
 # NOT excluded. Atlas does not use weak crypto in production code; if a future


### PR DESCRIPTION
## Summary

- Enables `funlen` linter in `dashboard/.golangci.yml` with thresholds **lines=80, statements=50** — the conventional industry defaults. Third of five planned linter-expansion PRs (5c/5e). Closes part of the §4 audit MAJOR finding "thin lint config — no revive, gocyclo, funlen, dupl, gofumpt."
- **No findings** — PR #473 (Subscriber.Start split) and PR #477 (gocyclo refactors) pre-emptively cleaned the longest offenders, so the default thresholds are silent on the current tree.
- Test files (`_test.go`) excluded from funlen alongside gocyclo — table-driven test bodies are legitimately long and that's the desired pattern.

## Findings

None. Default thresholds (80/50) produce zero findings on the current tree.

| Function | File:line | Length | Action |
|---|---|---|---|
| _(none)_ | — | — | — |

## Test plan

- [x] `golangci-lint run --timeout 5m ./...` — silent (only pre-existing gosec G101 hits in test fixtures, unrelated to this PR)
- [x] `go test -race -count=1 ./...` — green
- [x] `go test -tags=integration -race -count=1 ./tests/integration/...` — green
- [x] `gosec -quiet ./...` — clean
- [ ] CI green
- [ ] Auto-merge fires once base lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)