### PR TITLE
chore(ci): collapse security/gosec into lint job for uniform required-check policy

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -41,6 +41,35 @@ jobs:
             echo "No JSON files found — nothing to validate"
           fi
 
+      - name: Skip Go gosec if no Go module
+        id: gosec-detect
+        run: |
+          if [ ! -f dashboard/go.mod ]; then
+            echo "::notice::No dashboard/go.mod, skipping gosec"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Go (for gosec)
+        if: steps.gosec-detect.outputs.skip == 'false'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: dashboard/go.mod
+          cache-dependency-path: dashboard/go.sum
+
+      # gosec runs as a step inside the `lint` job per the org's policy of
+      # uniform required-check names. Failure of this step fails the `lint`
+      # required check; no separate `security/gosec` check name is exposed.
+      # golangci-lint also enables the `gosec` linter (see
+      # dashboard/.golangci.yml) for fast developer-loop feedback inside
+      # `Atlas dashboard (Go)`; this step is the authoritative gate.
+      - name: Run gosec
+        if: steps.gosec-detect.outputs.skip == 'false'
+        uses: securego/gosec@4a3bd8af174872c778439083ded7adbf3747e770  # v2.26.1
+        with:
+          args: ./dashboard/...
+
   markdownlint:
     name: markdownlint
     runs-on: ubuntu-24.04
@@ -214,42 +243,6 @@ jobs:
           scan-type: fs
           scan-ref: .
           exit-code: 0
-
-  security-gosec:
-    name: security/gosec
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-      - name: Skip if no Go module
-        id: detect
-        run: |
-          if [ ! -f dashboard/go.mod ]; then
-            echo "::notice::No dashboard/go.mod, skipping gosec"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Set up Go
-        if: steps.detect.outputs.skip == 'false'
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: dashboard/go.mod
-          cache-dependency-path: dashboard/go.sum
-      # Run gosec as a standalone, branch-protectable check separate from
-      # the in-process golangci-lint integration. golangci-lint already
-      # enables the `gosec` linter (see dashboard/.golangci.yml) and that
-      # remains the fast developer-loop check; this job exposes the same
-      # findings as their own required status so branch-protection rulesets
-      # can gate explicitly on `security/gosec` rather than burying it
-      # inside an aggregated lint check.
-      - name: Run gosec
-        if: steps.detect.outputs.skip == 'false'
-        uses: securego/gosec@4a3bd8af174872c778439083ded7adbf3747e770  # v2.26.1
-        with:
-          args: ./dashboard/...
 
   security-secrets-scan:
     name: security/secrets-scan


### PR DESCRIPTION
## Summary

- Collapses the standalone `security/gosec` required-check job (introduced in PR #458) into a step inside the existing `lint` required-check job. The org's branch-protection ruleset is kept uniform across repos — Atlas no longer adds a new required-check name; gosec gates via `lint`.
- gosec args, version pin (`v2.26.1`, SHA `4a3bd8af`), and skip-if-no-Go-module logic are preserved exactly. Failure of the gosec step fails `lint`.
- golangci-lint's `gosec` linter (in `dashboard/.golangci.yml`) remains the fast developer-loop check; this `_required.yml` step is the authoritative gate.

## Test plan

- [x] YAML parses and validates against the GitHub Actions schema
- [x] `security-gosec:` job is gone; `name: security/gosec` no longer appears
- [x] Three new steps in the `lint` job: gosec-detect, Set up Go (for gosec), Run gosec
- [x] gosec action SHA pin preserved (`securego/gosec@4a3bd8af...`)
- [ ] CI green
- [ ] Auto-merge fires once base lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)