### PR TITLE
fix(docs): resolve MD025 and MD024 markdownlint errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,7 @@ just status
 just test-scrape
 ```
 
-# AGENTS.md — Multi-Agent Coordination for ProjectArgus
+## AGENTS.md — Multi-Agent Coordination for ProjectArgus
 
 This file describes how AI agents and automated tooling should interact with this
 repository. It follows the conventions established across HomericIntelligence projects.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Exporter self-metrics use the `homeric_exporter_` prefix:
 
 All metrics include `# HELP` and `# TYPE` lines.
 
-## Environment Variables
+## Exporter Environment Variables
 
 Copy `.env.example` to `.env` at the repository root and set values before running `just start`.
 


### PR DESCRIPTION
## Summary
- **AGENTS.md:147** — MD025 (multiple top-level headings): downgraded duplicate `# AGENTS.md` H1 to `##`
- **CLAUDE.md:93** — MD024 (duplicate heading text): renamed duplicate `## Environment Variables` to `## Exporter Environment Variables`

## Why
These two markdownlint errors are failing CI on all open PRs that inherit from main. Fixing on main unblocks ~7-8 PRs at once.

## Test plan
- [ ] markdownlint CI check passes on this PR
- [ ] After merge, open PRs rebased onto main pass markdownlint

🤖 Generated with [Claude Code](https://claude.com/claude-code)