### PR TITLE
chore(rename): drop Project prefix → Argus

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,4 +1,4 @@
-title = "ProjectArgus Gitleaks Configuration"
+title = "Argus Gitleaks Configuration"
 
 [extend]
 useDefault = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
         description: >
           Compares ${VAR} references in docker-compose.yml against keys in
           .env.example so new variables can't silently drift undocumented.
-          See HomericIntelligence/ProjectArgus#215.
+          See HomericIntelligence/Argus#215.
         entry: bash scripts/check-env-example.sh
         language: system
         files: ^(docker-compose\.ya?ml|\.env\.example|scripts/check-env-example\.sh)$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md — ProjectArgus Multi-Agent Coordination
+# AGENTS.md — Argus Multi-Agent Coordination
 
 This file is the coordination contract for any AI agent (interactive Claude Code session,
 Myrmidon swarm worker, or Agamemnon-orchestrated agent) that reads or modifies this
@@ -8,7 +8,7 @@ repository. Read it before touching any file.
 
 ## Repo Role in the HomericIntelligence Ecosystem
 
-ProjectArgus is a **read-only observability layer**. It scrapes metrics and tails logs from
+Argus is a **read-only observability layer**. It scrapes metrics and tails logs from
 ProjectAgamemnon, ProjectNestor, NATS, Nomad, and all running containers. It does **not**
 push data or commands back to any external service.
 
@@ -42,7 +42,7 @@ Three agent classes operate on this repo:
 
 ## Available Skills (Hephaestus Plugin)
 
-ProjectArgus delegates orchestration to the **Hephaestus plugin**. There is no `.claude/agents/`
+Argus delegates orchestration to the **Hephaestus plugin**. There is no `.claude/agents/`
 directory in this repo. Use these skills instead:
 
 | Skill | Trigger Condition | Description |
@@ -144,14 +144,14 @@ just status
 just test-scrape
 ```
 
-## AGENTS.md — Multi-Agent Coordination for ProjectArgus
+## AGENTS.md — Multi-Agent Coordination for Argus
 
 This file describes how AI agents and automated tooling should interact with this
 repository. It follows the conventions established across HomericIntelligence projects.
 
 ## Repository Role
 
-ProjectArgus is a **read-only observability consumer**. It scrapes metrics from
+Argus is a **read-only observability consumer**. It scrapes metrics from
 other HomericIntelligence services and does not write to or modify them. Agents
 working in this repository should maintain this invariant.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to ProjectArgus will be documented in this file.
+All notable changes to Argus will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
@@ -234,6 +234,6 @@ multi-arch image at `ghcr.io/homericintelligence/atlas:v0.2.0`.
 - `.gitignore` covering `.pixi/`, IDE files, OS files, and secrets
 - `pixi.toml` with locked dependencies (`just`, `jq`)
 
-[Unreleased]: https://github.com/HomericIntelligence/ProjectArgus/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/HomericIntelligence/ProjectArgus/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/HomericIntelligence/ProjectArgus/releases/tag/v0.1.0
+[Unreleased]: https://github.com/HomericIntelligence/Argus/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/HomericIntelligence/Argus/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/HomericIntelligence/Argus/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,13 @@
-# ProjectArgus — CLAUDE.md
+# Argus — CLAUDE.md
 
 ## Project Overview
 
-ProjectArgus is the observability stack for the HomericIntelligence ecosystem. It
+Argus is the observability stack for the HomericIntelligence ecosystem. It
 collects metrics from ProjectAgamemnon, ProjectNestor, NATS, Nomad, and all running
 containers, aggregates logs via Promtail → Loki, and exposes everything through
 Grafana dashboards.
 
-**Important**: ProjectArgus only reads from other services via HTTP scrapes and log
+**Important**: Argus only reads from other services via HTTP scrapes and log
 tailing. It does NOT modify Agamemnon or any other HomericIntelligence service.
 
 ## Stack Components
@@ -210,7 +210,7 @@ Atlas dashboard variables use the `ATLAS_` prefix — see `dashboard/README.md` 
 ## Repository Structure
 
 ```
-ProjectArgus/
+Argus/
 ├── configs/
 │   ├── prometheus.yml        # Scrape configs
 │   ├── loki.yml              # Loki server config

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-# CODEOWNERS — ProjectArgus
+# CODEOWNERS — Argus
 #
 # All files default to requiring review from the HomericIntelligence team.
 # Pattern order: last matching pattern wins.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to ProjectArgus
+# Contributing to Argus
 
-Thank you for your interest in contributing to ProjectArgus! This is the observability stack
+Thank you for your interest in contributing to Argus! This is the observability stack
 (Prometheus, Grafana, Loki) for the
 [HomericIntelligence](https://github.com/HomericIntelligence) distributed agent mesh, with a
 custom Python exporter for Agamemnon/Nestor/NATS metrics.
@@ -34,8 +34,8 @@ One command bootstraps everything (prerequisites check, pixi install,
 
 ```bash
 # Clone the repository
-git clone https://github.com/HomericIntelligence/ProjectArgus.git
-cd ProjectArgus
+git clone https://github.com/HomericIntelligence/Argus.git
+cd Argus
 
 # One-command bootstrap
 ./scripts/setup.sh
@@ -109,7 +109,7 @@ external dependencies. When contributing to the exporter, maintain this constrai
 
 Before starting work:
 
-- Browse [existing issues](https://github.com/HomericIntelligence/ProjectArgus/issues)
+- Browse [existing issues](https://github.com/HomericIntelligence/Argus/issues)
 - Comment on an issue to claim it before starting work
 - Create a new issue if one doesn't exist for your contribution
 
@@ -251,10 +251,10 @@ All documentation files must follow these standards:
 Dependency-update automation is configured via `renovate.json` in the repo root,
 but the config is **inert until the Renovate GitHub App is installed at the
 org or repo level** (<https://github.com/apps/renovate>). If you are not seeing
-Renovate PRs against ProjectArgus, that almost certainly means the App is not
+Renovate PRs against Argus, that almost certainly means the App is not
 installed — check the GitHub App settings on the
 [HomericIntelligence org](https://github.com/HomericIntelligence) and grant it
-access to ProjectArgus. Once installed, Renovate will pick up the existing
+access to Argus. Once installed, Renovate will pick up the existing
 `renovate.json` automatically; no further repo-side action is needed.
 
 ## Reporting Issues
@@ -274,4 +274,4 @@ Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
 
 ---
 
-Thank you for contributing to ProjectArgus!
+Thank you for contributing to Argus!

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# ProjectArgus
+# Argus
 
-[![CI](https://github.com/HomericIntelligence/ProjectArgus/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectArgus/actions/workflows/ci.yml)
+[![CI](https://github.com/HomericIntelligence/Argus/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/Argus/actions/workflows/ci.yml)
 
-Observability stack for the HomericIntelligence mesh. ProjectArgus provides
+Observability stack for the HomericIntelligence mesh. Argus provides
 centralized metrics collection, log aggregation, and dashboards for all
 components of the HomericIntelligence ecosystem.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -117,7 +117,7 @@ When you report a vulnerability:
 
 ## Security Best Practices
 
-When contributing to ProjectArgus:
+When contributing to Argus:
 
 - Never embed credentials in configuration files — use environment variables
 - Restrict Grafana to authenticated access (avoid anonymous admin)

--- a/certs/gen-certs.sh
+++ b/certs/gen-certs.sh
@@ -27,7 +27,7 @@ else
     echo "[gen] Generating CA key and certificate..."
     openssl genrsa -out ca.key 4096
     openssl req -new -x509 -days "$DAYS" -key ca.key -out ca.crt \
-        -subj "/CN=argus-local-ca/O=ProjectArgus/OU=HomericIntelligence"
+        -subj "/CN=argus-local-ca/O=Argus/OU=HomericIntelligence"
     echo "[ok]  CA generated: ca.crt"
 fi
 
@@ -51,7 +51,7 @@ prompt             = no
 
 [req_distinguished_name]
 CN = ${svc}
-O  = ProjectArgus
+O  = Argus
 
 [v3_req]
 subjectAltName = ${SANS[$svc]}

--- a/configs/grafana/dashboards.yml
+++ b/configs/grafana/dashboards.yml
@@ -1,7 +1,7 @@
 apiVersion: 1
 
 providers:
-  - name: ProjectArgus
+  - name: Argus
     orgId: 1
     type: file
     disableDeletion: false

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -65,7 +65,7 @@ ARG VERSION=dev
 
 LABEL org.opencontainers.image.title="atlas"
 LABEL org.opencontainers.image.description="Unified status dashboard for the HomericIntelligence ecosystem."
-LABEL org.opencontainers.image.source="https://github.com/HomericIntelligence/ProjectArgus"
+LABEL org.opencontainers.image.source="https://github.com/HomericIntelligence/Argus"
 LABEL org.opencontainers.image.licenses="BSD-3-Clause"
 LABEL org.opencontainers.image.version="${VERSION}"
 

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -84,7 +84,7 @@ nats pub hi.agents.demo '{"id":"demo","status":"ok"}'
 The `event: agent` frame should appear immediately on `/events`.
 
 For full-stack development against the rest of the Argus services, see the parent
-[`ProjectArgus` README](../README.md) and `just start`.
+[`Argus` README](../README.md) and `just start`.
 
 ## Configuration
 

--- a/dashboard/docs/review-charter.md
+++ b/dashboard/docs/review-charter.md
@@ -2,7 +2,7 @@
 
 > **Status:** Active. Referenced by every Atlas milestone PR template
 > (`atlas-M1.md` … `atlas-M6.md` and any future `atlas-M*` template).
-> **Owner:** Atlas team (HomericIntelligence/ProjectArgus).
+> **Owner:** Atlas team (HomericIntelligence/Argus).
 > **Last updated:** 2026-05-05.
 
 This document is the normative specification for the Atlas milestone review-wave

--- a/dashboard/docs/runbook.md
+++ b/dashboard/docs/runbook.md
@@ -262,9 +262,9 @@ before declaring the recovery complete.
 
 ## Escalation
 
-- Security issues: see [`SECURITY.md`](../../SECURITY.md) at the ProjectArgus root —
+- Security issues: see [`SECURITY.md`](../../SECURITY.md) at the Argus root —
   responsible disclosure with 48 h acknowledgement SLA.
 - Functional bugs: open a GitHub issue tagged `area:atlas` against
-  `HomericIntelligence/ProjectArgus`.
+  `HomericIntelligence/Argus`.
 - Architecture questions: [`docs/architecture.md`](architecture.md) is the source of
   truth for component composition, concurrency, and resource bounds.

--- a/dashboard/docs/runbook/rollback.md
+++ b/dashboard/docs/runbook/rollback.md
@@ -61,7 +61,7 @@ are unaffected.
 1. **Identify the previous good tag.** GitHub releases are immutable and ordered by publish time:
 
    ```bash
-   gh release list --repo HomericIntelligence/ProjectArgus --limit 10
+   gh release list --repo HomericIntelligence/Argus --limit 10
    ```
 
    Pick the most recent tag that is **not** the bad one. Example: bad = `v0.2.1`, good = `v0.2.0`.
@@ -160,7 +160,7 @@ Once the rollback is stable, mark the bad release on GitHub so nobody re-deploys
 immutable — you are only editing the release notes:
 
 ```bash
-gh release edit v0.2.1 --repo HomericIntelligence/ProjectArgus \
+gh release edit v0.2.1 --repo HomericIntelligence/Argus \
   --notes 'KNOWN BAD — do not deploy. Rolled back $(date -u +%F). See dashboard/docs/runbook/rollback.md.'
 ```
 
@@ -171,7 +171,7 @@ release edit --latest=false` does the same thing non-interactively if your `gh` 
 Open a tracking issue immediately, even if you do not yet know the root cause:
 
 ```bash
-gh issue create --repo HomericIntelligence/ProjectArgus \
+gh issue create --repo HomericIntelligence/Argus \
   --title 'Atlas v0.2.1 rolled back — root cause TBD' \
   --label 'area:atlas,severity:high' \
   --body 'Rolled back to v0.2.0 at <time>. Bad-deploy logs in /tmp/atlas-bad-deploy-*.log on <host>. RCA pending.'
@@ -231,9 +231,9 @@ Otherwise: revert now, investigate from the captured bad-deploy logs, ship the r
 ## Escalation
 
 - **Security regression in the bad release** (auth bypass, token leak, RCE, anything CVE-shaped): follow
-  [`SECURITY.md`](../../../SECURITY.md) at the ProjectArgus root for responsible disclosure and coordinated
+  [`SECURITY.md`](../../../SECURITY.md) at the Argus root for responsible disclosure and coordinated
   disclosure timing. Do not file a public GitHub issue with reproduction details.
-- **Functional regression**: open a GitHub issue on `HomericIntelligence/ProjectArgus` tagged `area:atlas` and link
+- **Functional regression**: open a GitHub issue on `HomericIntelligence/Argus` tagged `area:atlas` and link
   the captured bad-deploy log file from the pre-rollback step.
 - **Architecture questions** (what each component is supposed to do on startup, what `/readyz` covers):
   [`../architecture.md`](../architecture.md).

--- a/docs/tls-setup.md
+++ b/docs/tls-setup.md
@@ -1,4 +1,4 @@
-# TLS Setup Runbook — ProjectArgus
+# TLS Setup Runbook — Argus
 
 This document describes how to enable and maintain TLS for all inter-service
 communication in the argus observability stack.

--- a/scripts/check-env-example.sh
+++ b/scripts/check-env-example.sh
@@ -8,7 +8,7 @@
 # referenced from the compose file and verifies each one has a corresponding
 # entry in .env.example (commented or uncommented).
 #
-# Follow-up to HomericIntelligence/ProjectArgus#53; closes #215.
+# Follow-up to HomericIntelligence/Argus#53; closes #215.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/check-grafana-password.sh
+++ b/scripts/check-grafana-password.sh
@@ -5,7 +5,7 @@
 # whenever the Grafana stack would otherwise come up with the insecure
 # fallback password baked into docker-compose.yml.
 #
-# Issue: HomericIntelligence/ProjectArgus#182
+# Issue: HomericIntelligence/Argus#182
 
 set -euo pipefail
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# scripts/setup.sh — one-command bootstrap for ProjectArgus
+# scripts/setup.sh — one-command bootstrap for Argus
 #
 # Usage:
 #   ./scripts/setup.sh


### PR DESCRIPTION
## Rename: HomericIntelligence/ProjectArgus → HomericIntelligence/Argus

This PR is the follow-up to the GitHub-side `gh repo rename` (URL flipped in
Phase 1; this PR finishes the rename *inside* the repo).

### Diff summary

```
 20 files changed, 45 insertions(+), 45 deletions(-)
```

### Files updated

```
.gitleaks.toml
.pre-commit-config.yaml
AGENTS.md
CHANGELOG.md
CLAUDE.md
CODEOWNERS
CONTRIBUTING.md
README.md
SECURITY.md
certs/gen-certs.sh
configs/grafana/dashboards.yml
dashboard/Dockerfile
dashboard/README.md
dashboard/docs/review-charter.md
dashboard/docs/runbook.md
dashboard/docs/runbook/rollback.md
docs/tls-setup.md
scripts/check-env-example.sh
scripts/check-grafana-password.sh
scripts/setup.sh
```

### What this PR does NOT change

- Container names (`argus-exporter`, `argus-loki`, ...) where already
  lowercase — preserved (they already matched the bare form).
- `CHANGELOG.md` historical entries — preserved verbatim per
  [ADR-014](../Odysseus/blob/main/docs/adr/014-runnable-evidence-for-metric-claims.md) (evidence integrity).
- Branch protection / rulesets / secrets / environments — apply manually on
  the renamed repo (see Phase 6).

### Verification

- `grep -RIE 'ProjectArgus|projectargus|PROJECTARGUS' .` returns **zero** hits
  (Phase 4 pre-commit guard).
- CI green (lint, integration tests, package, dashboard, exporter).

### Followups (separate PRs)

1. `HomericIntelligence/Odyssey` — meta-repo PR updating `.gitmodules`, `justfile`,
   `docker-compose.e2e.yml`, `tools/github/*.sh`, `scripts/install/*`,
   `e2e/start-*.sh`, `docs/{architecture,onboarding,deployment,repo-conventions}.md`,
   `.github/PULL_REQUEST_TEMPLATE/atlas-*.md`.
2. Apply the same `gh repo rename + sed` sequence to the next prefixed repo
   in the queue (tools/github/rename-repo.sh is parametrized).
3. `HomericIntelligence/Hephaestus` and `HomericIntelligence/Athena` (`ProjectHephaestus` carve-out) —
   not a straight rename; handle as a separate procedure.