### PR TITLE
ci(lint): fail if htpasswd is tracked in the repo (#229)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,21 @@ jobs:
       - name: Lint shell scripts
         run: shellcheck --severity=warning scripts/*.sh
 
+      - name: Assert htpasswd is not tracked
+        # Guard against accidental re-addition of nginx basic-auth credentials
+        # to the index (see issue #229, follow-up from #101). Matches the
+        # canonical path plus any file named `htpasswd` or `*.htpasswd`.
+        run: |
+          set -euo pipefail
+          tracked=$(git ls-files -- 'configs/nginx/htpasswd' '**/htpasswd' 'htpasswd' '*.htpasswd' '**/*.htpasswd')
+          if [ -n "$tracked" ]; then
+            echo "::error::htpasswd file(s) found in the git index:"
+            echo "$tracked"
+            echo "These must not be committed. Remove with: git rm --cached <path>"
+            exit 1
+          fi
+          echo "OK: no htpasswd files tracked"
+
   unit-tests:
     name: Python unit tests + coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a CI guard in the `validate` job of `.github/workflows/ci.yml` that fails the build if any `htpasswd` file is tracked in the git index. This prevents accidental re-addition of nginx basic-auth credentials (e.g. via `git add -A` in a script or hook) and makes the guard machine-verifiable rather than relying solely on `.gitignore`.

Patterns checked (via `git ls-files`):
- `configs/nginx/htpasswd` (canonical path)
- `**/htpasswd`, `htpasswd`
- `*.htpasswd`, `**/*.htpasswd`

Follow-up from #101.

Closes #229

## Test plan

- [x] Locally simulated a repo with `configs/nginx/htpasswd` committed; the `git ls-files` invocation correctly emits the path and the step would `exit 1`.
- [x] Against the current clean tree, `git ls-files` returns empty and the step prints `OK: no htpasswd files tracked`.
- [x] `yamllint` reports no new findings on `.github/workflows/ci.yml` (pre-existing `document-start` warning only).
- [ ] CI green on this PR.