### PR TITLE
fix(ci): bump golangci-lint-action v6→v9 + suppress gosec G101 on test sentinels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,10 @@ jobs:
           if-no-files-found: warn
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        # v9 is required for golangci-lint v2 binaries; the older v6 action
+        # rejects "v2.x" version strings outright. SHA-pinned to v9.2.0
+        # (current latest as of 2026-05-07) per the repo's pin convention.
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
         with:
           version: v2.12.2
           working-directory: dashboard

--- a/dashboard/go.mod
+++ b/dashboard/go.mod
@@ -2,7 +2,7 @@ module github.com/HomericIntelligence/atlas
 
 go 1.23.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	github.com/a-h/templ v0.3.1001

--- a/dashboard/internal/server/access_log_test.go
+++ b/dashboard/internal/server/access_log_test.go
@@ -21,7 +21,12 @@ import (
 // path with a recognisable secret query value and verifying the secret does
 // not appear anywhere in the captured log output.
 func TestAccessLog_DoesNotLeakQueryString(t *testing.T) {
-	const secret = "ssetoken-must-not-appear-in-logs-12345"
+	// Test fixture, not a real credential — the whole point of the test is
+	// that this string MUST NOT appear in the captured log output. gosec's
+	// G101 pattern-matches the variable name `secret`, but suppressing it
+	// here is correct: this is a sentinel value the test searches for to
+	// prove the access log strips query strings.
+	const secret = "ssetoken-must-not-appear-in-logs-12345" //#nosec G101 -- intentional sentinel for redaction-behaviour assertion
 
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))

--- a/dashboard/internal/server/auth_test.go
+++ b/dashboard/internal/server/auth_test.go
@@ -253,7 +253,12 @@ func captureSlog(t *testing.T) *bytes.Buffer {
 //   - the expected mode + reason discriminator are present
 //   - the offered credential/token does NOT appear anywhere in the line
 func TestAuth_LogsFailures(t *testing.T) {
-	const offeredSecret = "REDACTED-MUST-NEVER-APPEAR-IN-LOGS"
+	// Test fixture, not a real credential — the whole point of the test is
+	// that this value MUST NOT appear in any log line. gosec's G101 pattern
+	// matches the variable name; suppressing it here is correct: the test
+	// uses this string as a sentinel the assertion searches for to prove
+	// the auth-failure logger never echoes the offered credential.
+	const offeredSecret = "REDACTED-MUST-NEVER-APPEAR-IN-LOGS" //#nosec G101 -- intentional sentinel for redaction-behaviour assertion
 
 	cases := []struct {
 		name       string


### PR DESCRIPTION
## Summary

Two fixes to unblock the `Atlas dashboard (Go)` CI job, which has been red since PR #464:

### 1. Action wrapper bump (v6 → v9.2.0)

PR #464 pinned the golangci-lint **binary** to v2.12.2 but kept the action **wrapper** at `@v6`. The v6 action rejects `v2.x` version strings outright:

```
Failed to run: invalid version string 'v2.12.2', golangci-lint v2 is not supported by golangci-lint-action v6, you must update to golangci-lint-action v7.
```

Bumps the wrapper to **v9.2.0** (current latest; supports v2 binaries since v7). SHA-pinned per repo convention.

### 2. `#nosec G101` on two test-fixture sentinels

Once the wrapper bump made golangci-lint actually run, it surfaced two `gosec G101` (hardcoded credentials) findings on intentional test fixtures:

- `internal/server/access_log_test.go:24` — `const secret = "ssetoken-must-not-appear-in-logs-12345"`
- `internal/server/auth_test.go:256` — `const offeredSecret = "REDACTED-MUST-NEVER-APPEAR-IN-LOGS"`

Both are sentinel values the corresponding tests **search for** to assert they DON'T appear in log output (proving redaction behaviour). gosec G101 pattern-matches the variable names; suppressing with a one-line `//#nosec G101` comment + reason is correct here.

(Standalone `gosec` runs were not surfacing these because they don't lint test files by default. golangci-lint's gosec integration does, which is why the issue only appears now that the wrapper actually runs.)

## Test plan

- [x] YAML still parses + validates against the GitHub Actions schema
- [x] `golangci-lint run --timeout 5m ./...` returns `0 issues.` locally (against the same v2.12.2 binary CI uses)
- [x] Action SHA pin (`1e7e51e7`) resolves to v9.2.0
- [ ] CI green — specifically the `Atlas dashboard (Go)` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)