### PR TITLE
ci: prepare Argus for main merge queue

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   push:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
@@ -57,7 +59,8 @@ jobs:
           fi
           if grep -nE '^[[:space:]]*continue-on-error:[[:space:]]*true[[:space:]]*$' "${files[@]}"; then
             echo ""
-            echo '::error::Found "continue-on-error: true" above. Fix the root cause per HomericIntelligence/Odysseus#280.'
+            echo \
+              '::error::Found "continue-on-error: true" above. Fix the root cause per HomericIntelligence/Odysseus#280.'
             exit 1
           fi
           echo 'OK: no "continue-on-error: true" found'
@@ -239,7 +242,9 @@ jobs:
             docker compose config --quiet
           fi
           # Validate all YAML files with yamllint (the canonical config-repo unit test)
-          find . -path './.git' -prune -o \( -name "*.yml" -o -name "*.yaml" \) -print | xargs yamllint -c .yamllint.yaml
+          find . -path './.git' -prune -o \
+            \( -name "*.yml" -o -name "*.yaml" \) -print \
+            | xargs yamllint -c .yamllint.yaml
       - name: Cache pixi environment
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
@@ -358,8 +363,9 @@ jobs:
           GITLEAKS_VERSION=8.30.1
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')
           ARCH=$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')
+          GITLEAKS_URL="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
           curl -sSfL \
-            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_${OS}_${ARCH}.tar.gz" \
+            "${GITLEAKS_URL}/gitleaks_${GITLEAKS_VERSION}_${OS}_${ARCH}.tar.gz" \
             | tar -xz -C /usr/local/bin gitleaks
           gitleaks version
 
@@ -380,7 +386,7 @@ jobs:
 
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: gitleaks-report
           path: gitleaks.sarif

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: ["main", "feature/**", "fix/**", "chore/**"]
   pull_request:
     branches: ["main"]
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,6 +221,8 @@ gh pr create --title "[Type] Brief description" --body "Closes #<issue-number>"
 ### Never Push Directly to Main
 
 The `main` branch is protected. All changes must go through pull requests.
+The required-check contract, staged merge-queue policy, and operator activation
+procedure are documented in [Merge Queue](docs/ci/merge-queue.md).
 
 ## Code Review
 

--- a/docs/ci/merge-queue.md
+++ b/docs/ci/merge-queue.md
@@ -1,0 +1,127 @@
+# Merge Queue
+
+Argus prepares GitHub Actions for a repository-level merge queue on `main`, but
+the queue is intentionally activated in a separate operator step. This staged
+rollout implements [Argus#550](https://github.com/HomericIntelligence/Argus/issues/550)
+under the policy approved in
+[Odysseus#386](https://github.com/HomericIntelligence/Odysseus/issues/386).
+
+## Required-check contract
+
+Two active repository rulesets supply the merge-blocking status-check contract:
+
+- `homeric-main-baseline`: `lint`, `unit-tests`, `integration-tests`,
+  `security/dependency-scan`, `security/secrets-scan`, `config-validate`,
+  `schema-validation`, `deps/version-sync`, `test`, `package`, `install`,
+  `release`, and `build`.
+- `homeric-main-extras`: `Validate configs`.
+
+The `Required Checks` and `CI` workflows emit these contexts. Both workflows
+must retain their existing `pull_request` and `push` behavior and must run for
+`merge_group` events of type `checks_requested`. GitHub evaluates the same
+required contexts on the synthetic merge-group SHA; the queue cannot advance if
+either workflow fails to run.
+
+## Approved queue policy
+
+The activation step must add exactly this rule to a repository ruleset that
+targets only `refs/heads/main`:
+
+```json
+{
+  "type": "merge_queue",
+  "parameters": {
+    "check_response_timeout_minutes": 60,
+    "grouping_strategy": "ALLGREEN",
+    "max_entries_to_build": 10,
+    "max_entries_to_merge": 5,
+    "merge_method": "SQUASH",
+    "min_entries_to_merge": 1,
+    "min_entries_to_merge_wait_minutes": 5
+  }
+}
+```
+
+This rule layers on top of the existing required-status-check rules. It does
+not replace, rename, or remove any required context or other protection.
+
+## Post-merge activation
+
+Do not activate before all of the following are true:
+
+1. The workflow and validation changes from Argus issue #550 are merged to
+   `main`.
+2. Both required workflows are present on `main` with the
+   `merge_group/checks_requested` trigger.
+3. An operator is ready to run and observe one representative queued PR through
+   the complete check cycle.
+
+Argus does not have a canonical repository-owned ruleset automation file. The
+operator must therefore create a dedicated active repository ruleset named
+`homeric-main-merge-queue`, targeting only `refs/heads/main`. Mirror the live
+`homeric-main-baseline` bypass actors so queue activation does not change bypass
+behavior. At the issue #550 baseline, that is repository role `5` in
+`pull_request` mode. Re-read the baseline immediately before activation and
+stop if it has drifted. A dedicated ruleset leaves both existing rulesets
+unchanged and makes rollback independent of the required-check contract.
+
+The equivalent create-ruleset payload is:
+
+```json
+{
+  "name": "homeric-main-merge-queue",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": ["refs/heads/main"]
+    }
+  },
+  "rules": [
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "check_response_timeout_minutes": 60,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 10,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5
+      }
+    }
+  ]
+}
+```
+
+Save the payload to `/tmp/argus-merge-queue-ruleset.json`, then create the
+ruleset with `POST /repos/HomericIntelligence/Argus/rulesets` only after the
+activation gates above are satisfied:
+
+```bash
+gh api --method POST repos/HomericIntelligence/Argus/rulesets \
+  --input /tmp/argus-merge-queue-ruleset.json
+```
+
+Immediately read back the effective rules on `main` and confirm:
+
+- the merge-queue parameters exactly match the approved policy;
+- all 14 required contexts listed above remain present across the two existing
+  rulesets;
+- required review-thread resolution and every unrelated protection still
+  apply; and
+- a queued smoke PR produces both required workflow runs on a `merge_group`
+  event and merges by squash only after all required checks pass.
+
+If read-back or the smoke cycle fails, disable the dedicated
+`homeric-main-merge-queue` ruleset. Do not edit the two existing required-check
+rulesets as part of rollback. Record the live ruleset response, workflow event,
+and queued merge result on Argus issue #550.

--- a/tests/smoke/test_required_workflow_properties.py
+++ b/tests/smoke/test_required_workflow_properties.py
@@ -1,6 +1,49 @@
 from pathlib import Path
 
-WORKFLOW = Path(__file__).parent.parent.parent / ".github" / "workflows" / "_required.yml"
+import yaml
+
+ROOT = Path(__file__).parent.parent.parent
+WORKFLOW = ROOT / ".github" / "workflows" / "_required.yml"
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+MERGE_QUEUE_RUNBOOK = ROOT / "docs" / "ci" / "merge-queue.md"
+
+# Live required contexts on main, captured from the active repository rulesets
+# for issue #550. Keep this map aligned with the supplying workflow so a trigger
+# edit cannot silently strand a required context on merge-group SHAs.
+REQUIRED_CONTEXTS = {
+    WORKFLOW: {
+        "lint",
+        "unit-tests",
+        "integration-tests",
+        "security/dependency-scan",
+        "security/secrets-scan",
+        "config-validate",
+        "schema-validation",
+        "deps/version-sync",
+    },
+    CI_WORKFLOW: {
+        "Validate configs",
+        "test",
+        "package",
+        "install",
+        "release",
+        "build",
+    },
+}
+EXISTING_TRIGGERS = {
+    WORKFLOW: {
+        "pull_request": {"branches": ["main"]},
+        "push": {"branches": ["main"]},
+    },
+    CI_WORKFLOW: {
+        "pull_request": {"branches": ["main"]},
+        "push": {"branches": ["main", "feature/**", "fix/**", "chore/**"]},
+    },
+}
+
+
+def _load_workflow(path: Path) -> dict:
+    return yaml.load(path.read_text(), Loader=yaml.BaseLoader)
 
 
 def test_required_workflow_exists() -> None:
@@ -13,3 +56,52 @@ def test_unit_tests_job_invokes_pytest() -> None:
         "unit-tests job in _required.yml does not invoke pytest — "
         "test regressions will reach main undetected"
     )
+
+
+def test_required_workflows_support_merge_queue_events() -> None:
+    for path in REQUIRED_CONTEXTS:
+        triggers = _load_workflow(path)["on"]
+
+        for event, expected_config in EXISTING_TRIGGERS[path].items():
+            assert triggers.get(event) == expected_config, (
+                f"{path.name} changed its existing {event} behavior"
+            )
+        assert triggers.get("merge_group") == {"types": ["checks_requested"]}, (
+            f"{path.name} must run for merge_group/checks_requested"
+        )
+
+
+def test_live_required_contexts_still_have_supplying_jobs() -> None:
+    for path, expected_contexts in REQUIRED_CONTEXTS.items():
+        workflow = _load_workflow(path)
+        emitted_contexts = {
+            job.get("name", job_id) for job_id, job in workflow["jobs"].items()
+        }
+
+        missing = expected_contexts - emitted_contexts
+        assert not missing, (
+            f"{path.name} no longer emits required contexts: {sorted(missing)}"
+        )
+
+
+def test_merge_queue_activation_runbook_records_approved_policy() -> None:
+    content = MERGE_QUEUE_RUNBOOK.read_text()
+
+    for required_value in (
+        '"type": "merge_queue"',
+        '"check_response_timeout_minutes": 60',
+        '"grouping_strategy": "ALLGREEN"',
+        '"max_entries_to_build": 10',
+        '"max_entries_to_merge": 5',
+        '"merge_method": "SQUASH"',
+        '"min_entries_to_merge": 1',
+        '"min_entries_to_merge_wait_minutes": 5',
+    ):
+        assert required_value in content
+
+    assert "Do not activate before" in content
+    assert "Odysseus#386" in content
+    assert "POST /repos/HomericIntelligence/Argus/rulesets" in content
+    assert '"actor_id": 5' in content
+    assert '"actor_type": "RepositoryRole"' in content
+    assert '"bypass_mode": "pull_request"' in content


### PR DESCRIPTION
## Summary

- add `merge_group: checks_requested` to both workflows that supply Argus's 14 live required contexts
- preserve the existing `pull_request` and `push` filters and every required job name
- add focused regression coverage for workflow triggers, required contexts, and the approved queue policy
- document the staged post-merge activation and rollback procedure without changing live rulesets

## Live baseline

- inspected `main` at `e9f2c5af5888adcc1bce60e6bcb27889dabbd4d6`
- preserved active rulesets `homeric-main-baseline` and `homeric-main-extras`
- confirmed no live `merge_queue` rule existed before implementation

## Post-merge activation requirement

Do not activate the queue until this PR is merged and an operator is ready to observe a queued smoke PR. Then create the dedicated `homeric-main-merge-queue` repository ruleset for `refs/heads/main` using:

- merge method `SQUASH`
- grouping strategy `ALLGREEN`
- maximum 10 queue builds
- maximum 5 merged entries per group
- minimum 1 entry
- minimum wait 5 minutes
- required-check timeout 60 minutes
- the live `homeric-main-baseline` bypass actors, re-read immediately before activation

The exact `POST /repos/HomericIntelligence/Argus/rulesets` payload, read-back checks, smoke evidence, and rollback are in `docs/ci/merge-queue.md`. This implementation does not mutate live GitHub rulesets or enable the queue.

## Validation

- `pixi run test` — 331 passed, 1 skipped, 12 subtests passed; 99.40% coverage
- `pixi run pytest tests/smoke/test_required_workflow_properties.py -v --no-cov` — 5 passed
- `pixi run ruff check exporter/ tests/` — passed
- `pixi run ruff format --check tests/smoke/test_required_workflow_properties.py` — passed
- pinned pre-commit hooks on all changed files — Yamllint, Ruff, Markdownlint, and policy guards passed
- GitHub workflow JSON-schema validation — `ok -- validation done`
- `docker compose config --quiet` and `scripts/check-env-example.sh` — passed
- `just validate` — Promtail's containerized syntax leg could not run locally because this account cannot access `/var/run/docker.sock`; preceding env-documentation validation passed

Closes #550

Rollout tracker: https://github.com/HomericIntelligence/Odysseus/issues/386
