### PR TITLE
fix(go): bump toolchain go1.25.8→go1.25.9 to clear govulncheck CVEs

### DIFF
--- a/dashboard/go.mod
+++ b/dashboard/go.mod
@@ -2,7 +2,7 @@ module github.com/HomericIntelligence/atlas
 
 go 1.23.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	github.com/a-h/templ v0.3.1001


### PR DESCRIPTION
## Summary

- Bumps `dashboard/go.mod` `toolchain` directive from `go1.25.8` to `go1.25.9`
- Fixes four govulncheck stdlib CVEs that are blocking the non-required **Atlas dashboard (Go)** CI job on both `main` and PR #483

## Root cause

`govulncheck` reports four vulnerabilities all fixed in go1.25.9:
- **GO-2026-4947** — Unexpected work during chain building in `crypto/x509`
- **GO-2026-4946** — Inefficient policy validation in `crypto/x509`
- **GO-2026-4870** — Unauthenticated TLS 1.3 KeyUpdate DoS in `crypto/tls`
- **GO-2026-4865** — XSS in `html/template`

All four are stdlib vulns. The only fix needed is the toolchain pin; no third-party dependency changes required.

## Test plan
- [ ] **Atlas dashboard (Go)** CI job passes govulncheck step after this merges
- [ ] No changes to third-party deps or `go.sum`

🤖 Generated with [Claude Code](https://claude.com/claude-code)