### PR TITLE
chore(deps): bump go toolchain 1.25.9 → 1.25.10 (GO-2026-4971, GO-2026-4918)

### DIFF
--- a/dashboard/go.mod
+++ b/dashboard/go.mod
@@ -2,7 +2,7 @@ module github.com/HomericIntelligence/atlas
 
 go 1.23.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/a-h/templ v0.3.1001


### PR DESCRIPTION
## Summary

Follow-on to #483. Two stdlib CVEs were reported by `govulncheck` after the go1.25.9 pin:

| ID | Package | Fixed in |
|----|---------|----------|
| GO-2026-4971 | `net` | go1.25.10 |
| GO-2026-4918 | `net/http` | go1.25.10 |

Call sites traced via `internal/nats/subscriber.go`, `internal/server/server.go`, and `internal/tailscale/api.go`.

## Changes

- `dashboard/go.mod`: `toolchain go1.25.9` → `toolchain go1.25.10`

No workflow files needed updating — both `ci.yml` and `_required.yml` use `go-version-file: dashboard/go.mod` rather than hardcoding a version string.

## Test plan

- [ ] CI `atlas-dashboard (Go)` job passes (`go build`, `go vet`, `go test`, `golangci-lint`)
- [ ] `govulncheck` step in CI reports no vulnerabilities for GO-2026-4971 / GO-2026-4918
- [ ] `_required.yml` `atlas/dashboard` job passes

`go build` was **not** run locally — local Go is v1.15 (too old for this module); CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)