### PR TITLE
ci: add promtail config validation (#193)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,20 @@ jobs:
             rules/atlas-alerts.yml \
             docker-compose.yml
 
+      - name: Validate Promtail config syntax
+        run: |
+          # Run promtail -check-syntax against the committed config inside
+          # the same image used by the compose stack. The config references
+          # env vars; promtail expands them at parse time when
+          # -config.expand-env=true, with missing vars resolving to an empty
+          # string — fine for a syntax-only check.
+          docker run --rm \
+            -v "$PWD/configs/promtail.yml:/etc/promtail/promtail.yml:ro" \
+            grafana/promtail:3.1.2 \
+            -config.file=/etc/promtail/promtail.yml \
+            -config.expand-env=true \
+            -check-syntax
+
       - name: Validate Grafana dashboard JSON
         run: |
           for f in dashboards/*.json; do

--- a/justfile
+++ b/justfile
@@ -78,7 +78,7 @@ clean:
     {{compose_cmd}} down -v
 
 # Validate docker-compose config, YAML files, and required runtime files
-validate: check-env-example
+validate: check-env-example validate-promtail
     #!/usr/bin/env bash
     set -euo pipefail
     {{compose_cmd}} config --quiet
@@ -92,6 +92,17 @@ validate: check-env-example
 # .env.example. Fails on undocumented drift (issue #215).
 check-env-example:
     @bash scripts/check-env-example.sh
+
+# Validate promtail config syntax via the official image's -check-syntax
+validate-promtail:
+    @echo "Validating configs/promtail.yml ..."
+    {{container_cmd}} run --rm \
+        -v "$(pwd)/configs/promtail.yml:/etc/promtail/promtail.yml:ro" \
+        grafana/promtail:3.1.2 \
+        -config.file=/etc/promtail/promtail.yml \
+        -config.expand-env=true \
+        -check-syntax
+    @echo "promtail config OK."
 
 # Hot-reload dev loop for the dashboard (templ generate --watch + air in parallel)
 dev:


### PR DESCRIPTION
## Summary
- Adds a CI step in the `validate` job that runs `promtail -check-syntax` against `configs/promtail.yml` using `grafana/promtail:3.1.2` (the version pinned in `docker-compose.yml`).
- Adds a `just validate-promtail` recipe and chains it into `just validate` so local runs catch syntax regressions before push.
- Closes #193

## Test plan
- [x] `docker run --rm -v "$PWD/configs/promtail.yml:/etc/promtail/promtail.yml:ro" grafana/promtail:3.1.2 -config.file=/etc/promtail/promtail.yml -config.expand-env=true -check-syntax` -> "Valid config file! No syntax issues found"
- [x] `pre-commit run --files .github/workflows/ci.yml justfile` passes (yamllint, no-silent-failure guard, continue-on-error guard)
- [x] CI passes on the PR

Generated with [Claude Code](https://claude.com/claude-code)