### PR TITLE
fix(docs): fix MD031 and MD013 markdownlint errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ on first run. It is idempotent — safe to re-run.
 
 Then access Grafana at <http://localhost:3000> (credentials: admin / the password set in `.env`).
 
+```bash
 cp .env.example .env   # copy and edit for your environment
 just start
 ```
@@ -48,7 +49,8 @@ Then access Grafana at http://localhost:3001 (default credentials: admin / admin
 
 ## Environment Configuration
 
-All environment-specific values live in a `.env` file that is **not** committed to version control. A fully-documented template is provided:
+All environment-specific values live in a `.env` file that is **not** committed to version
+control. A fully-documented template is provided:
 
 ```bash
 cp .env.example .env


### PR DESCRIPTION
## Summary
- **README.md:45** — MD031 (blanks around fences): Lines 43-44 were bare shell commands with no opening code fence. Added ` ```bash ` before them.
- **README.md:51** — MD013 (line-length): Line exceeded 120 chars. Wrapped the sentence.

## Why
These errors were introduced when PR #213 merged and added the .env workflow section to README.md. They're causing markdownlint CI failures on all PRs rebased onto main.

## Test plan
- [ ] markdownlint CI passes on this PR
- [ ] After merge, open PRs rebased onto updated main pass markdownlint

🤖 Generated with [Claude Code](https://claude.com/claude-code)