### PR TITLE
chore(prometheus): add alertmanager scrape job (#178)

### DIFF
--- a/configs/prometheus.yml
+++ b/configs/prometheus.yml
@@ -50,6 +50,12 @@ scrape_configs:
       - targets: ['argus-dashboard:3002']
     metrics_path: /metrics
 
+  # Alertmanager self-monitoring: exposes alert pipeline health
+  # (alertmanager_alerts, alertmanager_notifications_total, etc.) on :9093/metrics
+  - job_name: 'alertmanager'
+    static_configs:
+      - targets: ['alertmanager:9093']
+
 # NOTE: Promtail (port 9080) is intentionally NOT scraped here. Promtail
 # exposes useful self-metrics (lines ingested, target counts, push errors)
 # but they cardinality-multiply per tailed file/job and we keep this


### PR DESCRIPTION
## Summary
- Adds an Alertmanager scrape job to prometheus.yml so its own metrics are collected and visible in Grafana.
- Targets `alertmanager:9093` (matches the docker-compose service name and the existing `alerting.alertmanagers` entry).
- Closes #178

## Test plan
- [x] promtool check config passes (CI prometheus validation)
- [x] Targets show up in Prometheus /targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)