### PR TITLE
fix(ui): WCAG-AA contrast, keyboard a11y, semantic HTML for §15 audit

### DIFF
--- a/dashboard/web/static/css/atlas.css
+++ b/dashboard/web/static/css/atlas.css
@@ -2,7 +2,11 @@
     --bg: #0d1117;
     --surface: #161b22;
     --border: #30363d;
-    --text: #c9d1d9;
+    /* Primary body text. WCAG: 16.02:1 on --bg, 14.64:1 on --surface (AAA). */
+    --text: #e6edf3;
+    /* Muted/secondary text. WCAG: 8.73:1 on --bg, 7.98:1 on --surface (AAA).
+       Previously #8b949e (6.15:1 / 5.62:1) — bumped for §15 a11y audit. */
+    --text-muted: #a8b1bd;
     --accent: #58a6ff;
     --success: #3fb950;
     --warning: #d29922;
@@ -10,6 +14,20 @@
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
+
+/* Keyboard focus ring — :focus-visible only shows on keyboard navigation, not on
+   mouse click, which is the behaviour users expect. Applies to every focusable
+   element (links, buttons, inputs, [tabindex="0"] cards/rows). */
+:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+/* Suppress the default focus ring when focus-visible is supported, so mouse
+   clicks don't leave a stray outline. */
+:focus:not(:focus-visible) {
+    outline: none;
+}
 
 body {
     background: var(--bg);
@@ -58,8 +76,10 @@ main { padding: 1.5rem; }
     padding: 1rem;
 }
 
-.stat-card .label { font-size: 0.75rem; color: #8b949e; text-transform: uppercase; letter-spacing: .05em; }
+.stat-card .label { font-size: 0.75rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: .05em; }
 .stat-card .value { font-size: 2rem; font-weight: 700; margin-top: .25rem; }
+
+.muted-note { color: var(--text-muted); }
 
 /* ── Hosts page ─────────────────────────────────────────────────────────── */
 
@@ -85,7 +105,7 @@ main { padding: 1.5rem; }
 }
 
 .hostname { font-weight: 600; font-size: 1rem; }
-.mono { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: .8rem; color: #8b949e; }
+.mono { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: .8rem; color: var(--text-muted); }
 
 .badge {
     font-size: .7rem;
@@ -121,7 +141,7 @@ main { padding: 1.5rem; }
 .svc-link.err { border-left: 2px solid var(--danger); opacity: .7; }
 
 .svc-name { font-size: .75rem; font-weight: 600; }
-.svc-port { font-size: .7rem; color: #8b949e; }
+.svc-port { font-size: .7rem; color: var(--text-muted); }
 
 /* Mobile: stack cards vertically below 480 px */
 @media (max-width: 480px) {
@@ -153,12 +173,20 @@ main { padding: 1.5rem; }
     text-align: left;
     font-size: .875rem;
 }
-.data-table th { color: #8b949e; font-weight: 600; text-transform: uppercase; font-size: .7rem; letter-spacing: .05em; }
+.data-table th { color: var(--text-muted); font-weight: 600; text-transform: uppercase; font-size: .7rem; letter-spacing: .05em; }
 .data-table tbody tr:hover { background: var(--surface); }
+/* Keyboard-activatable rows (tabindex="0") get a clear pointer affordance and a
+   visible focus state. */
+.data-table tbody tr[tabindex] { cursor: pointer; }
+.data-table tbody tr[tabindex]:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
+    background: var(--surface);
+}
 .badge.blue { background: #1a2a3a; color: #58a6ff; }
-.badge.gray { background: #1e2530; color: #8b949e; }
-.ts { color: #8b949e; }
-.empty-state { color: #8b949e; padding: 2rem 0; text-align: center; }
+.badge.gray { background: #1e2530; color: var(--text-muted); }
+.ts { color: var(--text-muted); }
+.empty-state { color: var(--text-muted); padding: 2rem 0; text-align: center; }
 
 /* Mobile: collapse data-table columns below 640 px */
 @media (max-width: 640px) {
@@ -171,13 +199,13 @@ main { padding: 1.5rem; }
 .detail-card { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 1rem; margin-bottom: 1.5rem; }
 .detail-header { display: flex; align-items: center; gap: .5rem; margin-bottom: .75rem; flex-wrap: wrap; }
 .detail-meta { display: grid; grid-template-columns: auto 1fr; gap: .25rem .75rem; font-size: .875rem; }
-.detail-meta dt { color: #8b949e; font-weight: 600; }
+.detail-meta dt { color: var(--text-muted); font-weight: 600; }
 .accent-link { color: var(--accent); text-decoration: none; }
 .accent-link:hover { text-decoration: underline; }
-.section-title { font-size: .875rem; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; color: #8b949e; margin-bottom: .75rem; }
+.section-title { font-size: .875rem; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); margin-bottom: .75rem; }
 .event-row { display: flex; gap: .5rem; padding: .2rem 0; border-bottom: 1px solid var(--border); font-size: .8rem; align-items: baseline; flex-wrap: wrap; }
 .event-subject { color: var(--accent); min-width: 0; flex-shrink: 1; }
-.event-payload { color: #8b949e; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 400px; }
+.event-payload { color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 400px; }
 
 /* ── Grafana page ────────────────────────────────────────────────────────── */
 .time-range-bar {
@@ -215,7 +243,7 @@ main { padding: 1.5rem; }
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: .05em;
-    color: #8b949e;
+    color: var(--text-muted);
     padding: .5rem .75rem;
     border-bottom: 1px solid var(--border);
 }
@@ -232,7 +260,7 @@ main { padding: 1.5rem; }
 .skill-summary { display: flex; align-items: center; gap: .5rem; padding: .6rem .75rem; cursor: pointer; list-style: none; flex-wrap: wrap; }
 .skill-summary::-webkit-details-marker { display: none; }
 .skill-name { font-weight: 600; }
-.skill-desc { color: #8b949e; font-size: .8rem; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.skill-desc { color: var(--text-muted); font-size: .8rem; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .skill-body { padding: 1rem; border-top: 1px solid var(--border); font-size: .875rem; line-height: 1.6; }
 .skill-body h1, .skill-body h2, .skill-body h3 { margin: .75rem 0 .25rem; font-size: 1rem; }
 .skill-body p { margin-bottom: .5rem; }
@@ -243,5 +271,18 @@ main { padding: 1.5rem; }
 .external-links { display: flex; gap: .5rem; flex-wrap: wrap; margin-bottom: 1rem; }
 .ext-link { color: var(--accent); text-decoration: none; padding: .3rem .6rem; border: 1px solid var(--border); border-radius: 4px; font-size: .875rem; }
 .ext-link:hover { border-color: var(--accent); }
-.ext-link.disabled { color: #8b949e; cursor: default; }
+.ext-link.disabled { color: var(--text-muted); cursor: default; }
 .nats-top-iframe { width: 100%; height: 400px; border: 1px solid var(--border); border-radius: 4px; }
+
+/* ── Visually-hidden helper for screen-reader-only content ──────────────── */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}

--- a/dashboard/web/static/js/atlas.js
+++ b/dashboard/web/static/js/atlas.js
@@ -5,7 +5,31 @@ document.addEventListener("DOMContentLoaded", function () {
     // SSE connection placeholder — wired when /events endpoint lands (M2)
     if (typeof EventSource !== "undefined" && dot) {
         const src = new EventSource("/events");
-        src.onopen = () => dot.classList.add("connected");
-        src.onerror = () => dot.classList.remove("connected");
+        src.onopen = () => {
+            dot.classList.add("connected");
+            dot.setAttribute("aria-label", "SSE connected");
+            dot.setAttribute("title", "SSE connected");
+        };
+        src.onerror = () => {
+            dot.classList.remove("connected");
+            dot.setAttribute("aria-label", "SSE disconnected");
+            dot.setAttribute("title", "SSE disconnected");
+        };
     }
+
+    // Keyboard accessibility: Enter / Space on any element with tabindex="0"
+    // and a role of "link" or "button" should activate it like a click. This
+    // covers <tr tabindex="0" role="link"> rows and any future card/row that
+    // is wired for click-to-navigate via htmx.
+    document.addEventListener("keydown", function (ev) {
+        const t = ev.target;
+        if (!(t instanceof Element)) return;
+        if (t.getAttribute("tabindex") !== "0") return;
+        const role = t.getAttribute("role");
+        if (role !== "link" && role !== "button") return;
+        if (ev.key === "Enter" || ev.key === " " || ev.key === "Spacebar") {
+            ev.preventDefault();
+            t.click();
+        }
+    });
 });

--- a/dashboard/web/templates/agent_detail.templ
+++ b/dashboard/web/templates/agent_detail.templ
@@ -4,12 +4,12 @@ import "github.com/HomericIntelligence/atlas/internal/store"
 
 templ AgentDetailPage(a store.AgentRecord, task *store.TaskRecord, history []store.RawEvent) {
 	@Layout("Agent: " + a.Name) {
-		<div class="detail-card">
-			<div class="detail-header">
-				<span class="hostname">{ a.Name }</span>
+		<article class="detail-card" aria-labelledby="agent-detail-name">
+			<header class="detail-header">
+				<h1 class="hostname" id="agent-detail-name">{ a.Name }</h1>
 				<span class="mono">{ a.ID }</span>
-				<span class={ "badge " + agentStatusClass(a.Status) }>{ a.Status }</span>
-			</div>
+				<span class={ "badge " + agentStatusClass(a.Status) } role="status" aria-label={ "Status: " + a.Status }>{ a.Status }</span>
+			</header>
 			<dl class="detail-meta">
 				<dt>Host</dt><dd class="mono">{ a.Host }</dd>
 				<dt>Updated</dt><dd class="mono">{ a.UpdatedAt.Format("2006-01-02 15:04:05") }</dd>
@@ -18,9 +18,11 @@ templ AgentDetailPage(a store.AgentRecord, task *store.TaskRecord, history []sto
 					<dd><a href={ templ.SafeURL("/tasks/" + task.ID) } class="accent-link">{ task.Subject }</a></dd>
 				}
 			</dl>
-		</div>
+		</article>
 		<h2 class="section-title">Live event tail</h2>
-		<div id="agent-event-tail"
+		<section id="agent-event-tail"
+			aria-label="Live event tail"
+			aria-live="polite"
 			hx-ext="sse"
 			sse-connect="/events?topics=agent"
 			sse-swap="agent"
@@ -28,6 +30,6 @@ templ AgentDetailPage(a store.AgentRecord, task *store.TaskRecord, history []sto
 			for _, e := range history {
 				@EventRow(e)
 			}
-		</div>
+		</section>
 	}
 }

--- a/dashboard/web/templates/agent_detail_templ.go
+++ b/dashboard/web/templates/agent_detail_templ.go
@@ -43,20 +43,20 @@ func AgentDetailPage(a store.AgentRecord, task *store.TaskRecord, history []stor
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"detail-card\"><div class=\"detail-header\"><span class=\"hostname\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<article class=\"detail-card\" aria-labelledby=\"agent-detail-name\"><header class=\"detail-header\"><h1 class=\"hostname\" id=\"agent-detail-name\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(a.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_detail.templ`, Line: 9, Col: 35}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_detail.templ`, Line: 9, Col: 56}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</span> <span class=\"mono\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</h1><span class=\"mono\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -91,82 +91,95 @@ func AgentDetailPage(a store.AgentRecord, task *store.TaskRecord, history []stor
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" role=\"status\" aria-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var7 string
-			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(a.Status)
+			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs("Status: " + a.Status)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_detail.templ`, Line: 11, Col: 68}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_detail.templ`, Line: 11, Col: 106}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</span></div><dl class=\"detail-meta\"><dt>Host</dt><dd class=\"mono\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var8 string
-			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(a.Host)
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(a.Status)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_detail.templ`, Line: 14, Col: 42}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_detail.templ`, Line: 11, Col: 119}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</dd><dt>Updated</dt><dd class=\"mono\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</span></header><dl class=\"detail-meta\"><dt>Host</dt><dd class=\"mono\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var9 string
-			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(a.UpdatedAt.Format("2006-01-02 15:04:05"))
+			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(a.Host)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_detail.templ`, Line: 15, Col: 80}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_detail.templ`, Line: 14, Col: 42}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</dd>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</dd><dt>Updated</dt><dd class=\"mono\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var10 string
+			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(a.UpdatedAt.Format("2006-01-02 15:04:05"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_detail.templ`, Line: 15, Col: 80}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</dd>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if task != nil {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<dt>Current task</dt><dd><a href=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<dt>Current task</dt><dd><a href=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var10 templ.SafeURL
-				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/tasks/" + task.ID))
+				var templ_7745c5c3_Var11 templ.SafeURL
+				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/tasks/" + task.ID))
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_detail.templ`, Line: 18, Col: 53}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\" class=\"accent-link\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var11 string
-				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(task.Subject)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_detail.templ`, Line: 18, Col: 90}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</a></dd>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\" class=\"accent-link\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var12 string
+				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(task.Subject)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_detail.templ`, Line: 18, Col: 90}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</a></dd>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</dl></div><h2 class=\"section-title\">Live event tail</h2><div id=\"agent-event-tail\" hx-ext=\"sse\" sse-connect=\"/events?topics=agent\" sse-swap=\"agent\" hx-swap=\"afterbegin\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</dl></article><h2 class=\"section-title\">Live event tail</h2><section id=\"agent-event-tail\" aria-label=\"Live event tail\" aria-live=\"polite\" hx-ext=\"sse\" sse-connect=\"/events?topics=agent\" sse-swap=\"agent\" hx-swap=\"afterbegin\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -176,7 +189,7 @@ func AgentDetailPage(a store.AgentRecord, task *store.TaskRecord, history []stor
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/dashboard/web/templates/agent_row.templ
+++ b/dashboard/web/templates/agent_row.templ
@@ -7,11 +7,13 @@ templ AgentRow(a store.AgentRecord) {
 		hx-get={ agentPath(a.ID) }
 		hx-target="main"
 		hx-push-url="true"
-		style="cursor:pointer">
-		<td class="mono">{ shortID(a.ID) }</td>
+		tabindex="0"
+		role="link"
+		aria-label={ "Open agent " + a.Name }>
+		<th scope="row" class="mono">{ shortID(a.ID) }</th>
 		<td>{ a.Name }</td>
 		<td class="mono">{ a.Host }</td>
-		<td><span class={ "badge " + agentStatusClass(a.Status) }>{ a.Status }</span></td>
+		<td><span class={ "badge " + agentStatusClass(a.Status) } role="status" aria-label={ "Status: " + a.Status }>{ a.Status }</span></td>
 		<td class="ts mono">{ a.UpdatedAt.Format("15:04:05") }</td>
 	</tr>
 }

--- a/dashboard/web/templates/agent_row_templ.go
+++ b/dashboard/web/templates/agent_row_templ.go
@@ -57,94 +57,120 @@ func AgentRow(a store.AgentRecord) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" hx-target=\"main\" hx-push-url=\"true\" style=\"cursor:pointer\"><td class=\"mono\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" hx-target=\"main\" hx-push-url=\"true\" tabindex=\"0\" role=\"link\" aria-label=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(shortID(a.ID))
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs("Open agent " + a.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_row.templ`, Line: 11, Col: 34}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_row.templ`, Line: 12, Col: 37}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</td><td>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\"><th scope=\"row\" class=\"mono\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var5 string
-		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(a.Name)
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(shortID(a.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_row.templ`, Line: 12, Col: 14}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_row.templ`, Line: 13, Col: 46}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</td><td class=\"mono\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</th><td>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var6 string
-		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(a.Host)
+		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(a.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_row.templ`, Line: 13, Col: 27}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_row.templ`, Line: 14, Col: 14}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</td><td>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</td><td class=\"mono\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var7 = []any{"badge " + agentStatusClass(a.Status)}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var7...)
+		var templ_7745c5c3_Var7 string
+		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(a.Host)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_row.templ`, Line: 15, Col: 27}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<span class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</td><td>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var8 string
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var7).String())
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_row.templ`, Line: 1, Col: 0}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+		var templ_7745c5c3_Var8 = []any{"badge " + agentStatusClass(a.Status)}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var8...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<span class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var9 string
-		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(a.Status)
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var8).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_row.templ`, Line: 14, Col: 70}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_row.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</span></td><td class=\"ts mono\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" role=\"status\" aria-label=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var10 string
-		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(a.UpdatedAt.Format("15:04:05"))
+		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs("Status: " + a.Status)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_row.templ`, Line: 15, Col: 54}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_row.templ`, Line: 16, Col: 108}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</td></tr>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var11 string
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(a.Status)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_row.templ`, Line: 16, Col: 121}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</span></td><td class=\"ts mono\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var12 string
+		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(a.UpdatedAt.Format("15:04:05"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agent_row.templ`, Line: 17, Col: 54}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</td></tr>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/dashboard/web/templates/agents.templ
+++ b/dashboard/web/templates/agents.templ
@@ -21,18 +21,24 @@ func uniqueHosts(agents []store.AgentRecord) []string {
 
 templ AgentsPage(agents []store.AgentRecord, search, statusFilter, hostFilter string) {
 	@Layout("Agents") {
-		<div class="filter-bar">
-			<input type="text" name="search" value={ search } placeholder="Search name / host"
+		<div class="filter-bar" role="search" aria-label="Filter agents">
+			<label class="sr-only" for="agents-search">Search agents</label>
+			<input id="agents-search" type="text" name="search" value={ search } placeholder="Search name / host"
+				aria-label="Search agents by name or host"
 				hx-get="/partials/agents/table" hx-target="#agents-table-body"
 				hx-trigger="keyup changed delay:300ms" hx-include="[name='status'],[name='host']"/>
-			<select name="status" hx-get="/partials/agents/table" hx-target="#agents-table-body"
+			<label class="sr-only" for="agents-status-filter">Filter by status</label>
+			<select id="agents-status-filter" name="status" aria-label="Filter by status"
+				hx-get="/partials/agents/table" hx-target="#agents-table-body"
 				hx-trigger="change" hx-include="[name='search'],[name='host']">
 				<option value="">All statuses</option>
 				<option value="idle" selected={ statusFilter == "idle" }>idle</option>
 				<option value="running" selected={ statusFilter == "running" }>running</option>
 				<option value="error" selected={ statusFilter == "error" }>error</option>
 			</select>
-			<select name="host" hx-get="/partials/agents/table" hx-target="#agents-table-body"
+			<label class="sr-only" for="agents-host-filter">Filter by host</label>
+			<select id="agents-host-filter" name="host" aria-label="Filter by host"
+				hx-get="/partials/agents/table" hx-target="#agents-table-body"
 				hx-trigger="change" hx-include="[name='search'],[name='status']">
 				<option value="">All hosts</option>
 				for _, h := range uniqueHosts(agents) {
@@ -40,14 +46,14 @@ templ AgentsPage(agents []store.AgentRecord, search, statusFilter, hostFilter st
 				}
 			</select>
 		</div>
-		<table class="data-table">
+		<table class="data-table" aria-label="Agents">
 			<thead>
 				<tr>
-					<th>ID</th>
-					<th>Name</th>
-					<th>Host</th>
-					<th>Status</th>
-					<th>Updated</th>
+					<th scope="col">ID</th>
+					<th scope="col">Name</th>
+					<th scope="col">Host</th>
+					<th scope="col">Status</th>
+					<th scope="col">Updated</th>
 				</tr>
 			</thead>
 			<tbody id="agents-table-body"

--- a/dashboard/web/templates/agents_templ.go
+++ b/dashboard/web/templates/agents_templ.go
@@ -60,27 +60,27 @@ func AgentsPage(agents []store.AgentRecord, search, statusFilter, hostFilter str
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"filter-bar\"><input type=\"text\" name=\"search\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"filter-bar\" role=\"search\" aria-label=\"Filter agents\"><label class=\"sr-only\" for=\"agents-search\">Search agents</label> <input id=\"agents-search\" type=\"text\" name=\"search\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(search)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 25, Col: 50}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 26, Col: 69}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\" placeholder=\"Search name / host\" hx-get=\"/partials/agents/table\" hx-target=\"#agents-table-body\" hx-trigger=\"keyup changed delay:300ms\" hx-include=\"[name='status'],[name='host']\"> <select name=\"status\" hx-get=\"/partials/agents/table\" hx-target=\"#agents-table-body\" hx-trigger=\"change\" hx-include=\"[name='search'],[name='host']\"><option value=\"\">All statuses</option> <option value=\"idle\" selected=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\" placeholder=\"Search name / host\" aria-label=\"Search agents by name or host\" hx-get=\"/partials/agents/table\" hx-target=\"#agents-table-body\" hx-trigger=\"keyup changed delay:300ms\" hx-include=\"[name='status'],[name='host']\"> <label class=\"sr-only\" for=\"agents-status-filter\">Filter by status</label> <select id=\"agents-status-filter\" name=\"status\" aria-label=\"Filter by status\" hx-get=\"/partials/agents/table\" hx-target=\"#agents-table-body\" hx-trigger=\"change\" hx-include=\"[name='search'],[name='host']\"><option value=\"\">All statuses</option> <option value=\"idle\" selected=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(statusFilter == "idle")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 31, Col: 58}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 35, Col: 58}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -93,7 +93,7 @@ func AgentsPage(agents []store.AgentRecord, search, statusFilter, hostFilter str
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(statusFilter == "running")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 32, Col: 64}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 36, Col: 64}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -106,13 +106,13 @@ func AgentsPage(agents []store.AgentRecord, search, statusFilter, hostFilter str
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(statusFilter == "error")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 33, Col: 60}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 37, Col: 60}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\">error</option></select> <select name=\"host\" hx-get=\"/partials/agents/table\" hx-target=\"#agents-table-body\" hx-trigger=\"change\" hx-include=\"[name='search'],[name='status']\"><option value=\"\">All hosts</option> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\">error</option></select> <label class=\"sr-only\" for=\"agents-host-filter\">Filter by host</label> <select id=\"agents-host-filter\" name=\"host\" aria-label=\"Filter by host\" hx-get=\"/partials/agents/table\" hx-target=\"#agents-table-body\" hx-trigger=\"change\" hx-include=\"[name='search'],[name='status']\"><option value=\"\">All hosts</option> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -124,7 +124,7 @@ func AgentsPage(agents []store.AgentRecord, search, statusFilter, hostFilter str
 				var templ_7745c5c3_Var7 string
 				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(h)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 39, Col: 22}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 45, Col: 22}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 				if templ_7745c5c3_Err != nil {
@@ -137,7 +137,7 @@ func AgentsPage(agents []store.AgentRecord, search, statusFilter, hostFilter str
 				var templ_7745c5c3_Var8 string
 				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(hostFilter == h)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 39, Col: 51}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 45, Col: 51}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 				if templ_7745c5c3_Err != nil {
@@ -150,7 +150,7 @@ func AgentsPage(agents []store.AgentRecord, search, statusFilter, hostFilter str
 				var templ_7745c5c3_Var9 string
 				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(h)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 39, Col: 57}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/agents.templ`, Line: 45, Col: 57}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 				if templ_7745c5c3_Err != nil {
@@ -161,7 +161,7 @@ func AgentsPage(agents []store.AgentRecord, search, statusFilter, hostFilter str
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</select></div><table class=\"data-table\"><thead><tr><th>ID</th><th>Name</th><th>Host</th><th>Status</th><th>Updated</th></tr></thead> <tbody id=\"agents-table-body\" hx-ext=\"sse\" sse-connect=\"/events?topics=agent\" sse-swap=\"agent\" hx-swap=\"outerHTML settle:50ms\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</select></div><table class=\"data-table\" aria-label=\"Agents\"><thead><tr><th scope=\"col\">ID</th><th scope=\"col\">Name</th><th scope=\"col\">Host</th><th scope=\"col\">Status</th><th scope=\"col\">Updated</th></tr></thead> <tbody id=\"agents-table-body\" hx-ext=\"sse\" sse-connect=\"/events?topics=agent\" sse-swap=\"agent\" hx-swap=\"outerHTML settle:50ms\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/dashboard/web/templates/event_row.templ
+++ b/dashboard/web/templates/event_row.templ
@@ -3,9 +3,9 @@ package templates
 import "github.com/HomericIntelligence/atlas/internal/store"
 
 templ EventRow(e store.RawEvent) {
-	<div class="event-row" id={ "evt-" + e.ReceivedAt.Format("20060102150405.000") }>
+	<div class="event-row" id={ "evt-" + e.ReceivedAt.Format("20060102150405.000") } role="listitem">
 		<span class="mono ts">{ e.ReceivedAt.Format("15:04:05.000") }</span>
-		<span class={ "badge " + topicBadgeClass(e.Topic) }>{ e.Topic }</span>
+		<span class={ "badge " + topicBadgeClass(e.Topic) } aria-label={ "Topic: " + e.Topic }>{ e.Topic }</span>
 		<span class="mono event-subject">{ e.Subject }</span>
 		<span class="event-payload mono">{ truncate(string(e.Payload), 160) }</span>
 	</div>

--- a/dashboard/web/templates/event_row_templ.go
+++ b/dashboard/web/templates/event_row_templ.go
@@ -44,7 +44,7 @@ func EventRow(e store.RawEvent) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\"><span class=\"mono ts\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\" role=\"listitem\"><span class=\"mono ts\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -79,46 +79,59 @@ func EventRow(e store.RawEvent) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" aria-label=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var6 string
-		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(e.Topic)
+		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs("Topic: " + e.Topic)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/event_row.templ`, Line: 8, Col: 63}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/event_row.templ`, Line: 8, Col: 86}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</span> <span class=\"mono event-subject\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var7 string
-		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(e.Subject)
+		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(e.Topic)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/event_row.templ`, Line: 9, Col: 46}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/event_row.templ`, Line: 8, Col: 98}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</span> <span class=\"event-payload mono\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</span> <span class=\"mono event-subject\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var8 string
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(truncate(string(e.Payload), 160))
+		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(e.Subject)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/event_row.templ`, Line: 10, Col: 69}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/event_row.templ`, Line: 9, Col: 46}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</span> <span class=\"event-payload mono\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var9 string
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(truncate(string(e.Payload), 160))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/event_row.templ`, Line: 10, Col: 69}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/dashboard/web/templates/grafana.templ
+++ b/dashboard/web/templates/grafana.templ
@@ -6,26 +6,26 @@ import (
 
 templ GrafanaPage(panels []grafana.Panel, grafanaBase, from, to string) {
 	@Layout("Grafana") {
-		<div class="time-range-bar">
-			<span class="label">Time range:</span>
-			<button onclick="setTimeRange('now-1h','now')">1h</button>
-			<button onclick="setTimeRange('now-6h','now')">6h</button>
-			<button onclick="setTimeRange('now-24h','now')">24h</button>
-			<button onclick="setTimeRange('now-7d','now')">7d</button>
+		<div class="time-range-bar" role="toolbar" aria-label="Time range">
+			<span class="label" id="time-range-label">Time range:</span>
+			<button type="button" aria-label="Last 1 hour" onclick="setTimeRange('now-1h','now')">1h</button>
+			<button type="button" aria-label="Last 6 hours" onclick="setTimeRange('now-6h','now')">6h</button>
+			<button type="button" aria-label="Last 24 hours" onclick="setTimeRange('now-24h','now')">24h</button>
+			<button type="button" aria-label="Last 7 days" onclick="setTimeRange('now-7d','now')">7d</button>
 		</div>
-		<div class="grafana-grid">
+		<section class="grafana-grid" aria-label="Grafana panels">
 			for _, p := range panels {
-				<div class="panel-container">
-					<div class="panel-title">{ p.Title }</div>
+				<article class="panel-container" aria-label={ p.Title }>
+					<h2 class="panel-title">{ p.Title }</h2>
 					<iframe
 						src={ templ.SafeURL(grafana.PanelURL(grafanaBase, p, from, to)) }
 						sandbox="allow-scripts allow-popups"
 						loading="lazy"
 						title={ p.Title }>
 					</iframe>
-				</div>
+				</article>
 			}
-		</div>
+		</section>
 		<script>
 		function setTimeRange(from, to) {
 			document.querySelectorAll('.grafana-grid iframe').forEach(function(el) {

--- a/dashboard/web/templates/grafana_templ.go
+++ b/dashboard/web/templates/grafana_templ.go
@@ -45,56 +45,69 @@ func GrafanaPage(panels []grafana.Panel, grafanaBase, from, to string) templ.Com
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"time-range-bar\"><span class=\"label\">Time range:</span> <button onclick=\"setTimeRange('now-1h','now')\">1h</button> <button onclick=\"setTimeRange('now-6h','now')\">6h</button> <button onclick=\"setTimeRange('now-24h','now')\">24h</button> <button onclick=\"setTimeRange('now-7d','now')\">7d</button></div><div class=\"grafana-grid\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"time-range-bar\" role=\"toolbar\" aria-label=\"Time range\"><span class=\"label\" id=\"time-range-label\">Time range:</span> <button type=\"button\" aria-label=\"Last 1 hour\" onclick=\"setTimeRange('now-1h','now')\">1h</button> <button type=\"button\" aria-label=\"Last 6 hours\" onclick=\"setTimeRange('now-6h','now')\">6h</button> <button type=\"button\" aria-label=\"Last 24 hours\" onclick=\"setTimeRange('now-24h','now')\">24h</button> <button type=\"button\" aria-label=\"Last 7 days\" onclick=\"setTimeRange('now-7d','now')\">7d</button></div><section class=\"grafana-grid\" aria-label=\"Grafana panels\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, p := range panels {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"panel-container\"><div class=\"panel-title\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<article class=\"panel-container\" aria-label=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var3 string
 				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(p.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/grafana.templ`, Line: 19, Col: 39}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/grafana.templ`, Line: 18, Col: 57}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div><iframe src=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\"><h2 class=\"panel-title\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var4 string
-				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(templ.SafeURL(grafana.PanelURL(grafanaBase, p, from, to)))
+				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(p.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/grafana.templ`, Line: 21, Col: 69}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/grafana.templ`, Line: 19, Col: 38}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" sandbox=\"allow-scripts allow-popups\" loading=\"lazy\" title=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</h2><iframe src=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var5 string
-				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(p.Title)
+				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(templ.SafeURL(grafana.PanelURL(grafanaBase, p, from, to)))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/grafana.templ`, Line: 24, Col: 21}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/grafana.templ`, Line: 21, Col: 69}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\"></iframe></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" sandbox=\"allow-scripts allow-popups\" loading=\"lazy\" title=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var6 string
+				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(p.Title)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/grafana.templ`, Line: 24, Col: 21}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\"></iframe></article>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div><script>\n\t\tfunction setTimeRange(from, to) {\n\t\t\tdocument.querySelectorAll('.grafana-grid iframe').forEach(function(el) {\n\t\t\t\tel.src = el.src\n\t\t\t\t\t.replace(/from=[^&]+/, 'from=' + from)\n\t\t\t\t\t.replace(/to=[^&]+/, 'to=' + to);\n\t\t\t});\n\t\t}\n\t\t</script>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</section><script>\n\t\tfunction setTimeRange(from, to) {\n\t\t\tdocument.querySelectorAll('.grafana-grid iframe').forEach(function(el) {\n\t\t\t\tel.src = el.src\n\t\t\t\t\t.replace(/from=[^&]+/, 'from=' + from)\n\t\t\t\t\t.replace(/to=[^&]+/, 'to=' + to);\n\t\t\t});\n\t\t}\n\t\t</script>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/dashboard/web/templates/host_card.templ
+++ b/dashboard/web/templates/host_card.templ
@@ -8,35 +8,39 @@ import (
 )
 
 templ HostCard(h store.HostView) {
-	<div class="host-card" id={ "host-" + h.Hostname }
+	<article class="host-card" id={ "host-" + h.Hostname }
+		aria-label={ "Host " + h.Hostname }
 		hx-get={ "/partials/host/" + h.Hostname }
 		hx-trigger="every 5s"
 		hx-swap="outerHTML">
-		<div class="host-header">
+		<header class="host-header">
 			<span class="hostname">{ h.Hostname }</span>
 			<span class="ts-ip mono">{ h.TailscaleIP }</span>
 			if h.Online {
-				<span class="badge green">online</span>
+				<span class="badge green" role="status" aria-label="online">online</span>
 			} else {
-				<span class="badge red">offline</span>
+				<span class="badge red" role="status" aria-label="offline">offline</span>
 			}
-		</div>
-		<div class="services-grid">
+		</header>
+		<div class="services-grid" role="list" aria-label="Services">
 			for _, svc := range h.Services {
 				@ServiceLink(svc)
 			}
 		</div>
-	</div>
+	</article>
 }
 
 templ ServiceLink(s catalog.ProbeResult) {
-	<a href={ templ.SafeURL(s.URL) } target="_blank" rel="noopener noreferrer" class={ "svc-link " + okClass(s.OK) }>
+	<a href={ templ.SafeURL(s.URL) } target="_blank" rel="noopener noreferrer"
+		class={ "svc-link " + okClass(s.OK) }
+		role="listitem"
+		aria-label={ serviceAriaLabel(s) }>
 		<span class="svc-name">{ s.Name }</span>
 		<span class="svc-port mono">:{ strconv.Itoa(s.Port) }</span>
 		if s.OK {
-			<span class="badge green">↑ { fmt.Sprintf("%dms", s.LatencyMs) }</span>
+			<span class="badge green" aria-hidden="true">↑ { fmt.Sprintf("%dms", s.LatencyMs) }</span>
 		} else {
-			<span class="badge red">↓</span>
+			<span class="badge red" aria-hidden="true">↓</span>
 		}
 	</a>
 }
@@ -46,4 +50,11 @@ func okClass(ok bool) string {
 		return "ok"
 	}
 	return "err"
+}
+
+func serviceAriaLabel(s catalog.ProbeResult) string {
+	if s.OK {
+		return fmt.Sprintf("%s on port %d, online, %dms", s.Name, s.Port, s.LatencyMs)
+	}
+	return fmt.Sprintf("%s on port %d, offline", s.Name, s.Port)
 }

--- a/dashboard/web/templates/host_card_templ.go
+++ b/dashboard/web/templates/host_card_templ.go
@@ -36,74 +36,87 @@ func HostCard(h store.HostView) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"host-card\" id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<article class=\"host-card\" id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs("host-" + h.Hostname)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 11, Col: 49}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 11, Col: 53}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\" hx-get=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\" aria-label=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var3 string
-		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs("/partials/host/" + h.Hostname)
+		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs("Host " + h.Hostname)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 12, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 12, Col: 35}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" hx-trigger=\"every 5s\" hx-swap=\"outerHTML\"><div class=\"host-header\"><span class=\"hostname\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" hx-get=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(h.Hostname)
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs("/partials/host/" + h.Hostname)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 16, Col: 38}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 13, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</span> <span class=\"ts-ip mono\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" hx-trigger=\"every 5s\" hx-swap=\"outerHTML\"><header class=\"host-header\"><span class=\"hostname\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var5 string
-		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(h.TailscaleIP)
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(h.Hostname)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 17, Col: 43}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 17, Col: 38}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</span> <span class=\"ts-ip mono\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var6 string
+		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(h.TailscaleIP)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 18, Col: 43}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if h.Online {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<span class=\"badge green\">online</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<span class=\"badge green\" role=\"status\" aria-label=\"online\">online</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<span class=\"badge red\">offline</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<span class=\"badge red\" role=\"status\" aria-label=\"offline\">offline</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div><div class=\"services-grid\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</header><div class=\"services-grid\" role=\"list\" aria-label=\"Services\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -113,7 +126,7 @@ func HostCard(h store.HostView) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div></article>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -137,97 +150,110 @@ func ServiceLink(s catalog.ProbeResult) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var6 == nil {
-			templ_7745c5c3_Var6 = templ.NopComponent
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		var templ_7745c5c3_Var7 = []any{"svc-link " + okClass(s.OK)}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var7...)
+		var templ_7745c5c3_Var8 = []any{"svc-link " + okClass(s.OK)}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var8...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<a href=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<a href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var8 templ.SafeURL
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(s.URL))
+		var templ_7745c5c3_Var9 templ.SafeURL
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(s.URL))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 33, Col: 31}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var9 string
-		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var7).String())
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 34, Col: 31}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\"><span class=\"svc-name\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var10 string
-		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(s.Name)
+		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var8).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 34, Col: 33}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</span> <span class=\"svc-port mono\">:")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\" role=\"listitem\" aria-label=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var11 string
-		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(s.Port))
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(serviceAriaLabel(s))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 35, Col: 53}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 37, Col: 34}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\"><span class=\"svc-name\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var12 string
+		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(s.Name)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 38, Col: 33}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</span> <span class=\"svc-port mono\">:")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var13 string
+		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(s.Port))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 39, Col: 53}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if s.OK {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<span class=\"badge green\">↑ ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<span class=\"badge green\" aria-hidden=\"true\">↑ ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var12 string
-			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%dms", s.LatencyMs))
+			var templ_7745c5c3_Var14 string
+			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%dms", s.LatencyMs))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 37, Col: 67}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/host_card.templ`, Line: 41, Col: 86}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<span class=\"badge red\">↓</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<span class=\"badge red\" aria-hidden=\"true\">↓</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</a>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</a>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -240,6 +266,13 @@ func okClass(ok bool) string {
 		return "ok"
 	}
 	return "err"
+}
+
+func serviceAriaLabel(s catalog.ProbeResult) string {
+	if s.OK {
+		return fmt.Sprintf("%s on port %d, online, %dms", s.Name, s.Port, s.LatencyMs)
+	}
+	return fmt.Sprintf("%s on port %d, offline", s.Name, s.Port)
 }
 
 var _ = templruntime.GeneratedTemplate

--- a/dashboard/web/templates/hosts.templ
+++ b/dashboard/web/templates/hosts.templ
@@ -4,10 +4,10 @@ import "github.com/HomericIntelligence/atlas/internal/store"
 
 templ HostsPage(devices []store.HostView) {
 	@Layout("Hosts") {
-		<div class="hosts-grid">
+		<section class="hosts-grid" aria-label="Hosts">
 			for _, d := range devices {
 				@HostCard(d)
 			}
-		</div>
+		</section>
 	}
 }

--- a/dashboard/web/templates/hosts_templ.go
+++ b/dashboard/web/templates/hosts_templ.go
@@ -43,7 +43,7 @@ func HostsPage(devices []store.HostView) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"hosts-grid\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<section class=\"hosts-grid\" aria-label=\"Hosts\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -53,7 +53,7 @@ func HostsPage(devices []store.HostView) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/dashboard/web/templates/layout.templ
+++ b/dashboard/web/templates/layout.templ
@@ -13,7 +13,8 @@ templ Layout(title string) {
 			<script src="/static/js/atlas.js" defer></script>
 		</head>
 		<body>
-			<nav>
+			<a class="sr-only" href="#main-content">Skip to main content</a>
+			<nav aria-label="Primary">
 				<span class="brand">Atlas</span>
 				<a href="/">Overview</a>
 				<a href="/hosts">Hosts</a>
@@ -22,9 +23,9 @@ templ Layout(title string) {
 				<a href="/nats">NATS</a>
 				<a href="/grafana">Grafana</a>
 				<a href="/mnemosyne">Mnemosyne</a>
-				<span class="conn-dot" title="SSE disconnected"></span>
+				<span class="conn-dot" role="status" aria-live="polite" aria-label="SSE disconnected" title="SSE disconnected"></span>
 			</nav>
-			<main>
+			<main id="main-content" tabindex="-1">
 				{ children... }
 			</main>
 		</body>

--- a/dashboard/web/templates/layout_templ.go
+++ b/dashboard/web/templates/layout_templ.go
@@ -42,7 +42,7 @@ func Layout(title string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, " — HomericIntelligence</title><link rel=\"stylesheet\" href=\"/static/css/atlas.css\"><script src=\"https://unpkg.com/htmx.org@1.9.12\" defer></script><script src=\"https://unpkg.com/htmx-ext-sse@2.2.2/sse.js\" defer></script><script src=\"/static/js/atlas.js\" defer></script></head><body><nav><span class=\"brand\">Atlas</span> <a href=\"/\">Overview</a> <a href=\"/hosts\">Hosts</a> <a href=\"/agents\">Agents</a> <a href=\"/tasks\">Tasks</a> <a href=\"/nats\">NATS</a> <a href=\"/grafana\">Grafana</a> <a href=\"/mnemosyne\">Mnemosyne</a> <span class=\"conn-dot\" title=\"SSE disconnected\"></span></nav><main>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, " — HomericIntelligence</title><link rel=\"stylesheet\" href=\"/static/css/atlas.css\"><script src=\"https://unpkg.com/htmx.org@1.9.12\" defer></script><script src=\"https://unpkg.com/htmx-ext-sse@2.2.2/sse.js\" defer></script><script src=\"/static/js/atlas.js\" defer></script></head><body><a class=\"sr-only\" href=\"#main-content\">Skip to main content</a><nav aria-label=\"Primary\"><span class=\"brand\">Atlas</span> <a href=\"/\">Overview</a> <a href=\"/hosts\">Hosts</a> <a href=\"/agents\">Agents</a> <a href=\"/tasks\">Tasks</a> <a href=\"/nats\">NATS</a> <a href=\"/grafana\">Grafana</a> <a href=\"/mnemosyne\">Mnemosyne</a> <span class=\"conn-dot\" role=\"status\" aria-live=\"polite\" aria-label=\"SSE disconnected\" title=\"SSE disconnected\"></span></nav><main id=\"main-content\" tabindex=\"-1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/dashboard/web/templates/mnemosyne.templ
+++ b/dashboard/web/templates/mnemosyne.templ
@@ -4,11 +4,14 @@ import "github.com/HomericIntelligence/atlas/internal/mnemosyne"
 
 templ MnemosynePage(skills []mnemosyne.Skill, query string) {
 	@Layout("Mnemosyne") {
-		<div class="filter-bar">
+		<div class="filter-bar" role="search" aria-label="Filter skills">
+			<label class="sr-only" for="mnemosyne-search">Search skills</label>
 			<input
+				id="mnemosyne-search"
 				type="search"
 				name="q"
 				value={ query }
+				aria-label="Search skills by name, description, or tags"
 				hx-get="/partials/mnemosyne/search"
 				hx-trigger="keyup changed delay:200ms"
 				hx-target="#skill-list"
@@ -16,9 +19,9 @@ templ MnemosynePage(skills []mnemosyne.Skill, query string) {
 				placeholder="Search skills (name, description, tags)..."
 			/>
 		</div>
-		<div id="skill-list">
+		<section id="skill-list" aria-label="Skills" aria-live="polite">
 			@SkillList(skills)
-		</div>
+		</section>
 	}
 }
 
@@ -28,13 +31,13 @@ templ SkillList(skills []mnemosyne.Skill) {
 	}
 	for _, s := range skills {
 		<details class="skill-card">
-			<summary class="skill-summary">
+			<summary class="skill-summary" aria-label={ "Skill: " + s.Name }>
 				<span class="skill-name">{ s.Name }</span>
 				if s.Version != "" {
-					<span class={ "badge gray" }>{ s.Version }</span>
+					<span class="badge gray" aria-label={ "Version " + s.Version }>{ s.Version }</span>
 				}
 				if s.Verification != "" {
-					<span class={ "badge " + verifyClass(s.Verification) }>{ s.Verification }</span>
+					<span class={ "badge " + verifyClass(s.Verification) } role="status" aria-label={ "Verification: " + s.Verification }>{ s.Verification }</span>
 				}
 				<span class="skill-desc">{ s.Description }</span>
 			</summary>

--- a/dashboard/web/templates/mnemosyne_templ.go
+++ b/dashboard/web/templates/mnemosyne_templ.go
@@ -43,20 +43,20 @@ func MnemosynePage(skills []mnemosyne.Skill, query string) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"filter-bar\"><input type=\"search\" name=\"q\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"filter-bar\" role=\"search\" aria-label=\"Filter skills\"><label class=\"sr-only\" for=\"mnemosyne-search\">Search skills</label> <input id=\"mnemosyne-search\" type=\"search\" name=\"q\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(query)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/mnemosyne.templ`, Line: 11, Col: 17}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/mnemosyne.templ`, Line: 13, Col: 17}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\" hx-get=\"/partials/mnemosyne/search\" hx-trigger=\"keyup changed delay:200ms\" hx-target=\"#skill-list\" hx-include=\"this\" placeholder=\"Search skills (name, description, tags)...\"></div><div id=\"skill-list\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\" aria-label=\"Search skills by name, description, or tags\" hx-get=\"/partials/mnemosyne/search\" hx-trigger=\"keyup changed delay:200ms\" hx-target=\"#skill-list\" hx-include=\"this\" placeholder=\"Search skills (name, description, tags)...\"></div><section id=\"skill-list\" aria-label=\"Skills\" aria-live=\"polite\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -64,7 +64,7 @@ func MnemosynePage(skills []mnemosyne.Skill, query string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -106,56 +106,64 @@ func SkillList(skills []mnemosyne.Skill) templ.Component {
 			}
 		}
 		for _, s := range skills {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<details class=\"skill-card\"><summary class=\"skill-summary\"><span class=\"skill-name\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<details class=\"skill-card\"><summary class=\"skill-summary\" aria-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var5 string
-			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(s.Name)
+			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs("Skill: " + s.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/mnemosyne.templ`, Line: 32, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/mnemosyne.templ`, Line: 34, Col: 65}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</span> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\"><span class=\"skill-name\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var6 string
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(s.Name)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/mnemosyne.templ`, Line: 35, Col: 37}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if s.Version != "" {
-				var templ_7745c5c3_Var6 = []any{"badge gray"}
-				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var6...)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<span class=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<span class=\"badge gray\" aria-label=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var7 string
-				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var6).String())
+				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs("Version " + s.Version)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/mnemosyne.templ`, Line: 1, Col: 0}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/mnemosyne.templ`, Line: 37, Col: 65}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var8 string
 				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(s.Version)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/mnemosyne.templ`, Line: 34, Col: 45}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/mnemosyne.templ`, Line: 37, Col: 79}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</span> ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</span> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -166,7 +174,7 @@ func SkillList(skills []mnemosyne.Skill) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<span class=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<span class=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -179,51 +187,64 @@ func SkillList(skills []mnemosyne.Skill) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\" role=\"status\" aria-label=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var11 string
-				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(s.Verification)
+				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs("Verification: " + s.Verification)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/mnemosyne.templ`, Line: 37, Col: 76}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/mnemosyne.templ`, Line: 40, Col: 120}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</span> ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var12 string
+				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(s.Verification)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/mnemosyne.templ`, Line: 40, Col: 139}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</span> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<span class=\"skill-desc\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var12 string
-			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(s.Description)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/mnemosyne.templ`, Line: 39, Col: 44}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</span></summary><div class=\"skill-body\" hx-get=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<span class=\"skill-desc\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var13 string
-			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(skillBodyPath(s.Name))
+			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(s.Description)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/mnemosyne.templ`, Line: 43, Col: 34}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/mnemosyne.templ`, Line: 42, Col: 44}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\" hx-trigger=\"toggle once\" hx-swap=\"innerHTML\"><span class=\"ts\">Loading...</span></div></details>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</span></summary><div class=\"skill-body\" hx-get=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var14 string
+			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(skillBodyPath(s.Name))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/mnemosyne.templ`, Line: 46, Col: 34}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" hx-trigger=\"toggle once\" hx-swap=\"innerHTML\"><span class=\"ts\">Loading...</span></div></details>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/dashboard/web/templates/nats.templ
+++ b/dashboard/web/templates/nats.templ
@@ -14,6 +14,7 @@ func itoa(n int) string               { return strconv.Itoa(n) }
 
 templ NATSPage(streams []store.NATSStreamInfo, conns []store.NATSConnInfo, natsDashURL, natsTopURL, natsMon string) {
 	@Layout("NATS") {
+		<h1 class="sr-only">NATS</h1>
 		<h2 class="section-title">JetStream Streams</h2>
 		<div
 			id="nats-streams"
@@ -56,13 +57,13 @@ templ NATSPage(streams []store.NATSStreamInfo, conns []store.NATSConnInfo, natsD
 }
 
 templ NATSStreamRows(streams []store.NATSStreamInfo) {
-	<table class="data-table">
+	<table class="data-table" aria-label="JetStream streams">
 		<thead>
 			<tr>
-				<th>Stream</th>
-				<th>Subjects</th>
-				<th>Messages</th>
-				<th>Consumers</th>
+				<th scope="col">Stream</th>
+				<th scope="col">Subjects</th>
+				<th scope="col">Messages</th>
+				<th scope="col">Consumers</th>
 			</tr>
 		</thead>
 		<tbody>
@@ -71,7 +72,7 @@ templ NATSStreamRows(streams []store.NATSStreamInfo) {
 			} else {
 				for _, s := range streams {
 					<tr>
-						<td class="mono">{ s.Name }</td>
+						<th scope="row" class="mono">{ s.Name }</th>
 						<td class="mono">{ joinSubjects(s.Subjects) }</td>
 						<td class="mono">{ formatUint(s.Messages) }</td>
 						<td class="mono">{ itoa(s.Consumers) }</td>
@@ -83,15 +84,15 @@ templ NATSStreamRows(streams []store.NATSStreamInfo) {
 }
 
 templ NATSConnRows(conns []store.NATSConnInfo) {
-	<table class="data-table">
+	<table class="data-table" aria-label="NATS connections">
 		<thead>
 			<tr>
-				<th>Name</th>
-				<th>IP</th>
-				<th>Subs</th>
-				<th>In</th>
-				<th>Out</th>
-				<th>Uptime</th>
+				<th scope="col">Name</th>
+				<th scope="col">IP</th>
+				<th scope="col">Subs</th>
+				<th scope="col">In</th>
+				<th scope="col">Out</th>
+				<th scope="col">Uptime</th>
 			</tr>
 		</thead>
 		<tbody>
@@ -100,7 +101,7 @@ templ NATSConnRows(conns []store.NATSConnInfo) {
 			} else {
 				for _, c := range conns {
 					<tr>
-						<td>{ c.Name }</td>
+						<th scope="row">{ c.Name }</th>
 						<td class="mono">{ c.IP }</td>
 						<td class="mono">{ itoa(c.Subscriptions) }</td>
 						<td class="mono">{ formatInt(c.InMsgs) }</td>

--- a/dashboard/web/templates/nats_templ.go
+++ b/dashboard/web/templates/nats_templ.go
@@ -53,7 +53,7 @@ func NATSPage(streams []store.NATSStreamInfo, conns []store.NATSConnInfo, natsDa
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<h2 class=\"section-title\">JetStream Streams</h2><div id=\"nats-streams\" hx-get=\"/partials/nats/streams\" hx-trigger=\"every 5s\" hx-swap=\"innerHTML\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<h1 class=\"sr-only\">NATS</h1><h2 class=\"section-title\">JetStream Streams</h2><div id=\"nats-streams\" hx-get=\"/partials/nats/streams\" hx-trigger=\"every 5s\" hx-swap=\"innerHTML\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -81,7 +81,7 @@ func NATSPage(streams []store.NATSStreamInfo, conns []store.NATSConnInfo, natsDa
 				var templ_7745c5c3_Var3 templ.SafeURL
 				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(natsDashURL))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 38, Col: 40}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 39, Col: 40}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 				if templ_7745c5c3_Err != nil {
@@ -104,7 +104,7 @@ func NATSPage(streams []store.NATSStreamInfo, conns []store.NATSConnInfo, natsDa
 			var templ_7745c5c3_Var4 templ.SafeURL
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(natsMon + "/varz"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 42, Col: 45}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 43, Col: 45}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -117,7 +117,7 @@ func NATSPage(streams []store.NATSStreamInfo, conns []store.NATSConnInfo, natsDa
 			var templ_7745c5c3_Var5 templ.SafeURL
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(natsMon + "/jsz"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 43, Col: 44}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 44, Col: 44}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -130,7 +130,7 @@ func NATSPage(streams []store.NATSStreamInfo, conns []store.NATSConnInfo, natsDa
 			var templ_7745c5c3_Var6 templ.SafeURL
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(natsMon + "/connz"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 44, Col: 46}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 45, Col: 46}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -148,7 +148,7 @@ func NATSPage(streams []store.NATSStreamInfo, conns []store.NATSConnInfo, natsDa
 				var templ_7745c5c3_Var7 string
 				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(templ.SafeURL(natsTopURL))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 49, Col: 35}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 50, Col: 35}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 				if templ_7745c5c3_Err != nil {
@@ -190,7 +190,7 @@ func NATSStreamRows(streams []store.NATSStreamInfo) templ.Component {
 			templ_7745c5c3_Var8 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<table class=\"data-table\"><thead><tr><th>Stream</th><th>Subjects</th><th>Messages</th><th>Consumers</th></tr></thead> <tbody>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<table class=\"data-table\" aria-label=\"JetStream streams\"><thead><tr><th scope=\"col\">Stream</th><th scope=\"col\">Subjects</th><th scope=\"col\">Messages</th><th scope=\"col\">Consumers</th></tr></thead> <tbody>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -201,27 +201,27 @@ func NATSStreamRows(streams []store.NATSStreamInfo) templ.Component {
 			}
 		} else {
 			for _, s := range streams {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<tr><td class=\"mono\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<tr><th scope=\"row\" class=\"mono\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var9 string
 				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(s.Name)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 74, Col: 31}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 75, Col: 43}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</td><td class=\"mono\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</th><td class=\"mono\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var10 string
 				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(joinSubjects(s.Subjects))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 75, Col: 49}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 76, Col: 49}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 				if templ_7745c5c3_Err != nil {
@@ -234,7 +234,7 @@ func NATSStreamRows(streams []store.NATSStreamInfo) templ.Component {
 				var templ_7745c5c3_Var11 string
 				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(formatUint(s.Messages))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 76, Col: 47}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 77, Col: 47}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
@@ -247,7 +247,7 @@ func NATSStreamRows(streams []store.NATSStreamInfo) templ.Component {
 				var templ_7745c5c3_Var12 string
 				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(itoa(s.Consumers))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 77, Col: 42}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 78, Col: 42}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
@@ -288,7 +288,7 @@ func NATSConnRows(conns []store.NATSConnInfo) templ.Component {
 			templ_7745c5c3_Var13 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<table class=\"data-table\"><thead><tr><th>Name</th><th>IP</th><th>Subs</th><th>In</th><th>Out</th><th>Uptime</th></tr></thead> <tbody>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<table class=\"data-table\" aria-label=\"NATS connections\"><thead><tr><th scope=\"col\">Name</th><th scope=\"col\">IP</th><th scope=\"col\">Subs</th><th scope=\"col\">In</th><th scope=\"col\">Out</th><th scope=\"col\">Uptime</th></tr></thead> <tbody>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -299,27 +299,27 @@ func NATSConnRows(conns []store.NATSConnInfo) templ.Component {
 			}
 		} else {
 			for _, c := range conns {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<tr><td>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<tr><th scope=\"row\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var14 string
 				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(c.Name)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 103, Col: 18}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 104, Col: 30}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</td><td class=\"mono\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</th><td class=\"mono\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var15 string
 				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(c.IP)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 104, Col: 29}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 105, Col: 29}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 				if templ_7745c5c3_Err != nil {
@@ -332,7 +332,7 @@ func NATSConnRows(conns []store.NATSConnInfo) templ.Component {
 				var templ_7745c5c3_Var16 string
 				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(itoa(c.Subscriptions))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 105, Col: 46}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 106, Col: 46}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 				if templ_7745c5c3_Err != nil {
@@ -345,7 +345,7 @@ func NATSConnRows(conns []store.NATSConnInfo) templ.Component {
 				var templ_7745c5c3_Var17 string
 				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(formatInt(c.InMsgs))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 106, Col: 44}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 107, Col: 44}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 				if templ_7745c5c3_Err != nil {
@@ -358,7 +358,7 @@ func NATSConnRows(conns []store.NATSConnInfo) templ.Component {
 				var templ_7745c5c3_Var18 string
 				templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(formatInt(c.OutMsgs))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 107, Col: 45}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 108, Col: 45}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 				if templ_7745c5c3_Err != nil {
@@ -371,7 +371,7 @@ func NATSConnRows(conns []store.NATSConnInfo) templ.Component {
 				var templ_7745c5c3_Var19 string
 				templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(c.Uptime)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 108, Col: 36}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/nats.templ`, Line: 109, Col: 36}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 				if templ_7745c5c3_Err != nil {

--- a/dashboard/web/templates/overview.templ
+++ b/dashboard/web/templates/overview.templ
@@ -4,24 +4,24 @@ import "strconv"
 
 templ Overview(agents, tasks, streams, hosts int) {
 	@Layout("Atlas") {
-		<div class="stat-grid">
-			<div class="stat-card">
-				<div class="label">Agents</div>
+		<section class="stat-grid" aria-label="Cluster summary">
+			<article class="stat-card" aria-labelledby="stat-agents-label">
+				<div class="label" id="stat-agents-label">Agents</div>
 				<div class="value" id="stat-agents">{ strconv.Itoa(agents) }</div>
-			</div>
-			<div class="stat-card">
-				<div class="label">Tasks</div>
+			</article>
+			<article class="stat-card" aria-labelledby="stat-tasks-label">
+				<div class="label" id="stat-tasks-label">Tasks</div>
 				<div class="value" id="stat-tasks">{ strconv.Itoa(tasks) }</div>
-			</div>
-			<div class="stat-card">
-				<div class="label">Streams</div>
+			</article>
+			<article class="stat-card" aria-labelledby="stat-streams-label">
+				<div class="label" id="stat-streams-label">Streams</div>
 				<div class="value" id="stat-streams">{ strconv.Itoa(streams) }</div>
-			</div>
-			<div class="stat-card">
-				<div class="label">Hosts</div>
+			</article>
+			<article class="stat-card" aria-labelledby="stat-hosts-label">
+				<div class="label" id="stat-hosts-label">Hosts</div>
 				<div class="value" id="stat-hosts">{ strconv.Itoa(hosts) }</div>
-			</div>
-		</div>
-		<p style="color:#8b949e">Live feed active after M2 (NATS JetStream subscribers).</p>
+			</article>
+		</section>
+		<p class="muted-note">Live feed active after M2 (NATS JetStream subscribers).</p>
 	}
 }

--- a/dashboard/web/templates/overview_templ.go
+++ b/dashboard/web/templates/overview_templ.go
@@ -43,7 +43,7 @@ func Overview(agents, tasks, streams, hosts int) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"stat-grid\"><div class=\"stat-card\"><div class=\"label\">Agents</div><div class=\"value\" id=\"stat-agents\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<section class=\"stat-grid\" aria-label=\"Cluster summary\"><article class=\"stat-card\" aria-labelledby=\"stat-agents-label\"><div class=\"label\" id=\"stat-agents-label\">Agents</div><div class=\"value\" id=\"stat-agents\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -56,7 +56,7 @@ func Overview(agents, tasks, streams, hosts int) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div><div class=\"stat-card\"><div class=\"label\">Tasks</div><div class=\"value\" id=\"stat-tasks\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></article><article class=\"stat-card\" aria-labelledby=\"stat-tasks-label\"><div class=\"label\" id=\"stat-tasks-label\">Tasks</div><div class=\"value\" id=\"stat-tasks\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -69,7 +69,7 @@ func Overview(agents, tasks, streams, hosts int) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div><div class=\"stat-card\"><div class=\"label\">Streams</div><div class=\"value\" id=\"stat-streams\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></article><article class=\"stat-card\" aria-labelledby=\"stat-streams-label\"><div class=\"label\" id=\"stat-streams-label\">Streams</div><div class=\"value\" id=\"stat-streams\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -82,7 +82,7 @@ func Overview(agents, tasks, streams, hosts int) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div><div class=\"stat-card\"><div class=\"label\">Hosts</div><div class=\"value\" id=\"stat-hosts\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></article><article class=\"stat-card\" aria-labelledby=\"stat-hosts-label\"><div class=\"label\" id=\"stat-hosts-label\">Hosts</div><div class=\"value\" id=\"stat-hosts\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -95,7 +95,7 @@ func Overview(agents, tasks, streams, hosts int) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></div></div><p style=\"color:#8b949e\">Live feed active after M2 (NATS JetStream subscribers).</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></article></section><p class=\"muted-note\">Live feed active after M2 (NATS JetStream subscribers).</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/dashboard/web/templates/task_detail.templ
+++ b/dashboard/web/templates/task_detail.templ
@@ -4,12 +4,12 @@ import "github.com/HomericIntelligence/atlas/internal/store"
 
 templ TaskDetailPage(t store.TaskRecord, history []store.RawEvent) {
 	@Layout("Task: " + t.Subject) {
-		<div class="detail-card">
-			<div class="detail-header">
-				<span class="hostname">{ t.Subject }</span>
+		<article class="detail-card" aria-labelledby="task-detail-subject">
+			<header class="detail-header">
+				<h1 class="hostname" id="task-detail-subject">{ t.Subject }</h1>
 				<span class="mono">{ t.ID }</span>
-				<span class={ "badge " + taskStatusClass(t.Status) }>{ t.Status }</span>
-			</div>
+				<span class={ "badge " + taskStatusClass(t.Status) } role="status" aria-label={ "Status: " + t.Status }>{ t.Status }</span>
+			</header>
 			<dl class="detail-meta">
 				<dt>Team</dt><dd class="mono">{ t.TeamID }</dd>
 				<dt>Created</dt><dd class="mono">{ t.CreatedAt.Format("2006-01-02 15:04:05") }</dd>
@@ -19,9 +19,11 @@ templ TaskDetailPage(t store.TaskRecord, history []store.RawEvent) {
 					<dd><a href={ templ.SafeURL("/agents/" + t.AssigneeID) } class="accent-link">{ t.AssigneeID }</a></dd>
 				}
 			</dl>
-		</div>
+		</article>
 		<h2 class="section-title">Live event tail</h2>
-		<div id="task-event-tail"
+		<section id="task-event-tail"
+			aria-label="Live event tail"
+			aria-live="polite"
 			hx-ext="sse"
 			sse-connect="/events?topics=task"
 			sse-swap="task"
@@ -29,7 +31,7 @@ templ TaskDetailPage(t store.TaskRecord, history []store.RawEvent) {
 			for _, e := range history {
 				@EventRow(e)
 			}
-		</div>
+		</section>
 	}
 }
 

--- a/dashboard/web/templates/task_detail_templ.go
+++ b/dashboard/web/templates/task_detail_templ.go
@@ -43,20 +43,20 @@ func TaskDetailPage(t store.TaskRecord, history []store.RawEvent) templ.Componen
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"detail-card\"><div class=\"detail-header\"><span class=\"hostname\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<article class=\"detail-card\" aria-labelledby=\"task-detail-subject\"><header class=\"detail-header\"><h1 class=\"hostname\" id=\"task-detail-subject\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(t.Subject)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/task_detail.templ`, Line: 9, Col: 38}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/task_detail.templ`, Line: 9, Col: 61}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</span> <span class=\"mono\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</h1><span class=\"mono\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -91,95 +91,108 @@ func TaskDetailPage(t store.TaskRecord, history []store.RawEvent) templ.Componen
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" role=\"status\" aria-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var7 string
-			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(t.Status)
+			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs("Status: " + t.Status)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/task_detail.templ`, Line: 11, Col: 67}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/task_detail.templ`, Line: 11, Col: 105}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</span></div><dl class=\"detail-meta\"><dt>Team</dt><dd class=\"mono\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var8 string
-			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(t.TeamID)
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(t.Status)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/task_detail.templ`, Line: 14, Col: 44}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/task_detail.templ`, Line: 11, Col: 118}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</dd><dt>Created</dt><dd class=\"mono\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</span></header><dl class=\"detail-meta\"><dt>Team</dt><dd class=\"mono\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var9 string
-			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(t.CreatedAt.Format("2006-01-02 15:04:05"))
+			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(t.TeamID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/task_detail.templ`, Line: 15, Col: 80}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/task_detail.templ`, Line: 14, Col: 44}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</dd><dt>Updated</dt><dd class=\"mono\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</dd><dt>Created</dt><dd class=\"mono\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var10 string
-			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(t.UpdatedAt.Format("2006-01-02 15:04:05"))
+			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(t.CreatedAt.Format("2006-01-02 15:04:05"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/task_detail.templ`, Line: 16, Col: 80}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/task_detail.templ`, Line: 15, Col: 80}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</dd>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</dd><dt>Updated</dt><dd class=\"mono\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var11 string
+			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(t.UpdatedAt.Format("2006-01-02 15:04:05"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/task_detail.templ`, Line: 16, Col: 80}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</dd>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if t.AssigneeID != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<dt>Assigned agent</dt><dd><a href=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<dt>Assigned agent</dt><dd><a href=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var11 templ.SafeURL
-				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/agents/" + t.AssigneeID))
+				var templ_7745c5c3_Var12 templ.SafeURL
+				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/agents/" + t.AssigneeID))
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/task_detail.templ`, Line: 19, Col: 59}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\" class=\"accent-link\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var12 string
-				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(t.AssigneeID)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/task_detail.templ`, Line: 19, Col: 96}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</a></dd>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\" class=\"accent-link\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var13 string
+				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(t.AssigneeID)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/task_detail.templ`, Line: 19, Col: 96}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</a></dd>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</dl></div><h2 class=\"section-title\">Live event tail</h2><div id=\"task-event-tail\" hx-ext=\"sse\" sse-connect=\"/events?topics=task\" sse-swap=\"task\" hx-swap=\"afterbegin\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</dl></article><h2 class=\"section-title\">Live event tail</h2><section id=\"task-event-tail\" aria-label=\"Live event tail\" aria-live=\"polite\" hx-ext=\"sse\" sse-connect=\"/events?topics=task\" sse-swap=\"task\" hx-swap=\"afterbegin\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -189,7 +202,7 @@ func TaskDetailPage(t store.TaskRecord, history []store.RawEvent) templ.Componen
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}


### PR DESCRIPTION
## Summary

Closes the §15 audit MAJORs on accessibility for the Atlas dashboard UI.

- **Keyboard navigation**: `tabindex=\"0\"` plus a delegated Enter/Space `keydown` handler on agent rows; site-wide `:focus-visible` ring (2px `var(--accent)`); skip-to-main-content link; `<main>` made programmatically focusable.
- **WCAG-AA contrast**: introduced `--text` (`#e6edf3`) and `--text-muted` (`#a8b1bd`) custom properties and replaced every literal foreground hex with the variable. Primary text now lands at **16.02:1** on `--bg` and muted at **8.73:1** — both clear AA's 4.5:1 with substantial AAA headroom.
- **Semantic HTML**: `<nav aria-label=\"Primary\">` on top nav; `<th scope=\"col\">` on every table header and `<th scope=\"row\">` on row-leading identifiers; `<article>` for stat cards, host cards, and Grafana panels (with `aria-labelledby`); `<section aria-live=\"polite\">` wrapping live event tails; `role=\"status\"` + textual `aria-label` on every status badge so screen readers announce state changes.

i18n (the third §15 finding) is **OUT of scope** for this PR — deferred to v0.3 pending a library-choice conversation. Templ regenerated; `*_templ.go` diff committed.

## Contrast verification

Computed via the WCAG 2.1 relative-luminance formula `(L1 + 0.05) / (L2 + 0.05)`. (The §15 audit's reported ratios for `#c9d1d9` and `#8b949e` on `#0d1117` were significantly off — the actual baselines were already passing AA but well below AAA. The new palette puts both at AAA and gives `--text-muted` real headroom on lighter surfaces like `--surface` and the badge tints.)

| Foreground | Background | Ratio | AA (4.5:1) | AAA (7:1) |
|---|---|---|---|---|
| `--text: #e6edf3` | `--bg: #0d1117` | 16.02:1 | pass | pass |
| `--text: #e6edf3` | `--surface: #161b22` | 14.64:1 | pass | pass |
| `--text-muted: #a8b1bd` | `--bg: #0d1117` | 8.73:1 | pass | pass |
| `--text-muted: #a8b1bd` | `--surface: #161b22` | 7.98:1 | pass | pass |
| `--accent: #58a6ff` (links) | `--bg: #0d1117` | 7.49:1 | pass | pass |
| `--success: #3fb950` (badge text) | `#1a3a22` (badge bg) | 4.94:1 | pass | fail |
| `--danger: #f85149` (badge text) | `#3a1a1a` (badge bg) | 4.67:1 | pass | fail |

Badges fall short of AAA but are non-essential indicators paired with text content and an `aria-label` (e.g. `<span role=\"status\" aria-label=\"online\">online</span>`), so the visual contrast augments — not substitutes for — the screen-reader path.

## Files touched

- `dashboard/web/static/css/atlas.css` — palette variables, `:focus-visible` ring, `.sr-only` helper, swap literal hexes for `var(--text-muted)`.
- `dashboard/web/static/js/atlas.js` — delegated Enter/Space handler for `tabindex=\"0\"` + `role=link|button` elements; richer `aria-label`/`title` on the SSE conn dot.
- `dashboard/web/templates/layout.templ` — `<nav aria-label=\"Primary\">`, skip link, `<main id=\"main-content\" tabindex=\"-1\">`.
- `dashboard/web/templates/overview.templ` — `<section>` + `<article>` for stat grid, `aria-labelledby`, drop inline `style=\"color:#8b949e\"`.
- `dashboard/web/templates/agents.templ` — `aria-label` on table; `<th scope=\"col\">`; labelled filter inputs.
- `dashboard/web/templates/agent_row.templ` — `tabindex=\"0\"`, `role=\"link\"`, `aria-label`; first cell now `<th scope=\"row\">`; status badge gets `role=\"status\"`.
- `dashboard/web/templates/hosts.templ` — `<section aria-label=\"Hosts\">`.
- `dashboard/web/templates/host_card.templ` — `<article>` + `<header>`, `role=\"list\"` for service grid, status badges with `aria-label`, descriptive service link `aria-label`.
- `dashboard/web/templates/nats.templ` — `<th scope=\"col\">` + `<th scope=\"row\">`, `aria-label` on tables, sr-only `<h1>`.
- `dashboard/web/templates/agent_detail.templ`, `task_detail.templ` — `<article>`/`<header>` semantics, real `<h1>`, status `role=\"status\"`, live tail as `<section aria-live=\"polite\">`.
- `dashboard/web/templates/event_row.templ` — `aria-label` on topic badges, `role=\"listitem\"`.
- `dashboard/web/templates/grafana.templ` — toolbar `role`, button `aria-label`s with explicit time-range names, `<section>`/`<article>` for the panel grid.
- `dashboard/web/templates/mnemosyne.templ` — labelled search input, `<section aria-live=\"polite\">` skill list, badge `aria-label`s.
- All corresponding `*_templ.go` regenerated.

## Test plan

- [x] `templ generate ./...` produces zero diff post-commit (re-run: `updates=0`)
- [x] `golangci-lint run` introduces zero new issues (2 pre-existing G101 warnings on the base branch in `internal/server/*_test.go` are unchanged by this PR)
- [x] `go test -race -count=1 ./...` — green
- [x] `go test -tags=integration -race -count=1 ./tests/integration/...` — green
- [ ] CI green
- [ ] Auto-merge fires once base lands
- [ ] Manual a11y smoke-test (reviewer): tab through `/`, `/hosts`, `/agents`; verify focus rings appear on keyboard nav but not on mouse click; verify VoiceOver/NVDA announces status badges; verify contrast in browser devtools

🤖 Generated with [Claude Code](https://claude.com/claude-code)