### PR TITLE
chore: easy-issue sweep — refs #149 #146

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,18 @@
 {
   "enabledPlugins": {
     "hephaestus@ProjectHephaestus": true
-  }
+  },
+  "permissions": {
+    "deny": [
+      "Bash(rm -rf /)",
+      "Bash(rm -rf /*)",
+      "Bash(rm -rf ~)",
+      "Bash(rm -rf ~/*)",
+      "Bash(git push --force *)",
+      "Bash(git push -f *)",
+      "Bash(git reset --hard *)",
+      "Bash(git clean -fdx *)"
+    ]
+  },
+  "env": {}
 }

--- a/.github/workflows/publish-exporter-image.yml
+++ b/.github/workflows/publish-exporter-image.yml
@@ -1,0 +1,58 @@
+name: Publish Exporter Image
+
+# Builds and pushes the argus-exporter container to GHCR so deployments can
+# reference a versioned image instead of building from local source on every
+# `docker compose up`. Refs #149.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "exporter/**"
+      - ".github/workflows/publish-exporter-image.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build & push argus-exporter to GHCR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU (multi-arch)
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # GHCR rejects uppercase owner segments, so lower-case the repo owner.
+      - name: Compute image name
+        id: image
+        run: echo "name=ghcr.io/$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')/argus-exporter" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push multi-arch image
+        uses: docker/build-push-action@v7
+        with:
+          context: exporter
+          file: exporter/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ steps.image.outputs.name }}:latest
+            ${{ steps.image.outputs.name }}:sha-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true


### PR DESCRIPTION
## Summary

Two minor audit findings addressed in a single sweep.

- **Refs #149** — adds `.github/workflows/publish-exporter-image.yml` to build & push `ghcr.io/homericintelligence/argus-exporter` (multi-arch, with provenance + SBOM) on every push to `main` that touches `exporter/`. Deployments can now pin a versioned image instead of building from local source on every `docker compose up`.
- **Refs #146** — adds minimal `permissions.deny` guardrails to `.claude/settings.json` covering destructive `rm -rf`, force-push, hard-reset, and `clean -fdx` patterns. Appropriate for a config-only repo.

## Test plan

- [ ] CI passes (lint, security, required checks)
- [ ] After merge: confirm `Publish Exporter Image` workflow runs and pushes `ghcr.io/homericintelligence/argus-exporter:latest`
- [ ] `.claude/settings.json` is valid JSON (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)