### PR TITLE
docs(readme): add standardized CI/CD badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ProjectArgus
 
+[![CI](https://github.com/HomericIntelligence/ProjectArgus/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectArgus/actions/workflows/ci.yml)
+
 Observability stack for the HomericIntelligence mesh. ProjectArgus provides
 centralized metrics collection, log aggregation, and dashboards for all
 components of the HomericIntelligence ecosystem.


### PR DESCRIPTION
Part of HomericIntelligence/Odysseus#352

Adds a CI workflow status badge to the top of the README, standardizing badge presentation across the HomericIntelligence ecosystem.

Generated with [Claude Code](https://claude.com/claude-code)