### PR TITLE
security(promtail): redact URL-embedded credentials (#194)

### DIFF
--- a/configs/promtail.yml
+++ b/configs/promtail.yml
@@ -36,6 +36,16 @@ scrape_configs:
       - replace:
           expression: '(?i)(password[=:]\s*)\S+'
           replace: '${1}<redacted>'
+      # URL-embedded credentials: scheme://user:password@host -> scheme://<redacted>@host
+      - replace:
+          expression: '([a-zA-Z][a-zA-Z0-9+.\-]*://)[^\s/@:]+:[^\s/@]+@'
+          replace: '${1}<redacted>@'
+      # Query-string API keys / tokens / secrets / passwords:
+      # ?api_key=abc, &access_token=xyz, &client_secret=..., &password=...
+      - replace:
+          # yamllint disable-line rule:line-length
+          expression: '(?i)([?&](?:api[_-]?key|access[_-]?token|auth[_-]?token|client[_-]?secret|secret|token|password|key)=)[^&\s#]+'
+          replace: '${1}<redacted>'
 
   # Tail Hermes application log
   - job_name: hermes
@@ -69,6 +79,7 @@ scrape_configs:
       # Query-string API keys / tokens / secrets / passwords:
       # ?api_key=abc, &access_token=xyz, &client_secret=..., &password=...
       - replace:
+          # yamllint disable-line rule:line-length
           expression: '(?i)([?&](?:api[_-]?key|access[_-]?token|auth[_-]?token|client[_-]?secret|secret|token|password|key)=)[^&\s#]+'
           replace: '${1}<redacted>'
 
@@ -104,5 +115,6 @@ scrape_configs:
       # Query-string API keys / tokens / secrets / passwords:
       # ?api_key=abc, &access_token=xyz, &client_secret=..., &password=...
       - replace:
+          # yamllint disable-line rule:line-length
           expression: '(?i)([?&](?:api[_-]?key|access[_-]?token|auth[_-]?token|client[_-]?secret|secret|token|password|key)=)[^&\s#]+'
           replace: '${1}<redacted>'

--- a/configs/promtail.yml
+++ b/configs/promtail.yml
@@ -97,3 +97,12 @@ scrape_configs:
       - replace:
           expression: '(?i)(password[=:]\s*)\S+'
           replace: '${1}<redacted>'
+      # URL-embedded credentials: scheme://user:password@host -> scheme://<redacted>@host
+      - replace:
+          expression: '([a-zA-Z][a-zA-Z0-9+.\-]*://)[^\s/@:]+:[^\s/@]+@'
+          replace: '${1}<redacted>@'
+      # Query-string API keys / tokens / secrets / passwords:
+      # ?api_key=abc, &access_token=xyz, &client_secret=..., &password=...
+      - replace:
+          expression: '(?i)([?&](?:api[_-]?key|access[_-]?token|auth[_-]?token|client[_-]?secret|secret|token|password|key)=)[^&\s#]+'
+          replace: '${1}<redacted>'

--- a/configs/promtail.yml
+++ b/configs/promtail.yml
@@ -62,6 +62,15 @@ scrape_configs:
       - replace:
           expression: '(?i)(password[=:]\s*)\S+'
           replace: '${1}<redacted>'
+      # URL-embedded credentials: scheme://user:password@host -> scheme://<redacted>@host
+      - replace:
+          expression: '([a-zA-Z][a-zA-Z0-9+.\-]*://)[^\s/@:]+:[^\s/@]+@'
+          replace: '${1}<redacted>@'
+      # Query-string API keys / tokens / secrets / passwords:
+      # ?api_key=abc, &access_token=xyz, &client_secret=..., &password=...
+      - replace:
+          expression: '(?i)([?&](?:api[_-]?key|access[_-]?token|auth[_-]?token|client[_-]?secret|secret|token|password|key)=)[^&\s#]+'
+          replace: '${1}<redacted>'
 
   # Tail NATS server log
   - job_name: nats

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -171,13 +171,13 @@ class TestPromtailConfig(unittest.TestCase):
                     f"{pat!r}; got expressions: {joined!r}"
                 )
 
-    def _hermes_replace_expressions(self) -> list[str]:
-        hermes_job = next(
-            (j for j in self.config["scrape_configs"] if j.get("job_name") == "hermes"),
+    def _replace_expressions(self, job_name: str) -> list[str]:
+        job = next(
+            (j for j in self.config["scrape_configs"] if j.get("job_name") == job_name),
             None,
         )
-        assert hermes_job is not None, "hermes scrape job not found"
-        stages = hermes_job.get("pipeline_stages", [])
+        assert job is not None, f"{job_name} scrape job not found"
+        stages = job.get("pipeline_stages", [])
         exprs: list[str] = []
         for stage in stages:
             if isinstance(stage, dict) and "replace" in stage:
@@ -186,38 +186,55 @@ class TestPromtailConfig(unittest.TestCase):
                     exprs.append(expr)
         return exprs
 
-    def test_hermes_redacts_url_embedded_credentials(self):
-        """Issue #194: scheme://user:password@host must be redacted."""
+    def _jobs_with_redaction(self) -> list[str]:
+        """Return job_names that already perform credential redaction."""
+        jobs: list[str] = []
+        for j in self.config["scrape_configs"]:
+            stages = j.get("pipeline_stages") or []
+            if any(isinstance(s, dict) and "replace" in s for s in stages):
+                jobs.append(j["job_name"])
+        return jobs
+
+    def test_url_embedded_credentials_redacted_in_all_redaction_pipelines(self):
+        """Issue #194: scheme://user:password@host must be redacted in every
+        pipeline that already does credential redaction."""
         import re
 
-        exprs = self._hermes_replace_expressions()
-        sample = "connecting to https://alice:hunter2@db.example.com/foo"
-        for expr in exprs:
-            sample = re.sub(expr, "<redacted>", sample, flags=re.IGNORECASE)
-        assert "hunter2" not in sample, (
-            f"URL-embedded password leaked through redaction stages: {sample!r}"
-        )
-        assert "alice" not in sample, (
-            f"URL-embedded username leaked through redaction stages: {sample!r}"
-        )
+        jobs = self._jobs_with_redaction()
+        assert jobs, "expected at least one job with redaction stages"
+        sample_in = "connecting to https://alice:hunter2@db.example.com/foo"
+        for job in jobs:
+            sample = sample_in
+            for expr in self._replace_expressions(job):
+                sample = re.sub(expr, "<redacted>", sample, flags=re.IGNORECASE)
+            assert "hunter2" not in sample, (
+                f"job {job!r}: URL-embedded password leaked: {sample!r}"
+            )
+            assert "alice" not in sample, (
+                f"job {job!r}: URL-embedded username leaked: {sample!r}"
+            )
 
-    def test_hermes_redacts_query_string_api_keys(self):
-        """Issue #194: ?api_key= / &access_token= etc must be redacted."""
+    def test_query_string_api_keys_redacted_in_all_redaction_pipelines(self):
+        """Issue #194: ?api_key= / &access_token= etc must be redacted in every
+        pipeline that already does credential redaction."""
         import re
 
-        exprs = self._hermes_replace_expressions()
+        jobs = self._jobs_with_redaction()
         cases = [
             ("GET /v1?api_key=abc123XYZ&name=alice", "abc123XYZ"),
             ("url?access_token=tok_DEADBEEF&next=x", "tok_DEADBEEF"),
             ("/auth?client_secret=shh_SECRET_42 done", "shh_SECRET_42"),
         ]
-        for line, secret in cases:
-            redacted = line
-            for expr in exprs:
-                redacted = re.sub(expr, "<redacted>", redacted, flags=re.IGNORECASE)
-            assert secret not in redacted, (
-                f"query-string secret {secret!r} leaked: input={line!r} output={redacted!r}"
-            )
+        for job in jobs:
+            exprs = self._replace_expressions(job)
+            for line, secret in cases:
+                redacted = line
+                for expr in exprs:
+                    redacted = re.sub(expr, "<redacted>", redacted, flags=re.IGNORECASE)
+                assert secret not in redacted, (
+                    f"job {job!r}: query-string secret {secret!r} leaked: "
+                    f"input={line!r} output={redacted!r}"
+                )
 
 
 class TestGrafanaDatasourcesConfig(unittest.TestCase):

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -171,6 +171,54 @@ class TestPromtailConfig(unittest.TestCase):
                     f"{pat!r}; got expressions: {joined!r}"
                 )
 
+    def _hermes_replace_expressions(self) -> list[str]:
+        hermes_job = next(
+            (j for j in self.config["scrape_configs"] if j.get("job_name") == "hermes"),
+            None,
+        )
+        assert hermes_job is not None, "hermes scrape job not found"
+        stages = hermes_job.get("pipeline_stages", [])
+        exprs: list[str] = []
+        for stage in stages:
+            if isinstance(stage, dict) and "replace" in stage:
+                expr = stage["replace"].get("expression")
+                if expr:
+                    exprs.append(expr)
+        return exprs
+
+    def test_hermes_redacts_url_embedded_credentials(self):
+        """Issue #194: scheme://user:password@host must be redacted."""
+        import re
+
+        exprs = self._hermes_replace_expressions()
+        sample = "connecting to https://alice:hunter2@db.example.com/foo"
+        for expr in exprs:
+            sample = re.sub(expr, "<redacted>", sample, flags=re.IGNORECASE)
+        assert "hunter2" not in sample, (
+            f"URL-embedded password leaked through redaction stages: {sample!r}"
+        )
+        assert "alice" not in sample, (
+            f"URL-embedded username leaked through redaction stages: {sample!r}"
+        )
+
+    def test_hermes_redacts_query_string_api_keys(self):
+        """Issue #194: ?api_key= / &access_token= etc must be redacted."""
+        import re
+
+        exprs = self._hermes_replace_expressions()
+        cases = [
+            ("GET /v1?api_key=abc123XYZ&name=alice", "abc123XYZ"),
+            ("url?access_token=tok_DEADBEEF&next=x", "tok_DEADBEEF"),
+            ("/auth?client_secret=shh_SECRET_42 done", "shh_SECRET_42"),
+        ]
+        for line, secret in cases:
+            redacted = line
+            for expr in exprs:
+                redacted = re.sub(expr, "<redacted>", redacted, flags=re.IGNORECASE)
+            assert secret not in redacted, (
+                f"query-string secret {secret!r} leaked: input={line!r} output={redacted!r}"
+            )
+
 
 class TestGrafanaDatasourcesConfig(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- Adds two replace stages to every promtail pipeline that already performs credential redaction (currently `hermes` and `nats`):
  - **URL-embedded credentials**: `scheme://user:password@host` -> `scheme://<redacted>@host`
  - **Query-string secrets**: `?api_key=...`, `&access_token=...`, `&client_secret=...`, `&password=...`, `&token=...`, `&auth_token=...`, `&secret=...`, `&key=...` -> `<redacted>`
- Adds regression tests in `tests/test_configs.py` that iterate over every redaction-enabled scrape job and assert both forms are stripped.
- Out of scope (separate issues): adding redaction to pipelines that don't currently have it (#190 syslog, etc).

Closes #194

## Test plan
- [x] `pixi run test` — 319 passed, coverage 99.40%
- [x] Verified each new regex against the Go RE2 engine (promtail's runtime) with positive + negative cases (`alice:hunter2@`, `?api_key=abc`, `&access_token=...`, plus a no-creds URL).
- [x] Verified YAML still parses (`python -c "import yaml; yaml.safe_load(open('configs/promtail.yml'))"`).

Generated with [Claude Code](https://claude.com/claude-code)