### PR TITLE
chore(settings): swap hephaestus plugin → Athena marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,28 @@
 {
   "enabledPlugins": {
-    "hephaestus@ProjectHephaestus": true
+    "advise@Athena": true,
+    "brainstorm@Athena": true,
+    "code-review@Athena": true,
+    "create-reusable-utilities@Athena": true,
+    "finish-branch@Athena": true,
+    "git-worktrees@Athena": true,
+    "github-actions-python-cicd@Athena": true,
+    "learn@Athena": true,
+    "myrmidon-swarm@Athena": true,
+    "python-repo-modernization@Athena": true,
+    "repo-analyze@Athena": true,
+    "repo-analyze-full@Athena": true,
+    "repo-analyze-quick@Athena": true,
+    "repo-analyze-quick-full@Athena": true,
+    "repo-analyze-strict@Athena": true,
+    "repo-analyze-strict-full@Athena": true,
+    "review-pr-strict@Athena": true,
+    "skill-advisor@Athena": true,
+    "systematic-debugging@Athena": true,
+    "test-driven-development@Athena": true,
+    "tidy@Athena": true,
+    "verification@Athena": true,
+    "worktree-cleanup@Athena": true
   },
   "permissions": {
     "deny": [
@@ -14,5 +36,13 @@
       "Bash(git clean -fdx *)"
     ]
   },
-  "env": {}
+  "env": {},
+  "extraKnownMarketplaces": {
+    "Athena": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/HomericIntelligence/Athena.git"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Migrate `.claude/settings.json` from the stale `hephaestus@ProjectHephaestus` plugin to the new `HomericIntelligence/Athena` marketplace.

## Changes
- Removed `hephaestus@ProjectHephaestus` from `enabledPlugins`.
- Enabled the 23 `<skill>@Athena` per-skill plugins.
- Registered the `Athena` marketplace in `extraKnownMarketplaces`.
- Preserved `permissions.deny` (8 entries) and `env` unchanged.

Verified: valid JSON, hephaestus key gone, exactly 23 @Athena keys, Athena marketplace present, all other keys preserved.

Closes #547