### PR TITLE
chore: refactor || true workarounds; add forbid-suppressions guard

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -11,6 +11,57 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  forbid-suppressions:
+    name: forbid-suppressions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: "Reject silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git ls-files \
+            -- \
+            '*.sh' '*.bash' '*.yml' '*.yaml' '*.hcl' \
+            'Dockerfile*' '**/Dockerfile*' \
+            'justfile' '**/justfile' 'Justfile' '**/Justfile')
+          declare -a scan_files=()
+          for f in "${files[@]}"; do
+            case "$f" in
+              # Exempt this workflow file (heredoc would otherwise self-match)
+              .github/workflows/_required.yml) continue ;;
+              # Exempt any runbook that documents the rule (if present)
+              docs/runbooks/no-silent-failures.md) continue ;;
+            esac
+            scan_files+=("$f")
+          done
+          if [ "${#scan_files[@]}" -eq 0 ]; then
+            echo "No files to scan"
+            exit 0
+          fi
+          if grep -nE '\|\|[[:space:]]*true([[:space:]]*$|[[:space:]]+#)' "${scan_files[@]}"; then
+            echo ""
+            echo '::error::Found silent-failure workarounds above. Refactor per HomericIntelligence/Odysseus#280.'
+            exit 1
+          fi
+          echo 'OK: no silent-failure workarounds found'
+
+      - name: "Reject continue-on-error workflow opt-out"
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git ls-files -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No workflow files"
+            exit 0
+          fi
+          if grep -nE '^[[:space:]]*continue-on-error:[[:space:]]*true[[:space:]]*$' "${files[@]}"; then
+            echo ""
+            echo '::error::Found "continue-on-error: true" above. Fix the root cause per HomericIntelligence/Odysseus#280.'
+            exit 1
+          fi
+          echo 'OK: no "continue-on-error: true" found'
+
   lint:
     name: lint
     runs-on: ubuntu-24.04
@@ -174,9 +225,14 @@ jobs:
           GF_ADMIN_PASSWORD: ci-validation-only
         run: |
           pip install yamllint
-          # Validate Prometheus alert rules via promtool if rules/ directory exists
-          if command -v promtool &>/dev/null; then
-            find . -path './.git' -prune -o -name "*.yml" -print | xargs promtool check rules 2>/dev/null || true
+          # Validate Prometheus alert rules via promtool if rules/ directory exists.
+          # Only scan files under rules/ — running `promtool check rules` against
+          # non-rule YAML (workflows, compose) reports false errors.
+          if command -v promtool &>/dev/null && [ -d rules ]; then
+            mapfile -t rule_files < <(find rules -type f \( -name "*.yml" -o -name "*.yaml" \))
+            if [ "${#rule_files[@]}" -gt 0 ]; then
+              promtool check rules "${rule_files[@]}"
+            fi
           fi
           # Validate docker-compose YAML
           if [ -f docker-compose.yml ]; then
@@ -287,6 +343,11 @@ jobs:
           gitleaks version
 
       - name: Run Gitleaks
+        # `--exit-code 0` already makes gitleaks always succeed when it
+        # finds leaks; the SARIF report is uploaded for review instead.
+        # No `continue-on-error` opt-out is needed — the step is wired
+        # so true command failures (e.g. gitleaks crash, missing binary)
+        # still fail the job, per HomericIntelligence/Odysseus#280.
         run: |
           if [ -f .gitleaks.toml ]; then
             gitleaks detect --source . --config .gitleaks.toml \
@@ -295,7 +356,6 @@ jobs:
             gitleaks detect --source . \
               --report-format sarif --report-path gitleaks.sarif --exit-code 0
           fi
-        continue-on-error: true
 
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,20 @@ jobs:
 
       - name: Security scan exporter Python
         run: |
-          pixi run bandit -ll -f json exporter/exporter.py > /tmp/bandit.json || true
+          # bandit exits non-zero when it finds issues; we want to capture
+          # the JSON report unconditionally and let the Python check below
+          # decide pass/fail based on severity. Use an explicit exit-code
+          # check instead of suppressing all failures with `|| true`.
+          set +e
+          pixi run bandit -ll -f json exporter/exporter.py > /tmp/bandit.json
+          bandit_rc=$?
+          set -e
+          # bandit exit codes: 0=clean, 1=issues found. Anything else is
+          # an unexpected error (e.g. parsing failure) and should fail.
+          if [ "$bandit_rc" -ne 0 ] && [ "$bandit_rc" -ne 1 ]; then
+              echo "::error::bandit exited with unexpected code $bandit_rc"
+              exit "$bandit_rc"
+          fi
           python3 << 'SCAN_CHECK'
           import json, sys
           with open('/tmp/bandit.json') as f:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,26 @@ repos:
         language: system
         files: ^exporter/.*\.py$
         pass_filenames: true
+
+      - id: forbid-or-true
+        name: "forbid silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
+        description: >
+          Rejects the `or-true` idiom (and its whitespace variants) in shell,
+          YAML, Dockerfile, justfile, and HCL sources. Refactor to an explicit
+          `if`-guard, a real conditional, or a documented `set +e`/`set -e`
+          bracket. See HomericIntelligence/Odysseus#280.
+        language: pygrep
+        entry: '\|\|\s*true(\s*$|\s+#)'
+        files: \.(sh|bash|yml|yaml|hcl)$|(^|/)Dockerfile[^/]*$|(^|/)[Jj]ustfile$
+        types: [text]
+        pass_filenames: true
+
+      - id: forbid-continue-on-error
+        name: "forbid continue-on-error workflow opt-out"
+        description: >
+          GitHub Actions `continue-on-error true` (truthy form) hides real CI
+          failures. Fix the underlying job/step instead.
+        language: pygrep
+        entry: '^\s*continue-on-error:\s*true\s*$'
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: true

--- a/scripts/dev-watch.sh
+++ b/scripts/dev-watch.sh
@@ -39,7 +39,13 @@ cleanup() {
   trap - INT TERM EXIT
   echo
   echo "dev-watch: stopping watchers..."
-  kill 0 2>/dev/null || true
+  # `kill 0` signals the whole process group; the watchers may already
+  # be gone (e.g. they exited first and triggered the trap), so a
+  # non-zero exit from kill is expected and benign. Log unexpected
+  # errors to stderr without aborting the cleanup.
+  if ! kill 0 2>/dev/null; then
+    echo "dev-watch: kill 0 reported no remaining processes (idempotent)" >&2
+  fi
 }
 trap cleanup INT TERM EXIT
 


### PR DESCRIPTION
## Summary

Ports the silent-failure regression guard from [HomericIntelligence/Odysseus#280](https://github.com/HomericIntelligence/Odysseus/pull/280) and refactors all 4 silent-failure suppressions in this repo per the Bucket A-E classification documented in that PR's `docs/runbooks/no-silent-failures.md`.

The runbook is summarized as: every `|| true` either (A) masks a real failure, (B) is best-effort cleanup, (C) is a `((counter++))` workaround under `set -e`, (D) is pipeline-tail suppression, or (E) is `continue-on-error: true` in a workflow. None are legitimate; every one gets a structural fix.

## Refactors

| File:Line | Bucket | Before -> After |
|---|---|---|
| `scripts/dev-watch.sh:42` | B | `kill 0 2>/dev/null \|\| true` -> `if ! kill 0 2>/dev/null; then echo "..." >&2; fi` (explicit log of unexpected kill failure during cleanup; remains idempotent for the common case where children already exited) |
| `.github/workflows/_required.yml:179` | A | `find . -name "*.yml" \| xargs promtool check rules ... \|\| true` -> scoped to `rules/*.yml` only via `mapfile`+`find rules`. Root cause: promtool was being fed non-rule YAML (workflows, compose), so failures were noise; the `\|\| true` was hiding real rule errors too. |
| `.github/workflows/ci.yml:70` | A | `pixi run bandit -ll ... \|\| true` -> `set +e`/`set -e` bracket capturing `bandit_rc`. Accepts 0 (clean) and 1 (findings, handled by downstream Python check). Fails on any other code (parser error, missing module). |
| `.github/workflows/_required.yml:298` | E | `continue-on-error: true` removed from gitleaks step. The step already uses `--exit-code 0`, so the opt-out was masking only real failures (binary missing, gitleaks crash). |

## Lint guard

- Added two pygrep hooks (`forbid-or-true`, `forbid-continue-on-error`) to `.pre-commit-config.yaml`.
- Added `forbid-suppressions` job (two steps: shell/YAML/Dockerfile/justfile/HCL `\|\| true` scan + workflow `continue-on-error: true` scan) to `.github/workflows/_required.yml`.

## Verification

- `pre-commit run forbid-or-true --all-files`: **Passed**.
- `pre-commit run forbid-continue-on-error --all-files`: **Passed**.
- `bash -n scripts/dev-watch.sh`: OK.
- `python3 -c "import yaml; yaml.safe_load(open('...'))"` for `.github/workflows/_required.yml`, `.github/workflows/ci.yml`, `.pre-commit-config.yaml`: all OK.
- `pixi run test`: **317 passed, 9 subtests passed** (coverage 99.40%).
- Strict-regex grep for remaining occurrences: **0 matches**.

## Out of scope / not fixed

- Other `\|\| true` instances exist in pipeline-tail contexts (e.g., `JSON_FILES=$(find ... \| grep ... \|\| true)` in `_required.yml:24`, similar in `:325`, `:351`, plus `scripts/generate-changelog.sh`, `scripts/bump-version.sh`, `dashboard/scripts/atlas-review-aggregate.sh`, `justfile:5-6`). These end in `\|\| true)` (followed by `)`, not whitespace+EOL/#) so they do **not** match the regex in the runbook or the lint guard. They're Bucket D and should be tightened in a follow-up — flagging here per the brief's instruction.
- Pre-existing yamllint warnings (`document-start`, line-length on lines unrelated to this change) in `_required.yml` and several other YAML files — not introduced by this PR; out of scope.
- `bandit` is not installed in my local pre-commit env, so the existing `bandit` local hook fails locally with "Executable not found"; this is environmental and unaffected by my changes.

Tool generated with [Claude Code](https://claude.com/claude-code)