### PR TITLE
ci: validate .env.example covers all required env vars (#215)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,3 +106,20 @@ NESTOR_URL=http://172.20.0.1:8081
 
 # NATS monitoring URL
 NATS_URL=http://172.24.0.1:8222
+
+# === Container name overrides (optional) ===
+# Each service uses ${*_CONTAINER_NAME:-<default>} in docker-compose.yml so
+# operators can run multiple stacks side-by-side on the same host without
+# colliding on Docker container names. Leave commented unless you need
+# to rename a container.
+# PROMETHEUS_CONTAINER_NAME=argus-prometheus
+# LOKI_CONTAINER_NAME=argus-loki
+# PROMTAIL_CONTAINER_NAME=argus-promtail
+# GRAFANA_CONTAINER_NAME=argus-grafana
+# EXPORTER_CONTAINER_NAME=argus-exporter
+
+# === Host port overrides (optional) ===
+# Grafana and the exporter publish on 127.0.0.1:<PORT>. Override only when
+# the defaults collide with another service on the host.
+# GRAFANA_PORT=3001
+# EXPORTER_PORT=9100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
         env:
           GF_ADMIN_PASSWORD: ci-validation-only
 
+      - name: Check .env.example documents every compose variable
+        run: bash scripts/check-env-example.sh
+
       - name: Lint exporter Python
         run: pixi run ruff check exporter/exporter.py
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,14 @@ repos:
         entry: '^\s*continue-on-error:\s*true\s*$'
         files: ^\.github/workflows/.*\.ya?ml$
         pass_filenames: true
+
+      - id: check-env-example
+        name: "check .env.example documents every docker-compose env var"
+        description: >
+          Compares ${VAR} references in docker-compose.yml against keys in
+          .env.example so new variables can't silently drift undocumented.
+          See HomericIntelligence/ProjectArgus#215.
+        entry: bash scripts/check-env-example.sh
+        language: system
+        files: ^(docker-compose\.ya?ml|\.env\.example|scripts/check-env-example\.sh)$
+        pass_filenames: false

--- a/justfile
+++ b/justfile
@@ -76,7 +76,7 @@ clean:
     {{compose_cmd}} down -v
 
 # Validate docker-compose config, YAML files, and required runtime files
-validate:
+validate: check-env-example
     #!/usr/bin/env bash
     set -euo pipefail
     {{compose_cmd}} config --quiet
@@ -85,6 +85,11 @@ validate:
         exit 1
     fi
     echo "Config is valid."
+
+# Verify every env var referenced by docker-compose.yml is documented in
+# .env.example. Fails on undocumented drift (issue #215).
+check-env-example:
+    @bash scripts/check-env-example.sh
 
 # Hot-reload dev loop for the dashboard (templ generate --watch + air in parallel)
 dev:

--- a/scripts/check-env-example.sh
+++ b/scripts/check-env-example.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# check-env-example.sh — fail if docker-compose.yml references env vars that
+# are not documented in .env.example.
+#
+# Background: docker-compose.yml uses ${VAR} and ${VAR:-default} interpolation.
+# Without enforcement, new variables silently drift away from .env.example
+# (the operator-facing canonical list). This script extracts every variable
+# referenced from the compose file and verifies each one has a corresponding
+# entry in .env.example (commented or uncommented).
+#
+# Follow-up to HomericIntelligence/ProjectArgus#53; closes #215.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${REPO_ROOT}/docker-compose.yml"
+ENV_EXAMPLE="${REPO_ROOT}/.env.example"
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+    echo "ERROR: $COMPOSE_FILE not found" >&2
+    exit 2
+fi
+if [[ ! -f "$ENV_EXAMPLE" ]]; then
+    echo "ERROR: $ENV_EXAMPLE not found" >&2
+    exit 2
+fi
+
+# System variables that compose interpolates from the calling shell and are
+# not expected to be documented in .env.example (Docker resolves them from
+# the host environment, not from .env). Extend as needed.
+SYSTEM_ALLOWLIST=(
+    HOSTNAME
+    HOME
+    USER
+    PATH
+    PWD
+    UID
+    GID
+)
+
+is_allowlisted() {
+    local var="$1"
+    local allowed
+    for allowed in "${SYSTEM_ALLOWLIST[@]}"; do
+        [[ "$var" == "$allowed" ]] && return 0
+    done
+    return 1
+}
+
+# Extract every ${VAR...} reference from docker-compose.yml. The regex
+# tolerates both ${VAR} and ${VAR:-default} forms. Each captured name is
+# emitted once, sorted.
+mapfile -t compose_vars < <(
+    grep -oE '\$\{[A-Z_][A-Z0-9_]*' "$COMPOSE_FILE" \
+        | sed 's/^\${//' \
+        | sort -u
+)
+
+# Extract every KEY= entry (commented or not) from .env.example. A line of
+# the form "# FOO=..." counts as documented because operators rely on the
+# inline comment to discover optional knobs.
+mapfile -t env_keys < <(
+    grep -oE '^[[:space:]]*#?[[:space:]]*[A-Z_][A-Z0-9_]*=' "$ENV_EXAMPLE" \
+        | sed -E 's/^[[:space:]]*#?[[:space:]]*//; s/=$//' \
+        | sort -u
+)
+
+# Build an associative lookup for fast membership checks.
+declare -A env_seen=()
+for k in "${env_keys[@]}"; do
+    env_seen["$k"]=1
+done
+
+missing=()
+for var in "${compose_vars[@]}"; do
+    if is_allowlisted "$var"; then
+        continue
+    fi
+    if [[ -z "${env_seen[$var]:-}" ]]; then
+        missing+=("$var")
+    fi
+done
+
+if (( ${#missing[@]} > 0 )); then
+    echo "ERROR: docker-compose.yml references env vars missing from .env.example:" >&2
+    for var in "${missing[@]}"; do
+        echo "  - $var" >&2
+    done
+    echo >&2
+    echo "Add each variable (with a brief comment and default) to .env.example" >&2
+    echo "so operators can discover and override it." >&2
+    exit 1
+fi
+
+echo "OK: all ${#compose_vars[@]} compose variable(s) are documented in .env.example."


### PR DESCRIPTION
## Summary
- Adds `scripts/check-env-example.sh` which extracts every `${VAR}` reference from `docker-compose.yml` and fails if any variable is missing from `.env.example` (system vars like `HOSTNAME` allow-listed).
- Wires the check into CI (validate job), `just validate` (via a new `just check-env-example` recipe), and pre-commit, so drift is caught at every layer.
- Documents the previously-undocumented optional overrides (`*_CONTAINER_NAME`, `GRAFANA_PORT`, `EXPORTER_PORT`) in `.env.example` so the new check passes against the current compose file.
- Closes #215 (follow-up to #53).

## Test plan
- [x] `bash scripts/check-env-example.sh` passes on the current tree.
- [x] Negative test: removing `AGAMEMNON_URL` from `.env.example` makes the check exit 1 with a clear error listing the missing var.
- [x] `shellcheck --severity=warning scripts/check-env-example.sh` is clean.
- [x] `pre-commit run check-env-example --all-files` passes.
- [x] `just --list` still parses; `check-env-example` is a dependency of `validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)