### PR TITLE
chore(lint): enable gofumpt and apply formatting (5e/5e)

### DIFF
--- a/dashboard/.golangci.yml
+++ b/dashboard/.golangci.yml
@@ -52,6 +52,27 @@ linters:
           - funlen
           - dupl
 
+# Formatters run separately from linters in golangci-lint v2. gofumpt is a
+# stricter superset of gofmt: tighter import groups, no empty line before a
+# closing brace of a single-statement block, etc. The §4 audit called out the
+# lack of formatter enforcement; this closes that gap.
+formatters:
+  enable:
+    - gofumpt
+  settings:
+    gofumpt:
+      # -extra enables additional stricter rules (e.g. normalizing for-range
+      # statements, flattening single-statement blocks). The diff at default
+      # vs. -extra is identical for this codebase, so we take -extra for the
+      # strongest guarantees going forward.
+      extra-rules: true
+  exclusions:
+    paths:
+      # Generated templ files (_templ.go) are produced by the templ codegen;
+      # their formatting is owned by the generator, not by hand. Skip gofumpt
+      # for them so re-running templ doesn't fight the formatter.
+      - ".*_templ\\.go$"
+
 # G401 (weak crypto, e.g. md5/sha1) and G501 (md5 import) are intentionally
 # NOT excluded. Atlas does not use weak crypto in production code; if a future
 # change introduces them, we want to know.

--- a/dashboard/internal/config/config.go
+++ b/dashboard/internal/config/config.go
@@ -43,7 +43,7 @@ type Config struct {
 	// from ATLAS_POLL_AGAMEMNON_MS (named with the "Ms" suffix in the env
 	// var to communicate the unit; the field is a time.Duration so the
 	// suffix is dropped on the Go side per staticcheck ST1011).
-	PollAgamemnon      time.Duration
+	PollAgamemnon time.Duration
 
 	// RateLimitPerMin is the per-IP request budget for every route except
 	// the dedicated liveness probes. Sourced from ATLAS_RATE_LIMIT_PER_MIN
@@ -211,28 +211,28 @@ func Load() *Config {
 	}
 
 	return &Config{
-		ListenAddr:         getenv("ATLAS_LISTEN_ADDR", ":3002"),
-		LogLevel:           logLevel,
-		NATSURL:            getenv("ATLAS_NATS_URL", "nats://nats:4222"),
-		NATSMonURL:         getenv("ATLAS_NATS_MON_URL", "http://nats:8222"),
-		NATSDashboardURL:   getenv("ATLAS_NATS_DASHBOARD_URL", ""),
-		NATSTopURL:         getenv("ATLAS_NATS_TOP_URL", ""),
-		AgamemnonURL:       getenv("ATLAS_AGAMEMNON_URL", "http://agamemnon:8080"),
-		NestorURL:          getenv("ATLAS_NESTOR_URL", "http://nestor:8081"),
-		HermesURL:          getenv("ATLAS_HERMES_URL", "http://hermes:8080"),
-		PrometheusURL:      getenv("ATLAS_PROMETHEUS_URL", "http://prometheus:9090"),
-		GrafanaURL:         getenv("ATLAS_GRAFANA_URL", "http://grafana:3000"),
-		LokiURL:            getenv("ATLAS_LOKI_URL", "http://loki:3100"),
-		ExporterURL:        getenv("ATLAS_EXPORTER_URL", "http://argus-exporter:9100"),
-		MnemosyneSkillsDir: getenv("ATLAS_MNEMOSYNE_SKILLS_DIR", "/mnt/mnemosyne/skills"),
-		TailscaleSource:    getenv("ATLAS_TAILSCALE_SOURCE", "static"),
-		TailscaleAPIKey:    getenv("ATLAS_TAILSCALE_API_KEY", ""),
-		TailnetName:        getenv("ATLAS_TAILNET_NAME", ""),
-		TailscaleSocket:    getenv("ATLAS_TAILSCALE_SOCKET", "/var/run/tailscale/tailscaled.sock"),
-		AuthMode:           getenv("ATLAS_AUTH_MODE", "bearer"),
-		AuthUser:           getenv("ATLAS_AUTH_USER", ""),
-		AuthPass:           getenv("ATLAS_AUTH_PASS", ""),
-		AuthBearerToken:    getenv("ATLAS_AUTH_BEARER_TOKEN", ""),
+		ListenAddr:           getenv("ATLAS_LISTEN_ADDR", ":3002"),
+		LogLevel:             logLevel,
+		NATSURL:              getenv("ATLAS_NATS_URL", "nats://nats:4222"),
+		NATSMonURL:           getenv("ATLAS_NATS_MON_URL", "http://nats:8222"),
+		NATSDashboardURL:     getenv("ATLAS_NATS_DASHBOARD_URL", ""),
+		NATSTopURL:           getenv("ATLAS_NATS_TOP_URL", ""),
+		AgamemnonURL:         getenv("ATLAS_AGAMEMNON_URL", "http://agamemnon:8080"),
+		NestorURL:            getenv("ATLAS_NESTOR_URL", "http://nestor:8081"),
+		HermesURL:            getenv("ATLAS_HERMES_URL", "http://hermes:8080"),
+		PrometheusURL:        getenv("ATLAS_PROMETHEUS_URL", "http://prometheus:9090"),
+		GrafanaURL:           getenv("ATLAS_GRAFANA_URL", "http://grafana:3000"),
+		LokiURL:              getenv("ATLAS_LOKI_URL", "http://loki:3100"),
+		ExporterURL:          getenv("ATLAS_EXPORTER_URL", "http://argus-exporter:9100"),
+		MnemosyneSkillsDir:   getenv("ATLAS_MNEMOSYNE_SKILLS_DIR", "/mnt/mnemosyne/skills"),
+		TailscaleSource:      getenv("ATLAS_TAILSCALE_SOURCE", "static"),
+		TailscaleAPIKey:      getenv("ATLAS_TAILSCALE_API_KEY", ""),
+		TailnetName:          getenv("ATLAS_TAILNET_NAME", ""),
+		TailscaleSocket:      getenv("ATLAS_TAILSCALE_SOCKET", "/var/run/tailscale/tailscaled.sock"),
+		AuthMode:             getenv("ATLAS_AUTH_MODE", "bearer"),
+		AuthUser:             getenv("ATLAS_AUTH_USER", ""),
+		AuthPass:             getenv("ATLAS_AUTH_PASS", ""),
+		AuthBearerToken:      getenv("ATLAS_AUTH_BEARER_TOKEN", ""),
 		PollAgamemnon:        time.Duration(pollMs) * time.Millisecond,
 		RateLimitPerMin:      rate,
 		LivezRateLimitPerMin: livezRate,

--- a/dashboard/internal/handlers/pages.go
+++ b/dashboard/internal/handlers/pages.go
@@ -20,12 +20,12 @@ var validTimeRange = regexp.MustCompile(`^(now(-[0-9]+(s|m|h|d|w|y))?|[0-9]{13})
 
 // HostsHandler serves the /hosts page and the /partials/host/{name} fragment.
 type HostsHandler struct {
-	cache        *store.Cache
-	grafanaURL   string
-	natsDashURL  string
-	natsTopURL   string
-	natsMon      string
-	mnemoReader  *mnemosyne.Reader
+	cache       *store.Cache
+	grafanaURL  string
+	natsDashURL string
+	natsTopURL  string
+	natsMon     string
+	mnemoReader *mnemosyne.Reader
 }
 
 // NewHostsHandler creates a HostsHandler backed by the given cache.

--- a/dashboard/internal/handlers/sse_test.go
+++ b/dashboard/internal/handlers/sse_test.go
@@ -101,8 +101,8 @@ func TestSSEHeaders(t *testing.T) {
 	}
 
 	wantHeaders := map[string]string{
-		"Content-Type":    "text/event-stream",
-		"Cache-Control":   "no-cache",
+		"Content-Type":      "text/event-stream",
+		"Cache-Control":     "no-cache",
 		"X-Accel-Buffering": "no",
 	}
 	for header, want := range wantHeaders {

--- a/dashboard/internal/mnemosyne/reader_test.go
+++ b/dashboard/internal/mnemosyne/reader_test.go
@@ -40,7 +40,7 @@ Send an HTTP GET request to a remote endpoint.
 // Test 1: Load fixture .md file; assert Name, Description, Version, Tags populated.
 func TestLoadSkill(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "nats-publish.md"), []byte(fixtureSkill), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "nats-publish.md"), []byte(fixtureSkill), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -70,10 +70,10 @@ func TestLoadSkill(t *testing.T) {
 // Test 2: Filter("nats") returns only NATS-tagged skills; Filter("") returns all.
 func TestFilter(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "nats-publish.md"), []byte(fixtureSkill), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "nats-publish.md"), []byte(fixtureSkill), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "http-request.md"), []byte(fixtureSkill2), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "http-request.md"), []byte(fixtureSkill2), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/dashboard/internal/nats/subscriber.go
+++ b/dashboard/internal/nats/subscriber.go
@@ -73,9 +73,9 @@ type MetricsSink interface {
 
 type noopMetrics struct{}
 
-func (noopMetrics) SetNATSConnected(bool)        {}
-func (noopMetrics) IncNATSMessage(string)        {}
-func (noopMetrics) IncEventParseError(string)    {}
+func (noopMetrics) SetNATSConnected(bool)     {}
+func (noopMetrics) IncNATSMessage(string)     {}
+func (noopMetrics) IncEventParseError(string) {}
 
 // Subscriber connects to NATS and maintains durable push consumers for each
 // configured stream.

--- a/dashboard/internal/poller/nats_readyz_test.go
+++ b/dashboard/internal/poller/nats_readyz_test.go
@@ -14,10 +14,10 @@ import (
 
 // canonical successful payloads reused across the per-endpoint failure cases.
 const (
-	canonicalVarzJSON       = `{"connections":5,"in_msgs":1000,"out_msgs":800}`
-	canonicalJszJSON        = `{"num_streams":3}`
-	canonicalJszDetailJSON  = `{"streams":[{"config":{"name":"S1","subjects":["s.>"]},"state":{"messages":1,"bytes":2,"consumer_count":3},"created":"2024-01-01T00:00:00Z"}]}`
-	canonicalConnzJSON      = `{"connections":[{"name":"c1","ip":"127.0.0.1","subscriptions":1,"in_msgs":1,"out_msgs":2,"uptime":"1s"}]}`
+	canonicalVarzJSON      = `{"connections":5,"in_msgs":1000,"out_msgs":800}`
+	canonicalJszJSON       = `{"num_streams":3}`
+	canonicalJszDetailJSON = `{"streams":[{"config":{"name":"S1","subjects":["s.>"]},"state":{"messages":1,"bytes":2,"consumer_count":3},"created":"2024-01-01T00:00:00Z"}]}`
+	canonicalConnzJSON     = `{"connections":[{"name":"c1","ip":"127.0.0.1","subscriptions":1,"in_msgs":1,"out_msgs":2,"uptime":"1s"}]}`
 )
 
 // natsHandler is a configurable httptest handler that returns 500 for any
@@ -64,8 +64,8 @@ func natsHandler(failing map[string]bool) http.HandlerFunc {
 // endpointCountingMetrics counts both cycle-level and per-endpoint failures
 // so the regression tests can assert the dedicated-method wiring works.
 type endpointCountingMetrics struct {
-	pollErrors      atomic.Int64
-	endpointErrors  sync.Map // endpoint string -> *atomic.Int64
+	pollErrors     atomic.Int64
+	endpointErrors sync.Map // endpoint string -> *atomic.Int64
 }
 
 func (c *endpointCountingMetrics) IncPollError(string) {

--- a/dashboard/internal/poller/poller.go
+++ b/dashboard/internal/poller/poller.go
@@ -48,8 +48,8 @@ type MetricsSink interface {
 // value so callers that never call SetMetrics still work.
 type noopMetrics struct{}
 
-func (noopMetrics) IncPollError(string)               {}
-func (noopMetrics) IncEndpointError(string, string)   {}
+func (noopMetrics) IncPollError(string)                 {}
+func (noopMetrics) IncEndpointError(string, string)     {}
 func (noopMetrics) ObservePollDuration(string, float64) {}
 
 // base is a shared helper for HTTP-based pollers. It tracks per-instance

--- a/dashboard/internal/server/access_log.go
+++ b/dashboard/internal/server/access_log.go
@@ -29,7 +29,8 @@ func accessLog(logger *slog.Logger) func(http.Handler) http.Handler {
 			start := time.Now()
 			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 			next.ServeHTTP(ww, r)
-			logger.Info("http",
+			logger.Info(
+				"http",
 				"method", r.Method,
 				"path", r.URL.Path, // path only — never RequestURI / RawQuery
 				"status", ww.Status(),

--- a/dashboard/internal/server/auth.go
+++ b/dashboard/internal/server/auth.go
@@ -78,7 +78,7 @@ func Middleware(mode AuthMode, user, pass, bearerToken string) func(http.Handler
 // Fields:
 //   - mode    : the configured auth scheme (basic / bearer / unknown-mode-string)
 //   - reason  : a stable discriminator (missing-header / wrong-creds /
-//               wrong-token / empty-configured-token / unknown-mode)
+//     wrong-token / empty-configured-token / unknown-mode)
 //   - method  : HTTP method, useful for distinguishing browsers from CLIs
 //   - path    : URL path only (no query string — see access_log for why)
 //   - remote  : r.RemoteAddr; reflects middleware.RealIP rewrites if any
@@ -87,7 +87,8 @@ func Middleware(mode AuthMode, user, pass, bearerToken string) func(http.Handler
 // operator wants throttling, the right place to add it is here, not by
 // reverting to silent 401s.
 func logAuthFailure(r *http.Request, mode, reason string) {
-	slog.Default().Warn("auth failure",
+	slog.Default().Warn(
+		"auth failure",
 		"mode", mode,
 		"reason", reason,
 		"method", r.Method,

--- a/dashboard/internal/server/metrics.go
+++ b/dashboard/internal/server/metrics.go
@@ -183,7 +183,7 @@ func (m *AtlasMetrics) ObservePollDuration(source string, seconds float64) {
 // exposition for this metric set.
 func (m *AtlasMetrics) Handler() http.HandlerFunc {
 	h := promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{
-		Registry:      m.registry,
+		Registry:          m.registry,
 		EnableOpenMetrics: false, // keep legacy text/plain; version=0.0.4 content-type
 	})
 	return h.ServeHTTP

--- a/dashboard/internal/server/middleware.go
+++ b/dashboard/internal/server/middleware.go
@@ -26,7 +26,8 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 		if s.cfg.NATSDashboardURL != "" {
 			frameSrc += " " + s.cfg.NATSDashboardURL
 		}
-		w.Header().Set("Content-Security-Policy",
+		w.Header().Set(
+			"Content-Security-Policy",
 			fmt.Sprintf(
 				"default-src 'self'; script-src 'self' https://unpkg.com; connect-src 'self'; style-src 'self'; img-src 'self' data:; frame-src %s",
 				frameSrc,

--- a/dashboard/internal/server/readyz_test.go
+++ b/dashboard/internal/server/readyz_test.go
@@ -16,9 +16,9 @@ type fakePoller struct {
 	err  error
 }
 
-func (f *fakePoller) Name() string             { return f.name }
-func (f *fakePoller) LastSuccess() time.Time   { return f.last }
-func (f *fakePoller) LastError() error         { return f.err }
+func (f *fakePoller) Name() string           { return f.name }
+func (f *fakePoller) LastSuccess() time.Time { return f.last }
+func (f *fakePoller) LastError() error       { return f.err }
 
 // fakeNATS satisfies natsReadyLike for tests.
 type fakeNATS struct {

--- a/dashboard/internal/store/cache.go
+++ b/dashboard/internal/store/cache.go
@@ -16,18 +16,18 @@ const maxAgentEvents = 50
 // Cache is a thread-safe in-memory store for dashboard state.
 // It is extended with new fields as Atlas milestones add data sources.
 type Cache struct {
-	mu           sync.RWMutex
-	devices      []tailscale.Device    // added in #158
-	probes       []catalog.ProbeResult
-	probesAt     time.Time
+	mu       sync.RWMutex
+	devices  []tailscale.Device // added in #158
+	probes   []catalog.ProbeResult
+	probesAt time.Time
 	// probes extended in #159
-	agents       []AgentRecord         // added in #161
-	tasks        []TaskRecord          // added in #161
-	natsStats    NATSStats             // added in #161
-	agentEvents  map[string][]RawEvent // added in #163: per-agent event history
-	natsStreams  []NATSStreamInfo      // added in #165: JetStream stream list
-	natsConsumers []NATSConsumerInfo   // added in #165: JetStream consumer list
-	natsConns    []NATSConnInfo        // added in #165: NATS connections
+	agents        []AgentRecord         // added in #161
+	tasks         []TaskRecord          // added in #161
+	natsStats     NATSStats             // added in #161
+	agentEvents   map[string][]RawEvent // added in #163: per-agent event history
+	natsStreams   []NATSStreamInfo      // added in #165: JetStream stream list
+	natsConsumers []NATSConsumerInfo    // added in #165: JetStream consumer list
+	natsConns     []NATSConnInfo        // added in #165: NATS connections
 }
 
 // NewCache returns an empty Cache.


### PR DESCRIPTION
## Summary

- Enables `gofumpt` formatter in `dashboard/.golangci.yml` (with `-extra` rules **enabled**) and applies the resulting reformat. Last of five linter-expansion PRs (5e/5e). Closes the §4 audit MAJOR finding *"thin lint config — no revive, gocyclo, funlen, dupl, gofumpt."*
- Mechanical reformat across **13** Go files: **67** insertions, **64** deletions. No semantic changes — gofumpt cannot alter behaviour.
- Specific gofumpt rules that fired: struct field/struct-literal alignment normalization, multi-line function-call argument layout (consistent first-arg-on-newline), and doc-comment continuation indentation.
- `-extra` vs. default produced an *identical* diff for this codebase (same 13 files, same hunks), so we take `-extra` for the strongest guarantees going forward.

## Schema notes

- In golangci-lint v2, `gofumpt` is a *formatter*, not a linter, so it is registered under the new top-level `formatters:` block (not `linters.enable`). Running with the wrong placement fails fast: `can't load config: gofumpt is a formatter`.
- Generated `*_templ.go` files are excluded via `formatters.exclusions.paths` so re-running the templ code generator doesn't fight gofumpt. The current generated files happened to already be gofumpt-clean, but the exclusion future-proofs against templ format drift.

## Test plan

- [x] `golangci-lint fmt --diff ./...` — silent (formatter satisfied)
- [x] `golangci-lint run` — *only* 2 pre-existing gosec G101 findings (`access_log_test.go:24`, `auth_test.go:256`); identical set on the base branch tip, not introduced by this PR
- [x] `go test -race -count=1 ./...` — green (formatting can't break behaviour, but verified)
- [x] `go test -tags=integration -race -count=1 ./tests/integration/...` — green
- [x] `gosec ./...` — clean (stand-alone gosec passes; the golangci-lint-bundled gosec G101 findings are config-driven and pre-existing)
- [ ] CI green
- [ ] Auto-merge fires once base lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)