### PR TITLE
chore(lint): enable dupl and fix findings (threshold=100)

### DIFF
--- a/dashboard/.golangci.yml
+++ b/dashboard/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - revive      # modern golint replacement: naming, comments, control flow
     - gocyclo     # cyclomatic complexity ceiling — keeps functions testable
     - funlen      # function length ceiling — complements gocyclo
+    - dupl        # detect token-level code clones (DRY enforcement)
   settings:
     gocyclo:
       # Industry-conventional ceiling for "well-tested" code. Anything above 15
@@ -32,15 +33,24 @@ linters:
       # findings, so most functions should already be under these limits.
       lines: 80
       statements: 50
+    dupl:
+      # Token-clone threshold. Default (150) is too lenient for production code;
+      # 100 catches the kinds of duplicates the §4 audit called out (e.g. the
+      # 12× cache Set/Get pairs collapsed by PR #474) without false-positiving
+      # on small struct-field assignment blocks.
+      threshold: 100
   exclusions:
     rules:
-      # gocyclo/funlen measure production functions — table-driven tests
-      # legitimately have many cases / are long, and that is the desired
-      # pattern, not a smell. Skip _test.go for these linters.
+      # gocyclo/funlen/dupl measure production functions — table-driven tests
+      # legitimately have many cases / are long / repeat scenario setup, and
+      # that is the desired pattern, not a smell. Skip _test.go for these
+      # linters. (golangci-lint also excludes _test.go from dupl by default,
+      # but make it explicit alongside gocyclo/funlen.)
       - path: _test\.go
         linters:
           - gocyclo
           - funlen
+          - dupl
 
 # G401 (weak crypto, e.g. md5/sha1) and G501 (md5 import) are intentionally
 # NOT excluded. Atlas does not use weak crypto in production code; if a future


### PR DESCRIPTION
## Summary

- Enables `dupl` linter in `dashboard/.golangci.yml` with `threshold: 100`. Fourth of five planned linter-expansion PRs (Wave 5d/5e). Closes part of the §4 audit MAJOR finding "thin lint config — no revive, gocyclo, funlen, dupl, gofumpt."
- **No findings to fix** — PR #474 (cache Set/Get generic helper) already pre-emptively cleaned the obvious offender the audit called out, and at threshold=100 (well below the 150 default) nothing else fires across the whole `dashboard/` tree. Pure config-only PR.
- `_test.go` is explicitly excluded from `dupl` alongside `gocyclo`/`funlen` so table-driven tests don't false-positive on intentional scenario-setup repetition.

## Threshold rationale

100 tokens is the industry-conventional production-code threshold. The default 150 is too lenient — it would have missed exactly the kind of small-but-numerous duplications PR #474 collapsed (12× cache Set/Get pairs). 100 catches those without producing noise on small struct-field assignment blocks.

## Findings

| Files | Tokens | Action |
|---|---|---|
| _(none)_ | — | dupl is silent at threshold=100 across all production files |

## Test plan

- [x] `golangci-lint run --timeout 5m ./...` — silent (only 2 pre-existing gosec G101 false positives in `*_test.go` test fixtures that are unrelated to this PR)
- [x] `go test -race -count=1 ./...` — green
- [x] `go test -tags=integration -race -count=1 ./tests/integration/...` — green
- [x] `gosec ./...` — clean
- [ ] CI green
- [ ] Auto-merge fires once base lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)