### PR TITLE
chore(docs): fix MD060 table-column-style for markdownlint-cli2 v23

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ push data or commands back to any external service.
 **Permitted write targets** (within this repo only):
 
 | Path | Description |
-|------|-------------|
+| ------ | ------------- |
 | `configs/` | Prometheus, Loki, Promtail, Grafana config files |
 | `dashboards/` | Grafana dashboard JSON |
 | `rules/` | Prometheus alerting rules |
@@ -33,7 +33,7 @@ Agents **MUST NOT** modify `docker-compose.yml` network topology, external servi
 Three agent classes operate on this repo:
 
 | Class | Spawned By | Write Access | Notes |
-|-------|-----------|--------------|-------|
+| ------- | ----------- | -------------- | ------- |
 | **Interactive** | Human via Claude Code CLI/IDE | Yes (user-confirmed) | Full permission scope |
 | **Myrmidon swarm worker** | `hephaestus:myrmidon-swarm` | Worktree only | `isolation: "worktree"` required |
 | **Agamemnon-orchestrated** | Remote trigger from Agamemnon | Read-only | Scrape validation and metric checks only |
@@ -46,7 +46,7 @@ ProjectArgus delegates orchestration to the **Hephaestus plugin**. There is no `
 directory in this repo. Use these skills instead:
 
 | Skill | Trigger Condition | Description |
-|-------|------------------|-------------|
+| ------- | ------------------ | ------------- |
 | `hephaestus:advise` | Before unfamiliar work or unknown errors | Searches team knowledge base for prior learnings |
 | `hephaestus:learn` | After experiments or novel discoveries | Saves session learnings as a new skill |
 | `hephaestus:myrmidon-swarm` | Multi-step parallel file changes | Hierarchical delegation (Opus → Sonnet → Haiku) |
@@ -62,7 +62,7 @@ directory in this repo. Use these skills instead:
 ## Model-Tier Assignments
 
 | Task Class | Model Tier | Rationale |
-|-----------|-----------|-----------|
+| ----------- | ----------- | ----------- |
 | Architecture decisions, cross-service impact analysis | L0/L1 — Opus | Strategic reasoning across many constraints |
 | Config authoring, dashboard JSON, alert rules, code review | L2/L3 — Sonnet | Domain specialist; cost-effective |
 | Boilerplate YAML edits, single-file formatting, lint fixes | L4/L5 — Haiku | Focused, fast, cheap |
@@ -102,7 +102,7 @@ writes files without user confirmation has violated this protocol.
 ## Wave Execution Constraints
 
 | Constraint | Value |
-|-----------|-------|
+| ----------- | ------- |
 | Max agents per wave | 5 |
 | Shared file writes within a wave | Not permitted |
 | Each agent write scope | Its own worktree only |
@@ -160,7 +160,7 @@ working in this repository should maintain this invariant.
 Agents are permitted to make the following changes autonomously:
 
 | Area | Permitted |
-|------|-----------|
+| ------ | ----------- |
 | `configs/prometheus.yml` — add/edit scrape jobs | Yes |
 | `configs/loki.yml` — adjust retention, limits | Yes |
 | `configs/promtail.yml` — add log scrape targets | Yes |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,13 +12,13 @@ tailing. It does NOT modify Agamemnon or any other HomericIntelligence service.
 
 ## Stack Components
 
-| Service         | Image                          | Purpose                                 |
-|-----------------|--------------------------------|-----------------------------------------|
-| Prometheus      | prom/prometheus:v2.54.1        | Scrape and store metrics                |
-| Loki            | grafana/loki:3.1.2             | Store and query log streams             |
-| loki-proxy      | nginx:1.27-alpine              | Basic-auth proxy in front of Loki       |
-| Promtail        | grafana/promtail:3.1.2         | Tail container logs and ship to Loki    |
-| Grafana         | grafana/grafana:11.2.2         | Visualize metrics and logs              |
+| Service         | Image                          | Purpose                                                |
+|-----------------|--------------------------------|--------------------------------------------------------|
+| Prometheus      | prom/prometheus:v2.54.1        | Scrape and store metrics                               |
+| Loki            | grafana/loki:3.1.2             | Store and query log streams                            |
+| loki-proxy      | nginx:1.27-alpine              | Basic-auth proxy in front of Loki                      |
+| Promtail        | grafana/promtail:3.1.2         | Tail container logs and ship to Loki                   |
+| Grafana         | grafana/grafana:11.2.2         | Visualize metrics and logs                             |
 | argus-exporter  | built from exporter/           | Convert HomericIntelligence APIs to Prometheus metrics |
 
 All services run on the `argus` Docker network and are managed via `docker-compose.yml`.
@@ -44,12 +44,12 @@ graph TD
 Copy `.env.example` to `.env` before running `just start`. The stack will refuse
 to start without a `.env` file.
 
-| Variable            | Default in .env.example              | Required | Purpose                              |
-|---------------------|--------------------------------------|----------|--------------------------------------|
-| `GF_ADMIN_PASSWORD` | `changeme`                           | **Yes**  | Grafana admin password               |
-| `AGAMEMNON_URL`     | `http://172.20.0.1:8080`             | Yes      | Agamemnon API base URL               |
-| `NESTOR_URL`        | `http://172.20.0.1:8081`             | Yes      | Nestor API base URL                  |
-| `NATS_URL`          | `http://172.24.0.1:8222`             | Yes      | NATS monitoring API base URL         |
+| Variable            | Default in .env.example              | Required | Purpose                                            |
+|---------------------|--------------------------------------|----------|----------------------------------------------------|
+| `GF_ADMIN_PASSWORD` | `changeme`                           | **Yes**  | Grafana admin password                             |
+| `AGAMEMNON_URL`     | `http://172.20.0.1:8080`             | Yes      | Agamemnon API base URL                             |
+| `NESTOR_URL`        | `http://172.20.0.1:8081`             | Yes      | Nestor API base URL                                |
+| `NATS_URL`          | `http://172.24.0.1:8222`             | Yes      | NATS monitoring API base URL                       |
 | `NATS_LOG_DIR`      | `/home/mvillmow/.local/share/nats`   | Yes      | Host path to NATS log files (Promtail mounts this) |
 
 `172.20.0.1` / `172.24.0.1` are WSL2 host gateway addresses — they reach services
@@ -97,7 +97,7 @@ Copy `.env.example` to `.env` at the repository root and set values before runni
 Atlas dashboard variables use the `ATLAS_` prefix — see `dashboard/README.md` for the full table.
 
 | Variable | Required | Default | Purpose |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `NATS_LOG_DIR` | No | `~/.local/share/nats` | Host path Promtail mounts read-only for NATS logs |
 | `GF_ADMIN_PASSWORD` | **Yes** | `changeme` | Grafana admin password — change before first run |
 | `AGAMEMNON_URL` | No | `http://172.20.0.1:8080` | Agamemnon API base URL |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cp .env.example .env
 Key variables:
 
 | Variable | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `AGAMEMNON_URL` | `http://172.20.0.1:8080` | Agamemnon API base URL |
 | `NESTOR_URL` | `http://172.20.0.1:8081` | Nestor API base URL |
 | `NATS_URL` | `http://172.24.0.1:8222` | NATS monitoring endpoint |

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -91,7 +91,7 @@ For full-stack development against the rest of the Argus services, see the paren
 All configuration is via environment variables with the `ATLAS_` prefix:
 
 | Variable | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `ATLAS_LISTEN_ADDR` | `:3002` | HTTP listen address |
 | `ATLAS_LOG_LEVEL` | `info` | Log level (debug/info/warn/error) |
 | `ATLAS_NATS_URL` | `nats://nats:4222` | NATS server URL |
@@ -141,7 +141,7 @@ GET /events?topics=agent,task&replay=20
 ```
 
 | Parameter | Description |
-|---|---|
+| --- | --- |
 | `topics` | Comma-separated topic filter. Omit to receive all topics. |
 | `replay` | Number of buffered events to replay on connect (ring buffer, max 256). |
 
@@ -150,7 +150,7 @@ GET /events?topics=agent,task&replay=20
 are bus-only — published by Atlas itself when its REST pollers refresh state.
 
 | Topic | Source | NATS stream / origin | Subject pattern |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `agent` | NATS subscriber | `homeric-agents` | `hi.agents.>` |
 | `task` | NATS subscriber | `homeric-tasks` | `hi.tasks.>` |
 | `myrmidon` | NATS subscriber | `homeric-myrmidon` | `hi.myrmidon.>` |
@@ -178,7 +178,7 @@ Keepalive comment frames are sent every 15 seconds:
 ## HTTP Endpoints
 
 | Method | Path | Description |
-|---|---|---|
+| --- | --- | --- |
 | `GET` | `/` | Overview page |
 | `GET` | `/hosts` | Tailscale host grid — cards refresh every 5 s via htmx |
 | `GET` | `/livez` | Liveness probe — always 200 if the process is up. **Unauthenticated.** |
@@ -206,7 +206,7 @@ Keepalive comment frames are sent every 15 seconds:
 Set `ATLAS_AUTH_MODE` to configure the auth gate:
 
 | Mode | Behaviour |
-|------|-----------|
+| ------ | ----------- |
 | `bearer` (default since v0.2.0) | `Authorization: Bearer <token>` header required; SSE endpoints also accept `?token=<token>`. Atlas refuses to start if the token is unset. |
 | `basic` | `Authorization: Basic <base64(user:pass)>` required. Atlas refuses to start if user or pass is unset. |
 | `none` | No authentication required. Logs a startup warning. **Do not use in production.** |
@@ -229,7 +229,7 @@ Atlas exposes Prometheus metrics at `/metrics`. The endpoint is **auth-gated** s
 (see [Authentication](#authentication)) — your scrape job must present the configured credentials.
 
 | Metric | Type | Description |
-|--------|------|-------------|
+| -------- | ------ | ------------- |
 | `atlas_build_info` | gauge | Build info (version, goversion labels) |
 | `atlas_nats_connected` | gauge | 1 if NATS is connected, 0 otherwise |
 | `atlas_sse_connected_clients` | gauge | Active SSE client connections |

--- a/dashboard/docs/architecture.md
+++ b/dashboard/docs/architecture.md
@@ -47,7 +47,7 @@ Mnemosyne browser
 The values below are hardcoded at v0.2.0 — operators sizing memory should account for these:
 
 | Bound | Value | Source |
-|---|---|---|
+| --- | --- | --- |
 | Event-bus ring capacity | 256 | `cmd/argus-dashboard/main.go` (`events.NewBus(256)`) |
 | Per-SSE-subscriber channel buffer | 1000 | `internal/handlers/sse.go` (`bus.Subscribe(1000)`) |
 | Per-agent event history | 50 | `internal/store/cache.go` (`maxAgentEvents`) |

--- a/dashboard/docs/review-charter.md
+++ b/dashboard/docs/review-charter.md
@@ -49,7 +49,7 @@ all six dimensions below have returned `approved`.
 Every reviewer returns exactly one of:
 
 | Verdict | Meaning | Effect |
-|---|---|---|
+| --- | --- | --- |
 | `approved` | The dimension's criteria are met. | Counts toward the 6/6 needed to merge. |
 | `changes-requested` | At least one criterion is not met. | Author must address findings, then re-dispatch the wave (new team). |
 | `not-applicable` | The dimension genuinely does not apply to this PR (e.g., no UX surface). | Treated as `approved`. **Must include a one-sentence justification** in the task result body. |

--- a/dashboard/docs/runbook.md
+++ b/dashboard/docs/runbook.md
@@ -204,7 +204,7 @@ ring-buffer size (256 events) on reconnect.
 Atlas uses Go `slog` with JSON output. Key structured fields:
 
 | Field | Meaning |
-|---|---|
+| --- | --- |
 | `level` | `DEBUG`, `INFO`, `WARN`, `ERROR` |
 | `msg` | One-line event description |
 | `version` | Build-stamped via `-ldflags -X version.Version=...` |

--- a/docs/tls-setup.md
+++ b/docs/tls-setup.md
@@ -7,10 +7,10 @@ communication in the argus observability stack.
 
 The stack uses a two-tier TLS strategy:
 
-| Tier | Path | Mechanism |
-|------|------|-----------|
-| 1 (high priority) | exporter → Agamemnon/NATS/Nestor | Tailscale transport encryption |
-| 2 (best practice) | Docker-internal services | Self-signed CA + per-service certificates |
+| Tier              | Path                             | Mechanism                                 |
+|-------------------|----------------------------------|-------------------------------------------|
+| 1 (high priority) | exporter → Agamemnon/NATS/Nestor | Tailscale transport encryption            |
+| 2 (best practice) | Docker-internal services         | Self-signed CA + per-service certificates |
 
 ## Quick Start
 
@@ -90,7 +90,7 @@ errors when `https://` is pointed at an HTTP-only endpoint.
 ## Tier 2: Docker-Internal Paths
 
 | Service | Certificate | Mounted at |
-|---------|-------------|------------|
+| --------- | ------------- | ------------ |
 | Prometheus | `certs/prometheus.{crt,key}` | `/etc/prometheus/tls/` |
 | Loki | `certs/loki.{crt,key}` | `/etc/loki/tls/` |
 | Grafana | `certs/grafana.{crt,key}` | `/etc/grafana/tls/` |


### PR DESCRIPTION
## Summary

Reformats markdown tables to satisfy the new MD060 (table-column-style) rule that
ships with `markdownlint-cli2-action` v0.18.x+ (bundled in
`DavidAnson/markdownlint-cli2-action@v23.2.0`, which pins `markdownlint-cli2@0.22.1`).
Unblocks dependabot PR #498.

Resolved 110 MD060 findings across 8 markdown files. Mechanical formatting only — no
content changes.

## Files touched

- `AGENTS.md`
- `CLAUDE.md`
- `README.md`
- `dashboard/README.md`
- `dashboard/docs/architecture.md`
- `dashboard/docs/review-charter.md`
- `dashboard/docs/runbook.md`
- `docs/tls-setup.md`

## Test plan

- [x] `npx markdownlint-cli2@0.22.1 '**/*.md' '#node_modules' '#.git'` exits 0 locally
- [ ] CI markdownlint job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)