### PR TITLE
fix(ci): Dependabot Updates failing — no manifests at declared paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     commit-message:
       prefix: "chore(deps)"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Aligns .github/dependabot.yml entries with the package manifests that actually exist in the repo. Fixes 'No files found in /' error from run 25617637543.

## Root cause
The `pip` ecosystem at `/` had no `requirements.txt`, `setup.py`, or `setup.cfg`. The existing `pyproject.toml` only configures pytest (no `[project]` table with dependencies), so Dependabot rejects it.

## Change
- Replace the broken `pip` entry with a `github-actions` entry (repo has `.github/workflows/*.yml`)
- Keep the `docker` entry for `/exporter` (real `Dockerfile` present)