### PR TITLE
security(grafana): warn at startup if GRAFANA_ADMIN_PASSWORD is unset/default (#182)

### DIFF
--- a/justfile
+++ b/justfile
@@ -56,6 +56,7 @@ start: gen-htpasswd
         echo "ERROR: configs/nginx/htpasswd is missing. Run 'just gen-htpasswd' to create it." >&2
         exit 1
     fi
+    ./scripts/check-grafana-password.sh
     {{compose_cmd}} up -d
 
 # Stop all services
@@ -68,6 +69,7 @@ status:
 
 # Restart all services (stop then start)
 restart: gen-htpasswd
+    ./scripts/check-grafana-password.sh
     {{compose_cmd}} down
     {{compose_cmd}} up -d
 

--- a/scripts/check-grafana-password.sh
+++ b/scripts/check-grafana-password.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Warn when GRAFANA_ADMIN_PASSWORD is unset or matches a known default.
+#
+# Called from `just start` / `just restart` so the user is told — loudly —
+# whenever the Grafana stack would otherwise come up with the insecure
+# fallback password baked into docker-compose.yml.
+#
+# Issue: HomericIntelligence/ProjectArgus#182
+
+set -euo pipefail
+
+# Source .env so GRAFANA_ADMIN_PASSWORD is visible even when the caller
+# didn't export it (justfile uses `set dotenv-load`, but this script may
+# also be invoked directly).
+if [ -f .env ] && [ -z "${GRAFANA_ADMIN_PASSWORD:-}" ]; then
+    # shellcheck disable=SC1091
+    set -a; . ./.env; set +a
+fi
+
+PASSWORD="${GRAFANA_ADMIN_PASSWORD:-}"
+
+# Known-insecure defaults that must never reach a deployed stack.
+#   - empty    : docker-compose.yml falls back to `admin`
+#   - admin    : the compose fallback itself
+#   - changeme : the placeholder shipped in .env.example
+case "$PASSWORD" in
+    ""|admin|changeme)
+        cat >&2 <<'WARN'
+================================================================================
+WARNING: GRAFANA_ADMIN_PASSWORD is unset or set to a known default value.
+
+Grafana will start with an insecure admin password (default fallback: 'admin').
+Set GRAFANA_ADMIN_PASSWORD to a strong, unique value in .env before exposing
+this stack to any network. See .env.example for the canonical variable name.
+================================================================================
+WARN
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Adds `scripts/check-grafana-password.sh` and wires it into `just start` / `just restart`.
- Warns to stderr when `GRAFANA_ADMIN_PASSWORD` is unset, equals the compose fallback `admin`, or equals the `.env.example` placeholder `changeme`.
- Closes #182

## Test plan
- [x] Warning fires when var is unset
- [x] Warning fires when value is `admin` (compose fallback)
- [x] Warning fires when value is `changeme` (.env.example placeholder)
- [x] Silent when password is a custom strong value

Manually verified all four cases by exporting the variable and running the script directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)