### PR TITLE
chore(config): dedupe hardcoded gateway IPs (#217)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,12 @@ NESTOR_URL=http://172.20.0.1:8081
 # NATS monitoring URL
 NATS_URL=http://172.24.0.1:8222
 
+# Nomad agent metrics endpoint (host:port) scraped by Prometheus for the
+# `nomad` job. Interpolated into configs/prometheus.yml at container start
+# (the file is mounted as a template — see docker-compose.yml prometheus
+# service). Default matches the WSL2 host gateway and the Nomad HTTP port.
+NOMAD_ADDR=172.20.0.1:4646
+
 # === Container name overrides (optional) ===
 # Each service uses ${*_CONTAINER_NAME:-<default>} in docker-compose.yml so
 # operators can run multiple stacks side-by-side on the same host without

--- a/configs/prometheus.yml
+++ b/configs/prometheus.yml
@@ -37,13 +37,18 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:9090']
 
-  # Nomad job and allocation metrics
+  # Nomad job and allocation metrics.
+  # The target host:port is provided via the NOMAD_ADDR env var, which is
+  # interpolated into this file by the prometheus service entrypoint (see
+  # docker-compose.yml). Default in .env.example matches the WSL2 host
+  # gateway (172.20.0.1:4646). Update .env to point at the Nomad agent
+  # reachable from inside the argus bridge network.
   - job_name: 'nomad'
     metrics_path: /v1/metrics
     params:
       format: ['prometheus']
     static_configs:
-      - targets: ['172.20.0.1:4646']
+      - targets: ['${NOMAD_ADDR}']
 
   - job_name: atlas
     static_configs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,19 +22,45 @@ services:
       - "127.0.0.1:9090:9090"
     expose:
       - "9090"
+    environment:
+      # Host:port of the Nomad agent serving /v1/metrics. Interpolated into
+      # /etc/prometheus/prometheus.yml at container start (see entrypoint below)
+      # so the gateway IP is sourced from .env instead of being hardcoded in
+      # the static config file. Closes #217.
+      NOMAD_ADDR: ${NOMAD_ADDR:-172.20.0.1:4646}
     volumes:
-      - ./configs/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./configs/prometheus.yml:/etc/prometheus/prometheus.yml.tmpl:ro
       - ./rules:/etc/prometheus/rules:ro
       - ./certs/prometheus.crt:/etc/prometheus/tls/prometheus.crt:ro
       - ./certs/prometheus.key:/etc/prometheus/tls/prometheus.key:ro
       - ./certs/ca.crt:/etc/prometheus/tls/ca.crt:ro
       - prometheus_data:/prometheus
+    tmpfs:
+      # Writable scratch for the rendered prometheus.yml (the template is
+      # mounted read-only). Sized small — only one tiny YAML file lives here.
+      - /run/prometheus:size=1m,mode=0700,uid=65534,gid=65534
+    # Render the env-var placeholders in prometheus.yml.tmpl into a writable
+    # tmpfs file, then exec the official entrypoint. Using `sed` (busybox-
+    # provided in prom/prometheus) avoids pulling envsubst/gettext into the
+    # image. The `set -eu` ensures startup fails loudly if NOMAD_ADDR is
+    # missing rather than silently scraping an empty target.
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        : "$${NOMAD_ADDR:?NOMAD_ADDR is required (see .env.example)}"
+        sed "s|\$${NOMAD_ADDR}|$${NOMAD_ADDR}|g" \
+          /etc/prometheus/prometheus.yml.tmpl \
+          > /run/prometheus/prometheus.yml
+        exec /bin/prometheus "$$@"
+      - "prometheus"
     command:
-      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--config.file=/run/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"
       - "--web.console.libraries=/usr/share/prometheus/console_libraries"
       - "--web.console.templates=/usr/share/prometheus/consoles"
-      - "--web.config.file=/etc/prometheus/prometheus.yml"
+      - "--web.config.file=/run/prometheus/prometheus.yml"
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:9090/-/ready"]
       interval: 30s


### PR DESCRIPTION
## Summary

- Replaces the last hardcoded WSL2 host-gateway IP in `configs/prometheus.yml` (`172.20.0.1:4646` on the `nomad` scrape job) with a `${NOMAD_ADDR}` placeholder.
- The `prometheus` service in `docker-compose.yml` now mounts the file as `prometheus.yml.tmpl`, exposes a small `/run/prometheus` tmpfs, and runs an `sh -c` entrypoint that renders the template with busybox `sed` before `exec`-ing `/bin/prometheus`. `NOMAD_ADDR` is required at startup (`set -eu` + `:?`) so a missing value fails loud instead of silently scraping nothing.
- `.env.example` documents `NOMAD_ADDR` with the same `172.20.0.1:4646` default the file used to hardcode, keeping existing operator setups working with no `.env` edit.

This finishes the work begun in #53 — `docker-compose.yml` was already `.env`-driven, but `configs/prometheus.yml` had retained one hardcoded gateway address.

Closes #217.

## Test plan

- [x] `yamllint` (same args as CI) on `configs/prometheus.yml` and `docker-compose.yml`: exit 0.
- [x] `pytest tests/test_configs.py tests/test_alertmanager_config.py` — 83 passed.
- [x] `bash scripts/check-env-example.sh` — OK: all 17 compose variable(s) documented.
- [x] `docker run --rm -v ./configs/prometheus.yml:/etc/prometheus/prometheus.yml.tmpl:ro -e NOMAD_ADDR=10.0.0.5:4646 prom/prometheus:v2.54.1 ...` rendered correctly and `promtool check config` on the rendered file reports `SUCCESS` (after stripping the pre-existing `tls_server_config` sentinel block that `promtool` rejects on `main` too).
- [ ] CI (yamllint, docker compose config, tests) on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)