### PR TITLE
chore(grafana): add Alertmanager notification pipeline dashboard (#179)

### DIFF
--- a/dashboards/alertmanager.json
+++ b/dashboards/alertmanager.json
@@ -1,0 +1,178 @@
+{
+  "uid": "alertmanager",
+  "title": "Alertmanager Notification Pipeline",
+  "version": 1,
+  "schemaVersion": 39,
+  "tags": ["alertmanager", "alerts", "notifications"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Active Alerts (Firing)",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(alertmanager_alerts{state=\"active\"})",
+          "legendFormat": "active",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "red" }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Suppressed Alerts",
+      "type": "stat",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(alertmanager_alerts{state=\"suppressed\"})",
+          "legendFormat": "suppressed",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "yellow" }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Active Silences",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(alertmanager_silences{state=\"active\"})",
+          "legendFormat": "silences",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background"
+      }
+    },
+    {
+      "id": 4,
+      "title": "Alertmanager Up",
+      "type": "stat",
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "up{job=\"alertmanager\"}",
+          "legendFormat": "up",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value"
+      }
+    },
+    {
+      "id": 5,
+      "title": "Notifications Sent / sec (by integration)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (integration) (rate(alertmanager_notifications_total[5m]))",
+          "legendFormat": "{{integration}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "ops" }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Notification Failures / sec (by integration)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (integration) (rate(alertmanager_notifications_failed_total[5m]))",
+          "legendFormat": "{{integration}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "fixed", "fixedColor": "red" }
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Notification Latency p95 (by integration)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (integration, le) (rate(alertmanager_notification_latency_seconds_bucket[5m])))",
+          "legendFormat": "{{integration}} p95",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s" }
+      }
+    },
+    {
+      "id": 8,
+      "title": "Alerts Received / sec",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (status) (rate(alertmanager_alerts_received_total[5m]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(alertmanager_alerts_invalid_total[5m]))",
+          "legendFormat": "invalid",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "ops" }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- New Grafana dashboard at `dashboards/alertmanager.json` (uid: `alertmanager`) tracking Alertmanager notification pipeline health.
- Panels: active/suppressed alerts, active silences, alertmanager up, notifications sent/failed by integration, p95 notification latency, and received/invalid alert rates.
- Uses metrics from the existing `alertmanager` Prometheus scrape job: `alertmanager_alerts`, `alertmanager_silences`, `alertmanager_notifications_total`, `alertmanager_notifications_failed_total`, `alertmanager_notification_latency_seconds_bucket`, `alertmanager_alerts_received_total`, `alertmanager_alerts_invalid_total`.
- Closes #179

## Test plan
- [x] Dashboard JSON validates (CI dashboard-validator: required title/uid/panels present)
- [x] Style matches existing dashboards (schemaVersion 39, prometheus datasource uid, gridPos layout)
- [ ] Dashboard loads in Grafana with no missing-data warnings (post-merge verification)

Generated with [Claude Code](https://claude.com/claude-code)