### PR TITLE
fix(tests): add missing _make_handler helper — fixes unit-tests on main

### DIFF
--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -286,6 +286,26 @@ class TestCollectMetricNames(unittest.TestCase):
 # Test Handler (HTTP server)
 # ---------------------------------------------------------------------------
 
+
+def _make_handler(path: str) -> tuple:
+    """Create a Handler instance with a mock socket/server for unit-testing methods
+    that don't require a real HTTP connection (e.g. log_message).
+
+    Returns (handler, mock_server) so callers can inspect either object.
+    """
+    mock_server = MagicMock()
+    mock_server.server_address = ("127.0.0.1", 0)
+    # Instantiating BaseHTTPRequestHandler calls handle() which would try I/O;
+    # suppress that by patching the method.
+    with patch.object(exporter_mod.Handler, "handle"):
+        handler = exporter_mod.Handler.__new__(exporter_mod.Handler)
+        handler.request = MagicMock()
+        handler.client_address = ("127.0.0.1", 0)
+        handler.server = mock_server
+        handler.path = path
+    return handler, mock_server
+
+
 @contextlib.contextmanager
 def _live_server():
     """Spin up a real ThreadingHTTPServer on an ephemeral port; yield the port."""


### PR DESCRIPTION
## Summary

- Adds `_make_handler(path)` helper function to `tests/test_exporter.py`
- Fixes `NameError: name '_make_handler' is not defined` that causes `unit-tests` required check to fail on `main` and on any PR that includes the two affected tests

## Root cause

Two tests were added to `tests/test_exporter.py` (`test_log_message_emits_debug_record` and `test_log_message_silent_at_info_level`) that call `_make_handler("/metrics")`, but the helper was never defined. This causes `NameError` at runtime and fails the `unit-tests` required check.

The helper creates a `Handler` instance with a mock socket/server so `log_message` can be unit-tested without spinning up a live TCP server.

## Test plan
- [ ] `unit-tests` required check passes after merge
- [ ] No other tests broken (174 tests currently pass; these 2 were the only failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)