### PR TITLE
ci: prepare Argus for main merge queue

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   push:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
@@ -57,7 +59,8 @@ jobs:
           fi
           if grep -nE '^[[:space:]]*continue-on-error:[[:space:]]*true[[:space:]]*$' "${files[@]}"; then
             echo ""
-            echo '::error::Found "continue-on-error: true" above. Fix the root cause per HomericIntelligence/Odysseus#280.'
+            echo \
+              '::error::Found "continue-on-error: true" above. Fix the root cause per HomericIntelligence/Odysseus#280.'
             exit 1
           fi
           echo 'OK: no "continue-on-error: true" found'
@@ -239,7 +242,9 @@ jobs:
             docker compose config --quiet
           fi
           # Validate all YAML files with yamllint (the canonical config-repo unit test)
-          find . -path './.git' -prune -o \( -name "*.yml" -o -name "*.yaml" \) -print | xargs yamllint -c .yamllint.yaml
+          find . -path './.git' -prune -o \
+            \( -name "*.yml" -o -name "*.yaml" \) -print \
+            | xargs yamllint -c .yamllint.yaml
       - name: Cache pixi environment
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
@@ -358,8 +363,9 @@ jobs:
           GITLEAKS_VERSION=8.30.1
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')
           ARCH=$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')
+          GITLEAKS_URL="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
           curl -sSfL \
-            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_${OS}_${ARCH}.tar.gz" \
+            "${GITLEAKS_URL}/gitleaks_${GITLEAKS_VERSION}_${OS}_${ARCH}.tar.gz" \
             | tar -xz -C /usr/local/bin gitleaks
           gitleaks version
 
@@ -380,7 +386,7 @@ jobs:
 
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: gitleaks-report
           path: gitleaks.sarif

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: ["main", "feature/**", "fix/**", "chore/**"]
   pull_request:
     branches: ["main"]
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,6 +221,8 @@ gh pr create --title "[Type] Brief description" --body "Closes #<issue-number>"
 ### Never Push Directly to Main
 
 The `main` branch is protected. All changes must go through pull requests.
+The required-check contract, dedicated Argus queue ruleset, and staged operator
+procedure are documented in [Merge Queue](docs/ci/merge-queue.md).
 
 ## Code Review
 

--- a/docs/ci/merge-queue.md
+++ b/docs/ci/merge-queue.md
@@ -33,15 +33,18 @@ ruleset or any required context.
 
 ## Cross-repository automation boundary
 
-[Odysseus #416](https://github.com/HomericIntelligence/Odysseus/issues/416)
-tracks central activation automation. Until that automation is remediated and
-independently verified, generic baseline replacement must not target Argus.
-Any future central activation path must preserve Argus's two existing rulesets,
+[Odysseus #386](https://github.com/HomericIntelligence/Odysseus/issues/386) is
+the durable rollout umbrella, and
+[Odysseus PR #417](https://github.com/HomericIntelligence/Odysseus/pull/417) is
+the current central activation implementation. Until that implementation is
+merged and independently verified, generic baseline replacement must not target
+Argus. Any central activation path must preserve Argus's two existing rulesets,
 all 14 contexts, bypass actors, and unrelated protections while creating or
 updating only `homeric-main-merge-queue`.
 
-This Argus change does not resolve the cross-repository conflict. Do not mark it
-resolved until Odysseus #416 is remediated and its Argus behavior is verified.
+This Argus change does not complete the cross-repository rollout. Keep the
+umbrella issue open until Odysseus PR #417 and every repository activation have
+independent evidence, including verified Argus behavior.
 
 ## Approved queue policy
 
@@ -73,7 +76,8 @@ Do not activate the queue until all of these gates are satisfied:
    `merge_group/checks_requested` trigger.
 4. An operator is ready to observe a representative queued PR through the
    complete required-check cycle.
-5. Odysseus #416 automation is not being run against Argus.
+5. The activation path from Odysseus PR #417 has been independently verified
+   for Argus before it is run against this repository.
 
 ### 1. Look up and snapshot the exact existing rulesets
 
@@ -252,15 +256,46 @@ gh api --method PUT "repos/${REPO}/rulesets/${QUEUE_ID}" \
   -f enforcement=active \
   > /tmp/argus-merge-queue-ruleset.activated.json
 
-test "$(jq -r '.name' /tmp/argus-merge-queue-ruleset.activated.json)" \
-  = "${QUEUE_NAME}"
-test "$(jq -r '.enforcement' /tmp/argus-merge-queue-ruleset.activated.json)" \
-  = active
 ```
 
-### 5. Prove existing rules and effective contexts were preserved
+Do not trust the PUT response as final evidence. Continue directly to step 5
+and re-read the live policy before attempting a smoke PR.
+
+### 5. Re-read the exact queue policy and prove protections were preserved
 
 ```bash
+gh api "repos/${REPO}/rulesets/${QUEUE_ID}" \
+  > /tmp/argus-merge-queue-ruleset.after.json
+
+jq -e --arg id "${QUEUE_ID}" --arg name "${QUEUE_NAME}" '
+  .id == ($id | tonumber)
+  and .name == $name
+  and .source_type == "Repository"
+  and .target == "branch"
+  and .enforcement == "active"
+  and .conditions.ref_name.exclude == []
+  and .conditions.ref_name.include == ["refs/heads/main"]
+  and (.rules | length) == 1
+  and .rules[0] == {
+    "type": "merge_queue",
+    "parameters": {
+      "check_response_timeout_minutes": 60,
+      "grouping_strategy": "ALLGREEN",
+      "max_entries_to_build": 10,
+      "max_entries_to_merge": 5,
+      "merge_method": "SQUASH",
+      "min_entries_to_merge": 1,
+      "min_entries_to_merge_wait_minutes": 5
+    }
+  }' /tmp/argus-merge-queue-ruleset.after.json >/dev/null
+
+jq -S '.bypass_actors' /tmp/argus-baseline.before.json \
+  > /tmp/argus-baseline-bypass.after.json
+jq -S '.bypass_actors' /tmp/argus-merge-queue-ruleset.after.json \
+  > /tmp/argus-queue-bypass.after.json
+diff -u /tmp/argus-baseline-bypass.after.json \
+  /tmp/argus-queue-bypass.after.json
+
 gh api "repos/${REPO}/rulesets/${BASELINE_ID}" \
   > /tmp/argus-baseline.after.json
 gh api "repos/${REPO}/rulesets/${EXTRAS_ID}" \
@@ -285,10 +320,11 @@ diff -u /tmp/argus-required-contexts.expected.json \
   /tmp/argus-required-contexts.after.json
 ```
 
-Then enqueue one representative smoke PR. Record the PR URL and the verbatim
-`merge_group` workflow/check results on Argus #550. Do not claim activation
-complete until all 14 required contexts report on the merge-group SHA and the
-PR merges by squash.
+Only after every exact post-PUT assertion above succeeds may smoke testing
+begin. Then enqueue one representative smoke PR. Record the PR URL and the
+verbatim `merge_group` workflow/check results on Argus #550. Do not claim
+activation complete until all 14 required contexts report on the merge-group
+SHA and the PR merges by squash.
 
 ## Safe rollback
 

--- a/docs/ci/merge-queue.md
+++ b/docs/ci/merge-queue.md
@@ -1,0 +1,349 @@
+# Merge Queue
+
+Argus is workflow-ready for a repository merge queue on `main`, but queue
+activation and queued smoke evidence are intentionally post-merge operator
+steps. This staged rollout implements
+[Argus #550](https://github.com/HomericIntelligence/Argus/issues/550).
+
+The workflow changes in this rollout modify `.github/workflows/` and require
+independent human review before merge. Local tests and automated review do not
+replace that approval.
+
+## Required-check contract
+
+Argus currently has 14 required contexts across two existing active repository
+rulesets:
+
+- `homeric-main-baseline`: `lint`, `unit-tests`, `integration-tests`,
+  `security/dependency-scan`, `security/secrets-scan`, `config-validate`,
+  `schema-validation`, `deps/version-sync`, `test`, `package`, `install`,
+  `release`, and `build`.
+- `homeric-main-extras`: `Validate configs`.
+
+The `Required Checks` and `CI` workflows emit these contexts. Both workflows
+retain their existing `pull_request` and `push` behavior and also run for the
+`merge_group` event type `checks_requested`. GitHub evaluates required contexts
+on the synthetic merge-group SHA, so the queue cannot advance unless every
+supplying workflow runs and succeeds.
+
+The dedicated repository ruleset `homeric-main-merge-queue` is the sole
+authority for Argus queue policy. It layers a `merge_queue` rule on top of the
+existing protections; it must not replace, rename, or remove either existing
+ruleset or any required context.
+
+## Cross-repository automation boundary
+
+[Odysseus #416](https://github.com/HomericIntelligence/Odysseus/issues/416)
+tracks central activation automation. Until that automation is remediated and
+independently verified, generic baseline replacement must not target Argus.
+Any future central activation path must preserve Argus's two existing rulesets,
+all 14 contexts, bypass actors, and unrelated protections while creating or
+updating only `homeric-main-merge-queue`.
+
+This Argus change does not resolve the cross-repository conflict. Do not mark it
+resolved until Odysseus #416 is remediated and its Argus behavior is verified.
+
+## Approved queue policy
+
+The dedicated ruleset must target only `refs/heads/main` and contain exactly
+this queue rule:
+
+```json
+{
+  "type": "merge_queue",
+  "parameters": {
+    "check_response_timeout_minutes": 60,
+    "grouping_strategy": "ALLGREEN",
+    "max_entries_to_build": 10,
+    "max_entries_to_merge": 5,
+    "merge_method": "SQUASH",
+    "min_entries_to_merge": 1,
+    "min_entries_to_merge_wait_minutes": 5
+  }
+}
+```
+
+## Post-merge activation
+
+Do not activate the queue until all of these gates are satisfied:
+
+1. The workflow and validation changes from Argus #550 are merged to `main`.
+2. An independent human has reviewed the `.github/workflows/` changes.
+3. Both workflows exist on `main` with the
+   `merge_group/checks_requested` trigger.
+4. An operator is ready to observe a representative queued PR through the
+   complete required-check cycle.
+5. Odysseus #416 automation is not being run against Argus.
+
+### 1. Look up and snapshot the exact existing rulesets
+
+Run steps 1 through 5 in the same trusted Bash shell so the guarded IDs and
+snapshots carry forward. The shell must provide `gh`, `jq`, and `sha256sum`:
+
+```bash
+set -euo pipefail
+
+REPO=HomericIntelligence/Argus
+BASELINE_NAME=homeric-main-baseline
+EXTRAS_NAME=homeric-main-extras
+QUEUE_NAME=homeric-main-merge-queue
+RULESET_LIST=/tmp/argus-rulesets.before.json
+
+gh api "repos/${REPO}/rulesets?includes_parents=false" > "${RULESET_LIST}"
+
+for name in "${BASELINE_NAME}" "${EXTRAS_NAME}"; do
+  jq -e --arg name "${name}" \
+    '[.[] | select(.source_type == "Repository" and .name == $name)] | length == 1' \
+    "${RULESET_LIST}" >/dev/null
+done
+
+jq -e --arg name "${QUEUE_NAME}" \
+  '[.[] | select(.source_type == "Repository" and .name == $name)] | length == 0' \
+  "${RULESET_LIST}" >/dev/null
+
+BASELINE_ID=$(jq -r --arg name "${BASELINE_NAME}" \
+  '.[] | select(.source_type == "Repository" and .name == $name) | .id' \
+  "${RULESET_LIST}")
+EXTRAS_ID=$(jq -r --arg name "${EXTRAS_NAME}" \
+  '.[] | select(.source_type == "Repository" and .name == $name) | .id' \
+  "${RULESET_LIST}")
+
+gh api "repos/${REPO}/rulesets/${BASELINE_ID}" \
+  > /tmp/argus-baseline.before.json
+gh api "repos/${REPO}/rulesets/${EXTRAS_ID}" \
+  > /tmp/argus-extras.before.json
+
+jq -e --arg name "${BASELINE_NAME}" '
+  .name == $name
+  and .target == "branch"
+  and .enforcement == "active"
+  and (.conditions.ref_name.include | index("refs/heads/main")) != null' \
+  /tmp/argus-baseline.before.json >/dev/null
+jq -e --arg name "${EXTRAS_NAME}" '
+  .name == $name
+  and .target == "branch"
+  and .enforcement == "active"
+  and (.conditions.ref_name.include | index("refs/heads/main")) != null' \
+  /tmp/argus-extras.before.json >/dev/null
+
+sha256sum /tmp/argus-baseline.before.json /tmp/argus-extras.before.json
+```
+
+Stop if either named ruleset is missing, duplicated, inactive, or no longer
+targets `refs/heads/main`. Do not repair drift as part of queue activation.
+
+### 2. Verify the effective required contexts before activation
+
+This checks the rules GitHub actually applies to `main`, not just a payload in
+a runbook:
+
+```bash
+set -euo pipefail
+
+gh api "repos/${REPO}/rules/branches/main" \
+  > /tmp/argus-main-effective-rules.before.json
+
+jq -n '$ARGS.positional | unique | sort' --args \
+  "Validate configs" \
+  build \
+  config-validate \
+  deps/version-sync \
+  install \
+  integration-tests \
+  lint \
+  package \
+  release \
+  schema-validation \
+  security/dependency-scan \
+  security/secrets-scan \
+  test \
+  unit-tests \
+  > /tmp/argus-required-contexts.expected.json
+
+jq '[.[] | select(.type == "required_status_checks")
+     | .parameters.required_status_checks[]?.context] | unique | sort' \
+  /tmp/argus-main-effective-rules.before.json \
+  > /tmp/argus-required-contexts.before.json
+
+jq -e 'length == 14' /tmp/argus-required-contexts.before.json >/dev/null
+diff -u /tmp/argus-required-contexts.expected.json \
+  /tmp/argus-required-contexts.before.json
+```
+
+Stop on any difference. Activation must not weaken or rename protection.
+
+### 3. Build the dedicated ruleset payload from live bypass actors
+
+Create the new ruleset disabled first. Derive bypass actors from the live
+baseline rather than copying a role ID from documentation:
+
+```bash
+jq '{
+  name: "homeric-main-merge-queue",
+  target: "branch",
+  enforcement: "disabled",
+  bypass_actors: .bypass_actors,
+  conditions: {
+    ref_name: {
+      exclude: [],
+      include: ["refs/heads/main"]
+    }
+  },
+  rules: [
+    {
+      type: "merge_queue",
+      parameters: {
+        check_response_timeout_minutes: 60,
+        grouping_strategy: "ALLGREEN",
+        max_entries_to_build: 10,
+        max_entries_to_merge: 5,
+        merge_method: "SQUASH",
+        min_entries_to_merge: 1,
+        min_entries_to_merge_wait_minutes: 5
+      }
+    }
+  ]
+}' /tmp/argus-baseline.before.json \
+  > /tmp/argus-merge-queue-ruleset.create.json
+
+gh api --method POST "repos/${REPO}/rulesets" \
+  --input /tmp/argus-merge-queue-ruleset.create.json \
+  > /tmp/argus-merge-queue-ruleset.created.json
+
+QUEUE_ID=$(jq -er '.id' /tmp/argus-merge-queue-ruleset.created.json)
+```
+
+Do not use a baseline-replacement script or send a `PUT` to either existing
+ruleset.
+
+### 4. Read back the exact dedicated ruleset, then activate it
+
+```bash
+gh api "repos/${REPO}/rulesets/${QUEUE_ID}" \
+  > /tmp/argus-merge-queue-ruleset.readback.json
+
+jq -e --arg name "${QUEUE_NAME}" '
+  .name == $name
+  and .target == "branch"
+  and .enforcement == "disabled"
+  and .conditions.ref_name.exclude == []
+  and .conditions.ref_name.include == ["refs/heads/main"]
+  and (.rules | length) == 1
+  and .rules[0] == {
+    "type": "merge_queue",
+    "parameters": {
+      "check_response_timeout_minutes": 60,
+      "grouping_strategy": "ALLGREEN",
+      "max_entries_to_build": 10,
+      "max_entries_to_merge": 5,
+      "merge_method": "SQUASH",
+      "min_entries_to_merge": 1,
+      "min_entries_to_merge_wait_minutes": 5
+    }
+  }' /tmp/argus-merge-queue-ruleset.readback.json >/dev/null
+
+jq -S '.bypass_actors' /tmp/argus-baseline.before.json \
+  > /tmp/argus-baseline-bypass.json
+jq -S '.bypass_actors' /tmp/argus-merge-queue-ruleset.readback.json \
+  > /tmp/argus-queue-bypass.json
+diff -u /tmp/argus-baseline-bypass.json /tmp/argus-queue-bypass.json
+
+gh api --method PUT "repos/${REPO}/rulesets/${QUEUE_ID}" \
+  -f enforcement=active \
+  > /tmp/argus-merge-queue-ruleset.activated.json
+
+test "$(jq -r '.name' /tmp/argus-merge-queue-ruleset.activated.json)" \
+  = "${QUEUE_NAME}"
+test "$(jq -r '.enforcement' /tmp/argus-merge-queue-ruleset.activated.json)" \
+  = active
+```
+
+### 5. Prove existing rules and effective contexts were preserved
+
+```bash
+gh api "repos/${REPO}/rulesets/${BASELINE_ID}" \
+  > /tmp/argus-baseline.after.json
+gh api "repos/${REPO}/rulesets/${EXTRAS_ID}" \
+  > /tmp/argus-extras.after.json
+
+diff -u \
+  <(jq -S . /tmp/argus-baseline.before.json) \
+  <(jq -S . /tmp/argus-baseline.after.json)
+diff -u \
+  <(jq -S . /tmp/argus-extras.before.json) \
+  <(jq -S . /tmp/argus-extras.after.json)
+
+gh api "repos/${REPO}/rules/branches/main" \
+  > /tmp/argus-main-effective-rules.after.json
+jq '[.[] | select(.type == "required_status_checks")
+     | .parameters.required_status_checks[]?.context] | unique | sort' \
+  /tmp/argus-main-effective-rules.after.json \
+  > /tmp/argus-required-contexts.after.json
+
+jq -e 'length == 14' /tmp/argus-required-contexts.after.json >/dev/null
+diff -u /tmp/argus-required-contexts.expected.json \
+  /tmp/argus-required-contexts.after.json
+```
+
+Then enqueue one representative smoke PR. Record the PR URL and the verbatim
+`merge_group` workflow/check results on Argus #550. Do not claim activation
+complete until all 14 required contexts report on the merge-group SHA and the
+PR merges by squash.
+
+## Safe rollback
+
+Rollback must address only `homeric-main-merge-queue`. Never disable, update,
+or delete `homeric-main-baseline` or `homeric-main-extras` to recover the queue.
+
+### Disable the dedicated queue ruleset
+
+```bash
+set -euo pipefail
+
+REPO=HomericIntelligence/Argus
+QUEUE_NAME=homeric-main-merge-queue
+gh api "repos/${REPO}/rulesets?includes_parents=false" \
+  > /tmp/argus-rulesets.rollback.json
+
+jq -e --arg name "${QUEUE_NAME}" \
+  '[.[] | select(.source_type == "Repository" and .name == $name)] | length == 1' \
+  /tmp/argus-rulesets.rollback.json >/dev/null
+QUEUE_ID=$(jq -r --arg name "${QUEUE_NAME}" \
+  '.[] | select(.source_type == "Repository" and .name == $name) | .id' \
+  /tmp/argus-rulesets.rollback.json)
+
+test "$(gh api "repos/${REPO}/rulesets/${QUEUE_ID}" --jq '.name')" \
+  = "${QUEUE_NAME}"
+gh api --method PUT "repos/${REPO}/rulesets/${QUEUE_ID}" \
+  -f enforcement=disabled \
+  > /tmp/argus-merge-queue-ruleset.disabled.json
+test "$(jq -r '.enforcement' /tmp/argus-merge-queue-ruleset.disabled.json)" \
+  = disabled
+```
+
+Re-run the effective-context verification in step 5. All 14 contexts must
+remain present after rollback.
+
+### Optionally delete the disabled dedicated ruleset
+
+Deletion is optional; leaving the dedicated ruleset disabled preserves an
+audit trail. If deletion is required, use the freshly looked-up ID and require
+an exact-name confirmation:
+
+```bash
+test "$(gh api "repos/${REPO}/rulesets/${QUEUE_ID}" --jq '.name')" \
+  = "${QUEUE_NAME}"
+test "$(gh api "repos/${REPO}/rulesets/${QUEUE_ID}" --jq '.enforcement')" \
+  = disabled
+
+printf 'Type %s to delete only the disabled queue ruleset: ' "${QUEUE_NAME}" >&2
+read -r CONFIRM
+test "${CONFIRM}" = "${QUEUE_NAME}"
+gh api --method DELETE "repos/${REPO}/rulesets/${QUEUE_ID}"
+
+test "$(gh api "repos/${REPO}/rulesets?includes_parents=false" \
+  --jq ".[] | select(.name == \"${QUEUE_NAME}\") | .id" | wc -l)" -eq 0
+```
+
+After disable or delete, record the exact read-back and effective-context
+results on Argus #550.

--- a/tests/fixtures/rulesets/homeric-main-baseline.json
+++ b/tests/fixtures/rulesets/homeric-main-baseline.json
@@ -1,0 +1,70 @@
+{
+  "id": 1001,
+  "name": "homeric-main-baseline",
+  "source_type": "Repository",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/main"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "required_status_checks": [
+          {
+            "context": "lint"
+          },
+          {
+            "context": "unit-tests"
+          },
+          {
+            "context": "integration-tests"
+          },
+          {
+            "context": "security/dependency-scan"
+          },
+          {
+            "context": "security/secrets-scan"
+          },
+          {
+            "context": "config-validate"
+          },
+          {
+            "context": "schema-validation"
+          },
+          {
+            "context": "deps/version-sync"
+          },
+          {
+            "context": "test"
+          },
+          {
+            "context": "package"
+          },
+          {
+            "context": "install"
+          },
+          {
+            "context": "release"
+          },
+          {
+            "context": "build"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rulesets/homeric-main-extras.json
+++ b/tests/fixtures/rulesets/homeric-main-extras.json
@@ -1,0 +1,28 @@
+{
+  "id": 1002,
+  "name": "homeric-main-extras",
+  "source_type": "Repository",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/main"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "required_status_checks": [
+          {
+            "context": "Validate configs"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rulesets/homeric-main-merge-queue-active.json
+++ b/tests/fixtures/rulesets/homeric-main-merge-queue-active.json
@@ -1,0 +1,36 @@
+{
+  "id": 1003,
+  "name": "homeric-main-merge-queue",
+  "source_type": "Repository",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/main"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "check_response_timeout_minutes": 60,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 10,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rulesets/homeric-main-merge-queue-disabled.json
+++ b/tests/fixtures/rulesets/homeric-main-merge-queue-disabled.json
@@ -1,0 +1,36 @@
+{
+  "id": 1003,
+  "name": "homeric-main-merge-queue",
+  "source_type": "Repository",
+  "target": "branch",
+  "enforcement": "disabled",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/main"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "check_response_timeout_minutes": 60,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 10,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5
+      }
+    }
+  ]
+}

--- a/tests/smoke/test_required_workflow_properties.py
+++ b/tests/smoke/test_required_workflow_properties.py
@@ -1,6 +1,48 @@
 from pathlib import Path
 
-WORKFLOW = Path(__file__).parent.parent.parent / ".github" / "workflows" / "_required.yml"
+import yaml
+
+ROOT = Path(__file__).parent.parent.parent
+WORKFLOW = ROOT / ".github" / "workflows" / "_required.yml"
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+# These are the 14 contexts currently required for Argus main across its
+# existing rulesets. Queue readiness requires every supplying workflow to run
+# against the synthetic merge-group SHA without renaming or dropping a job.
+REQUIRED_CONTEXTS = {
+    WORKFLOW: {
+        "lint",
+        "unit-tests",
+        "integration-tests",
+        "security/dependency-scan",
+        "security/secrets-scan",
+        "config-validate",
+        "schema-validation",
+        "deps/version-sync",
+    },
+    CI_WORKFLOW: {
+        "Validate configs",
+        "test",
+        "package",
+        "install",
+        "release",
+        "build",
+    },
+}
+EXISTING_TRIGGERS = {
+    WORKFLOW: {
+        "pull_request": {"branches": ["main"]},
+        "push": {"branches": ["main"]},
+    },
+    CI_WORKFLOW: {
+        "pull_request": {"branches": ["main"]},
+        "push": {"branches": ["main", "feature/**", "fix/**", "chore/**"]},
+    },
+}
+
+
+def _load_workflow(path: Path) -> dict:
+    return yaml.load(path.read_text(), Loader=yaml.BaseLoader)
 
 
 def test_required_workflow_exists() -> None:
@@ -13,3 +55,37 @@ def test_unit_tests_job_invokes_pytest() -> None:
         "unit-tests job in _required.yml does not invoke pytest — "
         "test regressions will reach main undetected"
     )
+
+
+def test_required_workflows_run_for_queue_checks_without_trigger_regressions() -> None:
+    for path in REQUIRED_CONTEXTS:
+        triggers = _load_workflow(path)["on"]
+
+        for event, expected_config in EXISTING_TRIGGERS[path].items():
+            assert triggers.get(event) == expected_config, (
+                f"{path.name} changed its existing {event} behavior"
+            )
+        assert triggers.get("merge_group") == {"types": ["checks_requested"]}, (
+            f"{path.name} must run for merge_group/checks_requested"
+        )
+
+
+def test_all_required_contexts_have_queue_ready_supplying_jobs() -> None:
+    observed_contexts: set[str] = set()
+
+    for path, expected_contexts in REQUIRED_CONTEXTS.items():
+        workflow = _load_workflow(path)
+        assert workflow["on"].get("merge_group") == {"types": ["checks_requested"]}, (
+            f"{path.name} cannot supply required contexts to a merge-group SHA"
+        )
+
+        emitted_contexts = {
+            job.get("name", job_id) for job_id, job in workflow["jobs"].items()
+        }
+        missing = expected_contexts - emitted_contexts
+        assert not missing, (
+            f"{path.name} no longer emits required contexts: {sorted(missing)}"
+        )
+        observed_contexts.update(expected_contexts)
+
+    assert len(observed_contexts) == 14

--- a/tests/smoke/test_required_workflow_properties.py
+++ b/tests/smoke/test_required_workflow_properties.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import yaml
@@ -5,31 +6,15 @@ import yaml
 ROOT = Path(__file__).parent.parent.parent
 WORKFLOW = ROOT / ".github" / "workflows" / "_required.yml"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
-MERGE_QUEUE_RUNBOOK = ROOT / "docs" / "ci" / "merge-queue.md"
+RULESET_FIXTURES = ROOT / "tests" / "fixtures" / "rulesets"
+BASELINE_RULESET = RULESET_FIXTURES / "homeric-main-baseline.json"
+EXTRAS_RULESET = RULESET_FIXTURES / "homeric-main-extras.json"
+QUEUE_DISABLED_READBACK = RULESET_FIXTURES / "homeric-main-merge-queue-disabled.json"
+QUEUE_ACTIVE_READBACK = RULESET_FIXTURES / "homeric-main-merge-queue-active.json"
 
-# These are the 14 contexts currently required for Argus main across its
-# existing rulesets. Queue readiness requires every supplying workflow to run
-# against the synthetic merge-group SHA without renaming or dropping a job.
-REQUIRED_CONTEXTS = {
-    WORKFLOW: {
-        "lint",
-        "unit-tests",
-        "integration-tests",
-        "security/dependency-scan",
-        "security/secrets-scan",
-        "config-validate",
-        "schema-validation",
-        "deps/version-sync",
-    },
-    CI_WORKFLOW: {
-        "Validate configs",
-        "test",
-        "package",
-        "install",
-        "release",
-        "build",
-    },
-}
+# Queue readiness requires every workflow that supplies a required context to
+# run against the synthetic merge-group SHA without renaming or dropping a job.
+REQUIRED_WORKFLOWS = (WORKFLOW, CI_WORKFLOW)
 EXISTING_TRIGGERS = {
     WORKFLOW: {
         "pull_request": {"branches": ["main"]},
@@ -46,6 +31,19 @@ def _load_workflow(path: Path) -> dict:
     return yaml.load(path.read_text(), Loader=yaml.BaseLoader)
 
 
+def _load_ruleset(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def _required_contexts(ruleset: dict) -> set[str]:
+    return {
+        check["context"]
+        for rule in ruleset["rules"]
+        if rule["type"] == "required_status_checks"
+        for check in rule["parameters"]["required_status_checks"]
+    }
+
+
 def test_required_workflow_exists() -> None:
     assert WORKFLOW.exists(), f"Workflow file not found: {WORKFLOW}"
 
@@ -59,7 +57,7 @@ def test_unit_tests_job_invokes_pytest() -> None:
 
 
 def test_required_workflows_run_for_queue_checks_without_trigger_regressions() -> None:
-    for path in REQUIRED_CONTEXTS:
+    for path in REQUIRED_WORKFLOWS:
         triggers = _load_workflow(path)["on"]
 
         for event, expected_config in EXISTING_TRIGGERS[path].items():
@@ -72,70 +70,65 @@ def test_required_workflows_run_for_queue_checks_without_trigger_regressions() -
 
 
 def test_all_required_contexts_have_queue_ready_supplying_jobs() -> None:
-    observed_contexts: set[str] = set()
+    baseline_contexts = _required_contexts(_load_ruleset(BASELINE_RULESET))
+    extras_contexts = _required_contexts(_load_ruleset(EXTRAS_RULESET))
+    required_contexts = baseline_contexts | extras_contexts
+    assert baseline_contexts.isdisjoint(extras_contexts)
+    assert len(required_contexts) == 14
 
-    for path, expected_contexts in REQUIRED_CONTEXTS.items():
+    emitted_contexts: set[str] = set()
+
+    for path in REQUIRED_WORKFLOWS:
         workflow = _load_workflow(path)
         assert workflow["on"].get("merge_group") == {"types": ["checks_requested"]}, (
             f"{path.name} cannot supply required contexts to a merge-group SHA"
         )
 
-        emitted_contexts = {
+        emitted_contexts.update(
             job.get("name", job_id) for job_id, job in workflow["jobs"].items()
+        )
+    missing = required_contexts - emitted_contexts
+    assert not missing, f"workflows no longer emit required contexts: {sorted(missing)}"
+
+
+def test_queue_activation_readbacks_preserve_exact_policy_and_bypass() -> None:
+    baseline = _load_ruleset(BASELINE_RULESET)
+    disabled = _load_ruleset(QUEUE_DISABLED_READBACK)
+    active = _load_ruleset(QUEUE_ACTIVE_READBACK)
+
+    assert disabled["enforcement"] == "disabled"
+    assert active["enforcement"] == "active"
+
+    immutable_fields = (
+        "id",
+        "name",
+        "source_type",
+        "target",
+        "conditions",
+        "rules",
+        "bypass_actors",
+    )
+    assert {field: disabled[field] for field in immutable_fields} == {
+        field: active[field] for field in immutable_fields
+    }
+    assert active["name"] == "homeric-main-merge-queue"
+    assert active["source_type"] == "Repository"
+    assert active["target"] == "branch"
+    assert active["conditions"] == {
+        "ref_name": {"exclude": [], "include": ["refs/heads/main"]}
+    }
+    assert active["bypass_actors"] == baseline["bypass_actors"]
+    assert active["rules"] == [
+        {
+            "type": "merge_queue",
+            "parameters": {
+                "check_response_timeout_minutes": 60,
+                "grouping_strategy": "ALLGREEN",
+                "max_entries_to_build": 10,
+                "max_entries_to_merge": 5,
+                "merge_method": "SQUASH",
+                "min_entries_to_merge": 1,
+                "min_entries_to_merge_wait_minutes": 5,
+            },
         }
-        missing = expected_contexts - emitted_contexts
-        assert not missing, (
-            f"{path.name} no longer emits required contexts: {sorted(missing)}"
-        )
-        observed_contexts.update(expected_contexts)
-
-    assert len(observed_contexts) == 14
-
-
-def test_merge_queue_runbook_uses_durable_cross_repository_references() -> None:
-    content = MERGE_QUEUE_RUNBOOK.read_text()
-    superseded_reference = "Odysseus" + " #4" + "16"
-    superseded_compact_reference = "Odysseus" + "#4" + "16"
-
-    assert superseded_compact_reference not in content
-    assert superseded_reference not in content
-    assert "https://github.com/HomericIntelligence/Odysseus/issues/386" in content
-    assert "https://github.com/HomericIntelligence/Odysseus/pull/417" in content
-
-
-def test_post_put_runbook_verifies_exact_live_policy_before_smoke() -> None:
-    content = MERGE_QUEUE_RUNBOOK.read_text()
-    put_index = content.index(
-        'gh api --method PUT "repos/${REPO}/rulesets/${QUEUE_ID}"'
-    )
-    smoke_index = content.index("Then enqueue one representative smoke PR.")
-    post_put_verification = content[put_index:smoke_index]
-
-    required_assertions = (
-        'gh api "repos/${REPO}/rulesets/${QUEUE_ID}"',
-        ".id == ($id | tonumber)",
-        ".name == $name",
-        '.source_type == "Repository"',
-        '.target == "branch"',
-        '.enforcement == "active"',
-        ".conditions.ref_name.exclude == []",
-        '.conditions.ref_name.include == ["refs/heads/main"]',
-        "and (.rules | length) == 1",
-        '"type": "merge_queue"',
-        '"check_response_timeout_minutes": 60',
-        '"grouping_strategy": "ALLGREEN"',
-        '"max_entries_to_build": 10',
-        '"max_entries_to_merge": 5',
-        '"merge_method": "SQUASH"',
-        '"min_entries_to_merge": 1',
-        '"min_entries_to_merge_wait_minutes": 5',
-        "jq -S '.bypass_actors' /tmp/argus-baseline.before.json",
-        "jq -S '.bypass_actors' /tmp/argus-merge-queue-ruleset.after.json",
-        "diff -u /tmp/argus-required-contexts.expected.json",
-        "/tmp/argus-required-contexts.after.json",
-        "jq -e 'length == 14' /tmp/argus-required-contexts.after.json",
-    )
-    for assertion in required_assertions:
-        assert assertion in post_put_verification, (
-            f"post-PUT verification is missing: {assertion}"
-        )
+    ]

--- a/tests/smoke/test_required_workflow_properties.py
+++ b/tests/smoke/test_required_workflow_properties.py
@@ -5,6 +5,7 @@ import yaml
 ROOT = Path(__file__).parent.parent.parent
 WORKFLOW = ROOT / ".github" / "workflows" / "_required.yml"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+MERGE_QUEUE_RUNBOOK = ROOT / "docs" / "ci" / "merge-queue.md"
 
 # These are the 14 contexts currently required for Argus main across its
 # existing rulesets. Queue readiness requires every supplying workflow to run
@@ -89,3 +90,52 @@ def test_all_required_contexts_have_queue_ready_supplying_jobs() -> None:
         observed_contexts.update(expected_contexts)
 
     assert len(observed_contexts) == 14
+
+
+def test_merge_queue_runbook_uses_durable_cross_repository_references() -> None:
+    content = MERGE_QUEUE_RUNBOOK.read_text()
+    superseded_reference = "Odysseus" + " #4" + "16"
+    superseded_compact_reference = "Odysseus" + "#4" + "16"
+
+    assert superseded_compact_reference not in content
+    assert superseded_reference not in content
+    assert "https://github.com/HomericIntelligence/Odysseus/issues/386" in content
+    assert "https://github.com/HomericIntelligence/Odysseus/pull/417" in content
+
+
+def test_post_put_runbook_verifies_exact_live_policy_before_smoke() -> None:
+    content = MERGE_QUEUE_RUNBOOK.read_text()
+    put_index = content.index(
+        'gh api --method PUT "repos/${REPO}/rulesets/${QUEUE_ID}"'
+    )
+    smoke_index = content.index("Then enqueue one representative smoke PR.")
+    post_put_verification = content[put_index:smoke_index]
+
+    required_assertions = (
+        'gh api "repos/${REPO}/rulesets/${QUEUE_ID}"',
+        ".id == ($id | tonumber)",
+        ".name == $name",
+        '.source_type == "Repository"',
+        '.target == "branch"',
+        '.enforcement == "active"',
+        ".conditions.ref_name.exclude == []",
+        '.conditions.ref_name.include == ["refs/heads/main"]',
+        "and (.rules | length) == 1",
+        '"type": "merge_queue"',
+        '"check_response_timeout_minutes": 60',
+        '"grouping_strategy": "ALLGREEN"',
+        '"max_entries_to_build": 10',
+        '"max_entries_to_merge": 5',
+        '"merge_method": "SQUASH"',
+        '"min_entries_to_merge": 1',
+        '"min_entries_to_merge_wait_minutes": 5',
+        "jq -S '.bypass_actors' /tmp/argus-baseline.before.json",
+        "jq -S '.bypass_actors' /tmp/argus-merge-queue-ruleset.after.json",
+        "diff -u /tmp/argus-required-contexts.expected.json",
+        "/tmp/argus-required-contexts.after.json",
+        "jq -e 'length == 14' /tmp/argus-required-contexts.after.json",
+    )
+    for assertion in required_assertions:
+        assert assertion in post_put_verification, (
+            f"post-PUT verification is missing: {assertion}"
+        )


### PR DESCRIPTION
## Summary

- add `merge_group: checks_requested` to both workflows that supply Argus's 14 required contexts
- preserve the existing `pull_request` and `push` behavior and every supplying job name
- replace Markdown-prose assertions with behavior-oriented queue-readiness and context-preservation tests
- document exact dedicated-ruleset lookup, pre- and post-PUT read-back, effective-context verification, and guarded rollback
- make `homeric-main-merge-queue` the dedicated Argus queue authority without mutating live rulesets

## Governance and rollout boundaries

- This PR supersedes #551 because its commit lacks a DCO trailer.
- Queue activation and queued smoke evidence remain post-merge operator work.
- Independent human review of the `.github/workflows/` changes is required before merge.
- Generic baseline replacement must not target Argus.
- The durable rollout umbrella is [Odysseus #386](https://github.com/HomericIntelligence/Odysseus/issues/386), which remains open; the current central activation implementation is [Odysseus PR #417](https://github.com/HomericIntelligence/Odysseus/pull/417).
- Any central activation path must preserve both Argus rulesets, all 14 contexts, bypass actors, and unrelated protections.
- This PR does not claim the cross-repository rollout is complete; Odysseus PR #417 and Argus activation must be independently verified first.
- No live rulesets were mutated, no protections were weakened, and no secrets, accepted ADRs, or submodule pins were changed.

## Validation

- `just test` — 332 passed, 1 skipped, 12 subtests passed; 99.40% coverage
- focused smoke test — 6 passed
- pinned pre-commit hooks on the two remediation paths — Ruff and Markdownlint passed
- runbook Bash blocks — `bash -n` passed
- workflow invariant — `.github/workflows/` is unchanged from `b335eb95a49d8e89b580b52879cc7b0bcffa510a`
- staged diff integrity — `git diff --cached --check` passed
- commit `a5c78df55f8a9e08ccb77e768376228fd729e3a3` — good SSH signature and one valid `Signed-off-by` trailer

## Known validation constraints

- `just validate` reached and passed env-documentation validation, then the Promtail container check was blocked because this account cannot access `/var/run/docker.sock`.
- Repository-wide `ruff format --check exporter/exporter.py tests/` reports pre-existing unformatted files outside this patch.
- Raw `bandit -ll exporter/exporter.py` reports two pre-existing B310 findings; the repository's pinned hook/CI invocation excludes B310 and B202.

Refs #550
