### PR TITLE
fix(docs): wrap bare URL to satisfy MD034 markdownlint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cp .env.example .env   # copy and edit for your environment
 just start
 ```
 
-Then access Grafana at http://localhost:3001 (default credentials: admin / admin).
+Then access Grafana at <http://localhost:3001> (default credentials: admin / admin).
 
 ## Environment Configuration
 


### PR DESCRIPTION
## Summary
- **README.md:48** — MD034 (bare URL): `http://localhost:3001` was an unformatted bare URL. Wrapped in angle brackets: `<http://localhost:3001>`.

## Why
This error was introduced in PR #213 (merged today). PR #490 fixed MD031 and MD013 but missed this MD034 bare URL on line 48. Fixing to keep markdownlint clean on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)