### PR TITLE
security(promtail): redact secrets from NATS log pipeline (#191)

### DIFF
--- a/configs/promtail.yml
+++ b/configs/promtail.yml
@@ -56,3 +56,19 @@ scrape_configs:
           job: nats
           service: nats-server
           __path__: /logs/nats/nats.log
+    pipeline_stages:
+      - replace:
+          expression: '(?i)(bearer\s+)[A-Za-z0-9._\-]+'
+          replace: '${1}<redacted>'
+      - replace:
+          expression: '(?i)(token[=:]\s*)[A-Za-z0-9._\-]+'
+          replace: '${1}<redacted>'
+      - replace:
+          expression: '(?i)(key[=:]\s*)[A-Za-z0-9._\-]+'
+          replace: '${1}<redacted>'
+      - replace:
+          expression: '(?i)(secret[=:]\s*)[A-Za-z0-9._\-]+'
+          replace: '${1}<redacted>'
+      - replace:
+          expression: '(?i)(password[=:]\s*)\S+'
+          replace: '${1}<redacted>'


### PR DESCRIPTION
## Summary
- NATS log pipeline now redacts API keys / passwords / JWTs / tokens before they reach Loki.
- Mirrors the five `replace` stages already applied to the `hermes` job in `configs/promtail.yml`.
- Closes #191

## Test plan
- [x] YAML validates (`yamllint configs/promtail.yml` — only pre-existing document-start warning)
- [x] `python3 -c "import yaml; yaml.safe_load(open('configs/promtail.yml'))"` succeeds
- [ ] Manual: a log line with a fake secret is redacted in Loki (post-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)