### PR TITLE
fix(justfile): dedupe variable and recipe definitions to fix justfile-check

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,10 +11,6 @@ GRAFANA_URL  := "http://localhost:" + GRAFANA_PORT
 GRAFANA_ADMIN_PASSWORD := env_var_or_default("GRAFANA_ADMIN_PASSWORD", "admin")
 GRAFANA_AUTH := "admin:" + GRAFANA_ADMIN_PASSWORD
 
-GRAFANA_PORT             := "3000"
-GRAFANA_URL              := "http://localhost:" + GRAFANA_PORT
-GRAFANA_ADMIN_PASSWORD   := env_var_or_default("GF_ADMIN_PASSWORD", "")
-
 # === Default ===
 
 default:
@@ -25,13 +21,6 @@ default:
 # One-command bootstrap: prereqs, pixi install, .env generation
 setup:
     @./scripts/setup.sh
-
-# Generate secrets/htpasswd from LOKI_AUTH_USER and LOKI_AUTH_PASSWORD in .env
-gen-htpasswd:
-    @scripts/gen-htpasswd.sh
-
-# Start all observability services
-start: gen-htpasswd
 
 # Generate configs/nginx/htpasswd using bcrypt; set LOKI_PASSWORD env var or be prompted
 gen-htpasswd:
@@ -45,7 +34,7 @@ gen-htpasswd:
     echo "configs/nginx/htpasswd written (bcrypt). Keep this file out of version control."
 
 # Start all observability services
-start:
+start: gen-htpasswd
     #!/usr/bin/env bash
     set -euo pipefail
     if [ ! -f configs/nginx/htpasswd ]; then
@@ -93,10 +82,6 @@ logs SERVICE:
 
 # === Prometheus ===
 
-# Hot-reload Prometheus configuration via SIGHUP (--web.enable-lifecycle is disabled)
-reload-prometheus:
-    {{compose_cmd}} kill -s HUP prometheus && echo "Prometheus config reloaded."
-
 # Restart Prometheus to pick up configuration changes
 reload-prometheus:
     {{compose_cmd}} restart prometheus
@@ -141,7 +126,5 @@ test-jetstream:
 # Import all JSON dashboards from dashboards/ into Grafana via API
 import-dashboards:
     @test -n "${GF_ADMIN_PASSWORD:-}" || { echo "ERROR: GF_ADMIN_PASSWORD is not set. Source .env first."; exit 1; }
-
-    GRAFANA_PORT={{GRAFANA_PORT}} GRAFANA_ADMIN_PASSWORD="${GF_ADMIN_PASSWORD}" ./scripts/import-dashboards.sh
 
     GRAFANA_PORT={{GRAFANA_PORT}} GRAFANA_ADMIN_PASSWORD={{GRAFANA_ADMIN_PASSWORD}} ./scripts/import-dashboards.sh


### PR DESCRIPTION
## Summary

Removes five duplicate definitions left over from a merge cascade that caused `just --evaluate` to fail entirely (justfile-check CI always red):

- **`GRAFANA_PORT`**: kept the first definition (line 9) which also initialises `GRAFANA_AUTH`; dropped the second block at old lines 14-16 which used a different env-var name (`GF_ADMIN_PASSWORD`) and had no `GRAFANA_AUTH`.
- **`gen-htpasswd`**: kept the full bash implementation (bcrypt via `docker run httpd:2.4-alpine`); dropped the earlier `@scripts/gen-htpasswd.sh` stub.
- **`start`**: kept the full bash body with the htpasswd existence check; restored the `gen-htpasswd` dependency (present only on the now-deleted stub); dropped the dependency-only stub.
- **`reload-prometheus`**: kept the `{{compose_cmd}} restart prometheus` variant; dropped the SIGHUP variant whose own comment documented it as disabled (`--web.enable-lifecycle is disabled`).
- **`import-dashboards`**: kept the justfile-native `{{GRAFANA_ADMIN_PASSWORD}}` form (evaluated at parse time, consistent with the variable block above); dropped the duplicate `"${GF_ADMIN_PASSWORD}"` shell-form line.

## Test plan

- [x] `just --evaluate` passes locally (all variables resolve, no duplicate errors)
- [x] `just --list` passes locally (all recipes listed exactly once)
- [ ] CI `justfile-check` goes green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)