### PR TITLE
fix(exporter): hi_jetstream_events_total is a Counter (#172)

### DIFF
--- a/jetstream-consumer/consumer.py
+++ b/jetstream-consumer/consumer.py
@@ -91,24 +91,29 @@ def _update_task_latency(payload: bytes, subject: str) -> None:
 def _render_metrics() -> str:
     lines: list[str] = []
 
-    def gauge(name: str, value: float | int, labels: dict[str, str] | None = None) -> None:
+    def _emit(name: str, mtype: str, value: float | int, labels: dict[str, str] | None = None) -> None:
+        lines.append(f"# TYPE {name} {mtype}")
         if labels:
             lstr = ",".join(f'{k}="{v}"' for k, v in labels.items())
-            lines.append(f"# TYPE {name} gauge")
             lines.append(f"{name}{{{lstr}}} {value}")
         else:
-            lines.append(f"# TYPE {name} gauge")
             lines.append(f"{name} {value}")
+
+    def gauge(name: str, value: float | int, labels: dict[str, str] | None = None) -> None:
+        _emit(name, "gauge", value, labels)
+
+    def counter(name: str, value: float | int, labels: dict[str, str] | None = None) -> None:
+        _emit(name, "counter", value, labels)
 
     with _lock:
         for (prefix, etype), count in _event_counts.items():
-            gauge(
+            counter(
                 "hi_jetstream_events_total",
                 count,
                 {"subject_prefix": prefix, "event_type": etype},
             )
         for stream, seq in _last_seq.items():
-            gauge("hi_jetstream_consumer_last_seq", seq, {"stream": stream})
+            counter("hi_jetstream_consumer_last_seq", seq, {"stream": stream})
         for status, (total_lat, count) in _latency_accum.items():
             mean = total_lat / count if count > 0 else 0.0
             gauge("hi_jetstream_task_latency_seconds", mean, {"status": status})

--- a/tests/test_jetstream_consumer.py
+++ b/tests/test_jetstream_consumer.py
@@ -235,11 +235,37 @@ class TestRenderMetrics:
         output = consumer._render_metrics()
         assert 'hi_jetstream_events_total{subject_prefix="hi.agents",event_type="created"} 3' in output
 
+    def test_events_total_typed_as_counter(self, consumer):
+        with consumer._lock:
+            consumer._event_counts[("hi.agents", "created")] = 3
+        output = consumer._render_metrics()
+        assert "# TYPE hi_jetstream_events_total counter" in output
+        assert "# TYPE hi_jetstream_events_total gauge" not in output
+
     def test_includes_last_seq(self, consumer):
         with consumer._lock:
             consumer._last_seq["hi_agents"] = 100
         output = consumer._render_metrics()
         assert 'hi_jetstream_consumer_last_seq{stream="hi_agents"} 100' in output
+
+    def test_last_seq_typed_as_counter(self, consumer):
+        with consumer._lock:
+            consumer._last_seq["hi_agents"] = 100
+        output = consumer._render_metrics()
+        assert "# TYPE hi_jetstream_consumer_last_seq counter" in output
+        assert "# TYPE hi_jetstream_consumer_last_seq gauge" not in output
+
+    def test_latency_remains_gauge(self, consumer):
+        with consumer._lock:
+            consumer._latency_accum["completed"] = (20.0, 2)
+        output = consumer._render_metrics()
+        assert "# TYPE hi_jetstream_task_latency_seconds gauge" in output
+
+    def test_connected_remains_gauge(self, consumer):
+        with consumer._lock:
+            consumer._connected = 1
+        output = consumer._render_metrics()
+        assert "# TYPE hi_jetstream_consumer_connected gauge" in output
 
     def test_includes_latency(self, consumer):
         with consumer._lock:


### PR DESCRIPTION
## Summary

- Render `hi_jetstream_events_total` and `hi_jetstream_consumer_last_seq` as Prometheus `counter` types instead of `gauge`. Both values already accumulate monotonically in the consumer (`_event_counts[k] += 1`, `_last_seq` is a high-water mark), so only the exposition `# TYPE` line was wrong.
- This restores counter-reset detection for `rate()` queries — after a consumer restart, the value drops to 0; with the old `gauge` type, `rate()` produced a misleading spike instead of treating the drop as a reset.
- `hi_jetstream_task_latency_seconds`, `hi_jetstream_consumer_connected`, and `hi_jetstream_consumer_scrape_timestamp` remain gauges (they are instantaneous values, not monotonic).

Closes #172

## Test plan

- [x] `pytest tests/test_jetstream_consumer.py` — 35/35 pass
- [x] New assertions lock in `# TYPE hi_jetstream_events_total counter` and `# TYPE hi_jetstream_consumer_last_seq counter`
- [x] Negative assertions ensure the old `gauge` TYPE line is no longer emitted for these metrics
- [x] Gauge-typed metrics (`hi_jetstream_task_latency_seconds`, `hi_jetstream_consumer_connected`) retain their `gauge` TYPE lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>