### PR TITLE
security(grafana): set GF_SERVER_ROOT_URL to mitigate host-header attacks (#244)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,17 @@ ATLAS_AUTH_BEARER_TOKEN=
 # Grafana admin password (default: changeme — change before exposing to a network)
 GRAFANA_ADMIN_PASSWORD=changeme
 
+# Grafana external root URL. Pins Grafana's served origin so it ignores
+# untrusted Host headers (mitigates host-header injection / cache-poisoning
+# attacks against the login + reset-password flows). Must end with a trailing
+# slash and match how operators actually reach Grafana.
+#
+# Default below matches the loopback-only port mapping in docker-compose.yml
+# (127.0.0.1:${GRAFANA_PORT:-3001} → container :3000, served over HTTPS).
+# Override when fronting Grafana with a reverse proxy on a different hostname,
+# e.g. GF_SERVER_ROOT_URL=https://grafana.example.com/.
+# GF_SERVER_ROOT_URL=https://localhost:3001/
+
 # Agamemnon API base URL (WSL2 host gateway default)
 AGAMEMNON_URL=http://172.20.0.1:8080
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,6 +192,13 @@ services:
       GF_SERVER_PROTOCOL: https
       GF_SERVER_CERT_FILE: /etc/grafana/tls/grafana.crt
       GF_SERVER_CERT_KEY: /etc/grafana/tls/grafana.key
+      # Pin Grafana's external URL so it ignores untrusted Host headers
+      # (host-header injection mitigation). Grafana is bound to
+      # 127.0.0.1:${GRAFANA_PORT:-3001} on the host and only reachable via
+      # local browser, SSH tunnel, or VPN — so the default root URL points
+      # at loopback. Override GF_SERVER_ROOT_URL in .env if you front
+      # Grafana with a reverse proxy on a different hostname.
+      GF_SERVER_ROOT_URL: ${GF_SERVER_ROOT_URL:-https://localhost:${GRAFANA_PORT:-3001}/}
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
       interval: 30s


### PR DESCRIPTION
## Summary
- Sets `GF_SERVER_ROOT_URL` on the Grafana container so it ignores untrusted Host headers (host-header injection / cache-poisoning mitigation on login and password-reset flows).
- Default value matches the loopback-only HTTPS port mapping already documented in `docker-compose.yml`: `https://localhost:${GRAFANA_PORT:-3001}/`.
- Documents the new override in `.env.example` for operators fronting Grafana with a reverse proxy on a different hostname.
- Closes #244

## Test plan
- [x] `yamllint` on `docker-compose.yml` passes (no new findings).
- [x] `python3 -c "yaml.safe_load(...)"` confirms `GF_SERVER_ROOT_URL` is present on the grafana service env block.
- [ ] Stack starts cleanly (`just start`) and Grafana login works at `https://localhost:3001/`.
- [ ] Operator override (`GF_SERVER_ROOT_URL=https://grafana.example.com/` in `.env`) propagates as expected.

Generated with Claude Code.