### PR TITLE
fix(ci): add YAML document start markers to configs

### DIFF
--- a/configs/loki.yml
+++ b/configs/loki.yml
@@ -1,3 +1,4 @@
+---
 auth_enabled: false
 
 server:

--- a/configs/prometheus.yml
+++ b/configs/prometheus.yml
@@ -1,3 +1,4 @@
+---
 global:
   scrape_interval: 15s
   evaluation_interval: 15s

--- a/configs/promtail.yml
+++ b/configs/promtail.yml
@@ -1,3 +1,4 @@
+---
 server:
   http_listen_port: 9080
   grpc_listen_port: 0


### PR DESCRIPTION
Fixes Required Checks CI failure caused by missing `---` document start in promtail.yml, loki.yml, and prometheus.yml.

Closes the yamllint `document-start` violations.